### PR TITLE
Input tolerance: Don’t prefer `on appointment` over `by appointment`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -113,6 +113,12 @@ Changed
 
 * Migrated to use `ES2015 modules`_ and rollup_ for module bundling [simon04_]
 
+* Input tolerance: For a value such as ``Mo-Fr 08:00-12:00 by_appointment`` the
+  tool did previously suggest to use ``Mo-Fr 08:00-12:00 "on appointment"`` but
+  as whether to use ``by appointment`` or ``on appointment`` is not defined the
+  tool now just uses the already given variant (``Mo-Fr 08:00-12:00 "by
+  appointment"`` in this case). [ypid_]
+
 .. _ES2015 modules: http://exploringjs.com/es6/ch_modules.html
 .. _rollup: http://rollupjs.org/
 

--- a/locales/word_error_correction.yaml
+++ b/locales/word_error_correction.yaml
@@ -102,7 +102,8 @@ wrong_words:
     'school ?holidays?': SH
     'weekends?': 'Sa,Su'
     'daylight': sunrise-sunset
-    '(?:on|by)?(?:_| )?appointments?': '"on appointment"'
+    'on(?:_| )?appointments?': '"on appointment"'
+    'by(?:_| )?appointments?': '"by appointment"'
   'Please use notation "<ok>" for "<ko>". Those characters look very similar but are not the same!':
     оff: 'off'
   'Please use time format in 24 hours notation ("<ko>"). If PM is used you might have to convert the hours to the 24 hours notation.':

--- a/test.de.log
+++ b/test.de.log
@@ -1477,9 +1477,6 @@ With [1m[34mwarnings[39m[22m:
 "Additional comment "on appointment"" for "Mo-Fr 08:00-12:00 open "appointment not needed", Mo-Fr 13:00-17:00 open on appointment": [1m[32mPASSED[39m[22m
 With [1m[34mwarnings[39m[22m:
 	*Mo-Fr 08:00-12:00 open "appointment not needed", Mo-Fr 13:00-17:00 open on appointment <--- (Please use notation ""on appointment"" for "on appointment".)
-"Additional comment "on appointment"" for "Mo-Fr 08:00-12:00 open "appointment not needed", Mo-Fr 13:00-17:00 open by_appointment": [1m[32mPASSED[39m[22m
-With [1m[34mwarnings[39m[22m:
-	*Mo-Fr 08:00-12:00 open "appointment not needed", Mo-Fr 13:00-17:00 open by_appointment <--- (Please use notation ""on appointment"" for "by_appointment".)
 "Additional comments" for "Mo,Tu 10:00-16:00 open "no warranty"; We 12:00-18:00 open "female only"; Th closed "Not open because we are coding :)"; Fr 10:00-16:00 open "male only"; Sa 10:00-12:00 "Maybe open. Call us."": [1m[32mPASSED[39m[22m
 "Additional comments for unknown" for "Sa 10:00-12:00 "Maybe open. Call us. (testing special tokens in comment: ; ;; ' || | test end)"": [1m[32mPASSED[39m[22m
 "Additional comments for unknown" for "Sa 10:00-12:00 unknown "Maybe open. Call us. (testing special tokens in comment: ; ;; ' || | test end)"": [1m[32mPASSED[39m[22m
@@ -2797,7 +2794,7 @@ Der optional_conf_parm["tag_key"] fehlt, ist aber notwendig wegen optional_conf_
 "Test isEqualTo function" for "Mo 10:00-20:00; We-Fr 10:00-20:01": [1m[32mPASSED[39m[22m
 "Test isEqualTo function" for "Mo 10:00-20:00; We-Fr 10:00-19:59": [1m[32mPASSED[39m[22m
 "Test isEqualTo function" for "closed; Sa unknown "comment"": [1m[32mPASSED[39m[22m
-864/915 tests passed. 51 did not pass.
+863/914 tests passed. 51 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test.en.log
+++ b/test.en.log
@@ -1298,9 +1298,6 @@ With [1m[34mwarnings[39m[22m:
 "Additional comment "on appointment"" for "Mo-Fr 08:00-12:00 open "appointment not needed", Mo-Fr 13:00-17:00 open on appointment": [1m[32mPASSED[39m[22m
 With [1m[34mwarnings[39m[22m:
 	*Mo-Fr 08:00-12:00 open "appointment not needed", Mo-Fr 13:00-17:00 open on appointment <--- (Please use notation ""on appointment"" for "on appointment".)
-"Additional comment "on appointment"" for "Mo-Fr 08:00-12:00 open "appointment not needed", Mo-Fr 13:00-17:00 open by_appointment": [1m[32mPASSED[39m[22m
-With [1m[34mwarnings[39m[22m:
-	*Mo-Fr 08:00-12:00 open "appointment not needed", Mo-Fr 13:00-17:00 open by_appointment <--- (Please use notation ""on appointment"" for "by_appointment".)
 "Additional comments" for "Mo,Tu 10:00-16:00 open "no warranty"; We 12:00-18:00 open "female only"; Th closed "Not open because we are coding :)"; Fr 10:00-16:00 open "male only"; Sa 10:00-12:00 "Maybe open. Call us."": [1m[32mPASSED[39m[22m
 "Additional comments for unknown" for "Sa 10:00-12:00 "Maybe open. Call us. (testing special tokens in comment: ; ;; ' || | test end)"": [1m[32mPASSED[39m[22m
 "Additional comments for unknown" for "Sa 10:00-12:00 unknown "Maybe open. Call us. (testing special tokens in comment: ; ;; ' || | test end)"": [1m[32mPASSED[39m[22m
@@ -2383,7 +2380,7 @@ The optional_conf_parm["tag_key"] is missing, required by optional_conf_parm["ma
 "Test isEqualTo function" for "Mo 10:00-20:00; We-Fr 10:00-20:01": [1m[32mPASSED[39m[22m
 "Test isEqualTo function" for "Mo 10:00-20:00; We-Fr 10:00-19:59": [1m[32mPASSED[39m[22m
 "Test isEqualTo function" for "closed; Sa unknown "comment"": [1m[32mPASSED[39m[22m
-898/908 tests passed. 10 did not pass.
+897/907 tests passed. 10 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test.js
+++ b/test.js
@@ -3688,7 +3688,7 @@ test.addTest('Additional comment "on appointment"', [
         'Mo-Fr 08:00-12:00 open "appointment not needed", Mo-Fr 13:00-17:00 open "on appointment"',
         'Mo-Fr 08:00-12:00 open "appointment not needed", Mo-Fr 13:00-17:00 open on_appointment',
         'Mo-Fr 08:00-12:00 open "appointment not needed", Mo-Fr 13:00-17:00 open on appointment',
-        'Mo-Fr 08:00-12:00 open "appointment not needed", Mo-Fr 13:00-17:00 open by_appointment',
+        // 'Mo-Fr 08:00-12:00 open "appointment not needed", Mo-Fr 13:00-17:00 open by_appointment',
     ], '2012.10.01 0:00', '2012.10.02 0:00', [
         [ '2012.10.01 08:00', '2012.10.01 12:00', false, 'appointment not needed' ],
         [ '2012.10.01 13:00', '2012.10.01 17:00', false, 'on appointment' ],


### PR DESCRIPTION
Fixes: #210