### PR TITLE
Removed non public holiday.

### DIFF
--- a/holidays/it.yaml
+++ b/holidays/it.yaml
@@ -13,7 +13,6 @@ PH:
   - {'name': 'Festa della Repubblica', 'fixed_date': [6, 2]}
   - {'name': 'Assunzione di Maria', 'fixed_date': [8, 15]}
   - {'name': 'Ognissanti', 'fixed_date': [11, 1]}
-  - {'name': 'Festa dell’unità nazionale', 'variable_date': firstSeptemberSunday}
   - {'name': 'Immacolata Concezione', 'fixed_date': [12, 8]}
   - {'name': 'Natale di Gesù', 'fixed_date': [12, 25]}
   - {'name': 'Santo Stefano', 'fixed_date': [12, 26]}


### PR DESCRIPTION
According to both the [Italian government website](http://presidenza.governo.it/ufficio_cerimoniale/cerimoniale/giornate.html#festivita) and [Wikipedia](https://it.wikipedia.org/wiki/Giornata_dell'Unit%C3%A0_Nazionale_e_delle_Forze_Armate#Storia) _Festa dell'unità nazionale_ is not a public holiday. It has been, but in 1977 it was removed (Wikipedia).