### PR TITLE
Added Easter Sunday to Slovak holidays

### DIFF
--- a/opening_hours.js
+++ b/opening_hours.js
@@ -3323,6 +3323,7 @@
                 'Deň vzniku Slovenskej republiky'                : [  1,  1 ],
                 'Zjavenie Pána'                                  : [  1,  6 ],
                 'Veľký piatok'                                   : [ 'easter', -2 ],
+                'Veľkonočná nedeľa'                              : [ 'easter',  0 ], 
                 'Veľkonočný pondelok'                            : [ 'easter',  1 ],
                 'Sviatok práce'                                  : [  5,  1 ],
                 'Deň víťazstva nad fašizmom'                     : [  5,  8 ],


### PR DESCRIPTION
Easter Sunday is not official public holiday in Slovakia (mainly because it is Sunday already). However, according to Slovak Labour Code, almost all shops must be closed on all public holidays plus Easter Sunday (as opposed to "normal" Sundays with no limitations), starting 1.6.2017. 
So from opening_hours.js POV, Easter Sunday should be included into Slovak PHs.

Source: https://spectator.sme.sk/c/20495133/shops-will-be-closed-on-all-national-holidays.html