### PR TITLE
Fix typo (defintion -> definition)

### DIFF
--- a/locales/core.js
+++ b/locales/core.js
@@ -113,8 +113,8 @@
                     'max differ': 'Es sollte keinen Grund geben, mehr als __maxdiffer__ Tage von einem __name__ abzuweichen. Wenn nötig, teile uns dies bitte mit …',
                     'adding 0': 'Addition von 0 verändert das Datum nicht. Bitte weglassen.',
                     'unexpected token holiday': 'Unerwarteter Token (in Feiertags-Auswertung): __token__',
-                    'no holiday defintion': '__name__ ist für das Land __cc__ nicht definiert.',
-                    'no holiday defintion state': '__name__ ist für das Land __cc__ und Bundesland __state__ nicht definiert.',
+                    'no holiday definition': '__name__ ist für das Land __cc__ nicht definiert.',
+                    'no holiday definition state': '__name__ ist für das Land __cc__ und Bundesland __state__ nicht definiert.',
                     'no country code': 'Der Ländercode fehlt. Dieser wird benötigt um die korrekten Feiertage zu bestimmen (siehe in der README wie dieser anzugeben ist)',
                     'movable no formular': 'Der bewegliche Feiertag __name__ kann nicht berechnet werden.'
                         + ' Bitte füge eine entsprechende Formel hinzu.',

--- a/opening_hours.js
+++ b/opening_hours.js
@@ -3836,8 +3836,8 @@
         'max differ': 'There should be no reason to differ more than __maxdiffer__ days from a __name__. If so tell us …',
         'adding 0': 'Adding 0 does not change the date. Please omit this.',
         'unexpected token holiday': 'Unexpected token (holiday parser): __token__',
-        'no holiday defintion': 'There are no holidays (__name__) defined for country __cc__.',
-        'no holiday defintion state': 'There are no holidays (__name__) defined for country __cc__ and state __state__.',
+        'no holiday definition': 'There are no holidays (__name__) defined for country __cc__.',
+        'no holiday definition state': 'There are no holidays (__name__) defined for country __cc__ and state __state__.',
         'no country code': 'Country code missing which is needed to select the correct holidays (see README how to provide it)',
         'movable no formular': 'Movable day __name__ can not not be calculated.'
             + ' Please add the formula how to calculate it.',
@@ -6291,21 +6291,21 @@
                                 break;
                         }
                         if (Object.keys(matching_holiday).length === 0) {
-                            throw formatLibraryBugMessage(t('no holiday defintion', {
+                            throw formatLibraryBugMessage(t('no holiday definition', {
                                 'name': type_of_holidays,
                                 'cc': location_cc,
                             }), 'library bug PR only');
                         }
                         return matching_holiday;
                     } else {
-                        throw formatLibraryBugMessage(t('no holiday defintion state', {
+                        throw formatLibraryBugMessage(t('no holiday definition state', {
                             'name': type_of_holidays,
                             'cc': location_cc,
                             'state': location_state,
                         }), 'library bug PR only');
                     }
                 } else {
-                    throw formatLibraryBugMessage(t('no holiday defintion', {
+                    throw formatLibraryBugMessage(t('no holiday definition', {
                         'name': type_of_holidays,
                         'cc': location_cc,
                     }), 'library bug PR only');


### PR DESCRIPTION
I found a typo: "defintion" instead of "definition". Fixed.