### PR TITLE
Increase NodeJS version requirement to `4.0.0`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,13 @@
 
 language: 'node_js'
 node_js:
-  - '0.12.3'
-  - '0.12'
   - '4'
   - '5'
   - '6'
   - '7'
-
-  # Seems NodeJS v8 support is currently broken for some reason:
-  # https://travis-ci.org/opening-hours/opening_hours.js/jobs/282669934#L665-L677
-  # - 'node'
+  - '8'
+  - '9'
+  - 'node'
 
 install:
   - 'make dependencies-user-wide-get'

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -156,6 +156,7 @@ Changed
 ~~~~~~~
 
 * Migrated to use `ES2015 modules`_ and rollup_ for module bundling. [simon04_]
+* Increased NodeJS version requirement to `4.0.0`. [ypid_]
 * Update to holiday definition format 2.2.0. Holidays are now maintained in
   YAML files, one for each country. [ypid_]
 * Rework the way Nominatim responses are handled (used for testing). [ypid_]

--- a/package.json
+++ b/package.json
@@ -68,6 +68,6 @@
     "country-language": "^0.1.7"
   },
   "engines": {
-    "node": ">=0.12.3"
+    "node": ">=4.0.0"
   }
 }


### PR DESCRIPTION
It seems that rollup was updated and now does not work with 0.12.x
anymore.
https://travis-ci.org/opening-hours/opening_hours.js/jobs/354818972