### PR TITLE
Add Canadian national and provincial holidays

### DIFF
--- a/opening_hours.js
+++ b/opening_hours.js
@@ -1102,6 +1102,204 @@
 				// 'Silvester'                 : [ 12, 31 ],
 			},
 		},
+		'ca': {
+			'PH': { // https://en.wikipedia.org/wiki/Public_holidays_in_Canada
+				"New Year's Day"            : [  1,  1 ],
+				"Good Friday"               : [  'easter', -2 ],
+				"Canada Day"                : [  'canadaDay', 0 ],
+				"Labour Day"                : [  'firstSeptemberMonday', 0 ],
+				"Christmas Day"             : [ 12, 25 ]
+			},
+			'Alberta': {
+				'PH': {
+					"New Year's Day"            : [  1,  1 ],
+					"Alberta Family Day"        : [  'firstFebruaryMonday', 14 ],
+					"Good Friday"               : [  'easter', -2 ],
+					"Easter Monday"             : [  'easter', 1 ],
+					"Victoria Day"              : [  'victoriaDay', 0 ],
+					"Canada Day"                : [  'canadaDay', 0 ],
+					"Heritage Day"              : [  'firstAugustMonday', 0 ],
+					"Labour Day"                : [  'firstSeptemberMonday', 0 ],
+					"Thanksgiving"              : [  'firstOctoberMonday', 7 ],
+					"Remembrance Day"           : [ 11, 11 ],
+					"Christmas Day"             : [ 12, 25 ],
+					"Boxing Day"                : [ 12, 26 ]
+				},
+			},
+			'British Columbia': {
+				'PH': {
+					"New Year's Day"            : [  1,  1 ],
+					"Family Day"                : [  'firstFebruaryMonday', 7 ],
+					"Good Friday"               : [  'easter', -2 ],
+					"Victoria Day"              : [  'victoriaDay', 0 ],
+					"Canada Day"                : [  'canadaDay', 0 ],
+					"British Columbia Day"      : [  'firstAugustMonday', 0 ],
+					"Labour Day"                : [  'firstSeptemberMonday', 0 ],
+					"Thanksgiving"              : [  'firstOctoberMonday', 7 ],
+					"Remembrance Day"           : [ 11, 11 ],
+					"Christmas Day"             : [ 12, 25 ]
+				},
+			},
+			'Manitoba': {
+				'PH': {
+					"New Year's Day"            : [  1,  1 ],
+					"Louis Riel Day"            : [  'firstFebruaryMonday', 14 ],
+					"Good Friday"               : [  'easter', -2 ],
+					"Victoria Day"              : [  'victoriaDay', 0 ],
+					"Canada Day"                : [  'canadaDay', 0 ],
+					"Civic Holiday"             : [  'firstAugustMonday', 0 ],
+					"Labour Day"                : [  'firstSeptemberMonday', 0 ],
+					"Thanksgiving"              : [  'firstOctoberMonday', 7 ],
+					"Remembrance Day"           : [ 11, 11 ],
+					"Christmas Day"             : [ 12, 25 ]
+				},
+			},
+			'New Brunswick': {
+				'PH': {
+					"New Year's Day"            : [  1,  1 ],
+					"Good Friday"               : [  'easter', -2 ],
+					"Victoria Day"              : [  'victoriaDay', 0 ],
+					"Canada Day"                : [  'canadaDay', 0 ],
+					"New Brunswick Day"         : [  'firstAugustMonday', 0 ],
+					"Labour Day"                : [  'firstSeptemberMonday', 0 ],
+					"Thanksgiving"              : [  'firstOctoberMonday', 7 ],
+					"Remembrance Day"           : [ 11, 11 ],
+					"Christmas Day"             : [ 12, 25 ],
+					"Boxing Day"                : [ 12, 26 ]
+				},
+			},
+			'Newfoundland and Labrador': {
+				'PH': {
+					"New Year's Day"            : [  1,  1 ],
+					"Saint Patrick's Day"       : [  3, 17 ],
+					"Good Friday"               : [  'easter', -2 ],
+					"Saint George's Day"        : [  4, 23 ],
+					"Discovery Day"             : [  6, 24 ],
+					"Memorial Day"              : [  7, 1 ],
+					"Orangemen's Day"           : [  7, 12 ],
+					"Labour Day"                : [  'firstSeptemberMonday', 0 ],
+					"Armistice Day"             : [ 11, 11 ],
+					"Christmas Day"             : [ 12, 25 ]
+				},
+			},
+			'Northwest Territories': {
+				'PH': {
+					"New Year's Day"            : [  1,  1 ],
+					"Good Friday"               : [  'easter', -2 ],
+					"Victoria Day"              : [  'victoriaDay', 0 ],
+					"National Aboriginal Day"   : [  6, 21 ],
+					"Canada Day"                : [  'canadaDay', 0 ],
+					"Civic Holiday"             : [  'firstAugustMonday', 0 ],
+					"Labour Day"                : [  'firstSeptemberMonday', 0 ],
+					"Thanksgiving"              : [  'firstOctoberMonday', 7 ],
+					"Remembrance Day"           : [ 11, 11 ],
+					"Christmas Day"             : [ 12, 25 ]
+				},
+			},
+			'Nova Scotia': {
+				'PH': {
+					"New Year's Day"            : [  1,  1 ],
+					"Good Friday"               : [  'easter', -2 ],
+					"Victoria Day"              : [  'victoriaDay', 0 ],
+					"Canada Day"                : [  'canadaDay', 0 ],
+					"Natal Day"                 : [  'firstAugustMonday', 0 ],
+					"Labour Day"                : [  'firstSeptemberMonday', 0 ],
+					"Thanksgiving"              : [  'firstOctoberMonday', 7 ],
+					"Remembrance Day"           : [ 11, 11 ],
+					"Christmas Day"             : [ 12, 25 ],
+					"Boxing Day"                : [ 12, 26 ]
+				},
+			},
+			'Nunavut': {
+				'PH': {
+					"New Year's Day"            : [  1,  1 ],
+					"Good Friday"               : [  'easter', -2 ],
+					"Victoria Day"              : [  'victoriaDay', 0 ],
+					"Canada Day"                : [  'canadaDay', 0 ],
+					"Nunavut Day"               : [  7, 9 ],
+					"Civic Holiday"             : [  'firstAugustMonday', 0 ],
+					"Labour Day"                : [  'firstSeptemberMonday', 0 ],
+					"Thanksgiving"              : [  'firstOctoberMonday', 7 ],
+					"Remembrance Day"           : [ 11, 11 ],
+					"Christmas Day"             : [ 12, 25 ]
+				},
+			},
+			'Ontario': {
+				'PH': {
+					"New Year's Day"              : [  1,  1 ],
+					"Family Day"                  : [  'firstFebruaryMonday', 14 ],
+					"Good Friday"                 : [  'easter', -2 ],
+					"Victoria Day"                : [  'victoriaDay', 0 ],
+					"Canada Day"                  : [  'canadaDay', 0 ],
+					"August Civic Public Holiday" : [  'firstAugustMonday', 0 ],
+					"Labour Day"                  : [  'firstSeptemberMonday', 0 ],
+					"Thanksgiving"                : [  'firstOctoberMonday', 7 ],
+					"Remembrance Day"             : [ 11, 11 ],
+					"Christmas Day"               : [ 12, 25 ],
+					"Boxing Day"                  : [ 12, 26 ]
+				},
+			},
+			'Prince Edward Island': {
+				'PH': {
+					"New Year's Day"            : [  1,  1 ],
+					"Islander Day"              : [  'firstFebruaryMonday', 14 ],
+					"Good Friday"               : [  'easter', -2 ],
+					"Easter Monday"             : [  'easter', 1 ],
+					"Victoria Day"              : [  'victoriaDay', 0 ],
+					"Canada Day"                : [  'canadaDay', 0 ],
+					"Civic Holiday"             : [  'firstAugustMonday', 0 ],
+					"Gold Cup Parade Day"       : [  'firstAugustMonday', 18 ],
+					"Labour Day"                : [  'firstSeptemberMonday', 0 ],
+					"Thanksgiving"              : [  'firstOctoberMonday', 7 ],
+					"Remembrance Day"           : [ 11, 11 ],
+					"Christmas Day"             : [ 12, 25 ],
+					"Boxing Day"                : [ 12, 26 ]
+				},
+			},
+			'Quebec': {
+				'PH': {
+					"Jour de l'an"                    : [  1,  1 ],
+					"Vendredi saint"                  : [  'easter', -2 ],
+					"Lundi de Pâques"                 : [  'easter', 1 ],
+					"Journée nationale des patriotes" : [  'victoriaDay', 0 ],
+					"Fête nationale du Québec"        : [  6, 24 ],
+					"Fête du Canada"                  : [  'canadaDay', 0 ],
+					"Fête du Travail"                 : [  'firstSeptemberMonday', 0 ],
+					"Jour de l'Action de grâce"       : [  'firstOctoberMonday', 7 ],
+					"Noël"                            : [ 12, 25 ]
+				},
+			},
+			'Saskatchewan': {
+				'PH': {
+					"New Year's Day"            : [  1,  1 ],
+					"Family Day"                : [  'firstFebruaryMonday', 14 ],
+					"Good Friday"               : [  'easter', -2 ],
+					"Victoria Day"              : [  'victoriaDay', 0 ],
+					"Canada Day"                : [  'canadaDay', 0 ],
+					"Saskatchewan Day"          : [  'firstAugustMonday', 0 ],
+					"Labour Day"                : [  'firstSeptemberMonday', 0 ],
+					"Thanksgiving"              : [  'firstOctoberMonday', 7 ],
+					"Remembrance Day"           : [ 11, 11 ],
+					"Christmas Day"             : [ 12, 25 ]
+				},
+			},
+			'Yukon': {
+				'PH': {
+					"New Year's Day"            : [  1,  1 ],
+					"Heritage Day"              : [  'lastFebruarySunday',  -2 ],
+					"Good Friday"               : [  'easter', -2 ],
+					"Easter Monday"             : [  'easter', 1 ],
+					"Victoria Day"              : [  'victoriaDay', 0 ],
+					"Canada Day"                : [  'canadaDay', 0 ],
+					"Discovery Day"             : [  'firstAugustMonday', 14 ],
+					"Labour Day"                : [  'firstSeptemberMonday', 0 ],
+					"Thanksgiving"              : [  'firstOctoberMonday', 7 ],
+					"Remembrance Day"           : [ 11, 11 ],
+					"Christmas Day"             : [ 12, 25 ],
+					"Boxing Day"                : [ 12, 26 ]
+				},
+			},
+		},
 	};
 	// }}}
 
