### PR TITLE
add Romanian school holidays 2020-2021

### DIFF
--- a/holidays/ro.yaml
+++ b/holidays/ro.yaml
@@ -17,8 +17,11 @@ PH:
   - {'name': 'Ziua Națională (Ziua Marii Uniri)', 'fixed_date': [12, 1]}
   - {'name': 'Crăciunul', 'fixed_date': [12, 25]}
   - {'name': 'A doua zi de Crăciun', 'fixed_date': [12, 26]}
+
+# source:
+# https://www.edu.ro/ordinul-ministrului-educa%C8%9Biei-%C8%99i-cercet%C4%83rii-nr-31252020-privind-structura-anului-%C8%99colar-2020-2021
 SH:
-  - {'2015': [1, 31, 2, 8], '2016': [1, 30, 2, 7], name: 'Vacanţa intersemestrială'}
-  - {'2015': [4, 11, 4, 19], '2016': [4, 23, 5, 3], name: 'Vacanța de primăvară'}
+  - {'2015': [1, 31, 2, 8], '2016': [1, 30, 2, 7], '2021': [1, 30, 2, 7], name: 'Vacanţa intersemestrială'}
+  - {'2015': [4, 11, 4, 19], '2016': [4, 23, 5, 3], '2021': [4, 30, 5, 9], name: 'Vacanța de primăvară'}
   - {'2015': [6, 20, 9, 13], '2016': [6, 18, 9, 4], name: 'Vacanța de vară'}
-  - {'2014': [12, 20, 1, 4], '2015': [12, 19, 1, 3], name: 'Vacanța de iarnă'}
+  - {'2014': [12, 20, 1, 4], '2015': [12, 19, 1, 3], '2020': [12, 23, 01, 10], name: 'Vacanța de iarnă'}


### PR DESCRIPTION
Add holidays as far as already known. Summer vacation end is not yet determined yet, see source

https://www.edu.ro/ordinul-ministrului-educa%C8%9Biei-%C8%99i-cercet%C4%83rii-nr-31252020-privind-structura-anului-%C8%99colar-2020-2021