### PR TITLE
Add holidays for virtual XA country

### DIFF
--- a/holidays/index.js
+++ b/holidays/index.js
@@ -24,3 +24,4 @@ export {default as si} from "./si.yaml";
 export {default as sk} from "./sk.yaml";
 export {default as ua} from "./ua.yaml";
 export {default as us} from "./us.yaml";
+export {default as xa} from "./xa.yaml";

--- a/holidays/xa.yaml
+++ b/holidays/xa.yaml
@@ -1,0 +1,12 @@
+---
+
+_nominatim_url: 'https://nominatim.openstreetmap.org/reverse?format=json&lat=0.0&lon=0.0&zoom=18&addressdetails=1&accept-language=en'
+
+# Generic country with a dummy public+school holiday
+# XA is a user-assigned code according to ISO 3166-1 alpha-2
+PH:
+  - name: New Year
+    fixed_date: [1, 1]
+SH:
+  - name: Summer
+    '2020': [6, 21, 9, 23]


### PR DESCRIPTION
For @JOSM, we only use `opening_hours.js` in order to validate the syntax, but do not compute whether a date is a public/school holiday. Thus, one could strip all country data and just keep a bare minimum dataset in terms of a user-assigned code ISO 3166-1 alpha-2 `XA`.