### PR TITLE
Relax version on moment optionalDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "optionalDependencies": {
     "i18next-client": "1.11.1",
-    "moment": "2.10.6",
+    "moment": "^2.10.6",
     "country-language": "0.1.7"
   },
   "devDependencies": {


### PR DESCRIPTION
The version was fixed and is now more relaxed. That allows better co-existence/merge with other modules that also use `momentjs`