### PR TITLE
remove gap-switch in table on changing date

### DIFF
--- a/css/table.css
+++ b/css/table.css
@@ -1,4 +1,7 @@
-tr.today td.day { text-decoration: underline }
+tr.today td.day {
+    text-decoration: underline; 
+    width: 16%
+}
 td {
     background: #E0E0E0;
     padding: 0 10px

--- a/css/table.css
+++ b/css/table.css
@@ -1,6 +1,6 @@
 tr.today td.day {
     text-decoration: underline; 
-    width: 16%
+    width: 6em
 }
 td {
     background: #E0E0E0;


### PR DESCRIPTION
add width for first table row in weekly-table

beim wechsel von "aug" zu "sept" und/oder von "31" zu "1" sprang die auswerte-grafik um einige pixel (durch breitenänderung der ersten Spalte)
behoben durch feste Breite in Prozent.