### PR TITLE
build: replace uglify-js with terser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -537,17 +537,12 @@ opening_hours.js:
 opening_hours+deps.js:
 	DEPS=YES ./node_modules/.bin/rollup -c
 
-uglifyjs.log: opening_hours.js
-	uglifyjs "$<" --lint 1>/dev/zero 2>uglifyjs.log
-
 opening_hours.min.js:
 
-opening_hours+deps.min.js: opening_hours+deps.js
-	@true I don’t really care for warnings in dependencies of opening_hours.js.
-	uglifyjs "$<" --output "$@" --comments '/github.com/' --lint 2> >(grep --invert-match '^WARN: ')
+opening_hours+deps.min.js:
 
 %.min.js: %.js
-	uglifyjs "$<" --output "$@" --comments '/github.com/' --lint
+	./node_modules/.bin/terser "$<" --output "$@" --comments '/github.com/' --lint
 
 README.html:
 

--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
     "regex_search": "make run-regex_search"
   },
   "dependencies": {
-    "suncalc": "^1.8.0",
-    "uglify-js": "^2.7.5"
+    "suncalc": "^1.8.0"
   },
   "devDependencies": {
     "assert": "^1.4.1",
@@ -59,8 +58,8 @@
     "rollup-plugin-node-resolve": "^3.0.0",
     "rollup-plugin-yaml": "^1.0.0",
     "sprintf-js": "1.1.1",
-    "timekeeper": "^2.0.0",
-    "uglify-js": "^3.0.15"
+    "terser": "^4.6.3",
+    "timekeeper": "^2.0.0"
   },
   "peerDependencies": {
     "i18next-client": "^1.11.1",


### PR DESCRIPTION
> terser is a fork of uglify-es that mostly retains API and CLI compatibility with uglify-es and uglify-js@3.