@@ -2978,8 +3176,35 @@
 			var M = 3 + Math.floor((L + 40)/44);
 			var D = L + 28 - 31*Math.floor(M/4);
 
+			// calculate last Sunday in February
+			var lastFebruaryDay = new Date(Y, 2, 0);
+			var lastFebruarySunday = lastFebruaryDay.getDate() - lastFebruaryDay.getDay();
+
+			// calculate Victoria Day. last Monday before or on May 24
+			var may_24 = new Date(Y, 4, 24);
+			var victoriaDay = 24  - ((6 + may_24.getDay()) % 7);
+
+			// calculate Canada Day. July 1st unless 1st is on Sunday, then July 2.
+			var july_1 = new Date(Y, 6, 1);
+			var canadaDay = july_1.getDay() === 0 ? 2 : 1;
+
+			// calculate first Monday for each month
+			var firstMondays = {};
+			for (var i = 0; i < 12; i++) {
+				var first = new Date(Y, i, 1);
+				var firstMonday = 1 + ((8 - first.getDay()) % 7);
+				firstMondays[i] = firstMonday;
+			};
+
 			return {
+				'firstFebruaryMonday': new Date(Y, 1, firstMondays[1]),
+				'lastFebruarySunday': new Date(Y, 1, lastFebruarySunday),
 				'easter': new Date(Y, M - 1, D),
+				'victoriaDay': new Date(Y, 4, victoriaDay),
+				'canadaDay': new Date(Y, 6, canadaDay),
+				'firstAugustMonday': new Date(Y, 7, firstMondays[7]),
+				'firstSeptemberMonday': new Date(Y, 8, firstMondays[8]),
+				'firstOctoberMonday': new Date(Y, 9, firstMondays[9]),
 			};
 		}
 


### PR DESCRIPTION
Uses moveable holidays, where holidays depend on certain weekday or are bound to a certain day of the month. Provincial holidays may be optional depending on employer or region.

The `getMovableEventsForYear()` function now includes the variable holidays. It would be cleaner to specify the rules in the `holidays` object instead of hard-coding them; I'm not sure if you have plans for this or want to wait for more input and settle on a more generalized solution/library.
