### PR TITLE
Build package during prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "osm-tag-data-check": "make osm-tag-data-check",
     "benchmark": "make benchmark",
     "interactive_testing": "make run-interactive_testing",
-    "regex_search": "make run-regex_search"
+    "regex_search": "make run-regex_search",
+    "prepare": "npm run build"
   },
   "dependencies": {
     "suncalc": "^1.8.0"


### PR DESCRIPTION
Build step must be run by npm before publishing.

According to this article, its usually best at the `prepare` hook of npm:
https://itnext.io/step-by-step-building-and-publishing-an-npm-typescript-package-44fe7164964c

> prepare will run both BEFORE the package is packed and published, and on local npm install. Perfect for running building the code. Add this script to package.json
```json
"prepare" : "npm run build"
```

Official npm documentation also has an article on `prepare`: https://docs.npmjs.com/cli/v6/using-npm/scripts#prepare-and-prepublish

I verified this method by:
1. `npm install git+https://github.com/fodor0205/opening_hours.js.git` in an npm project
2. building the same code, that built successfully with the v3.5.0 version currently published on npm
3. the functionality worked just like the original version

If this method is correct, it can solve #360 @ypid @pietervdvn