### PR TITLE
add Romanian SH for summer and winter vacation 2021

### DIFF
--- a/src/holidays/ro.yaml
+++ b/src/holidays/ro.yaml
@@ -18,7 +18,9 @@ PH:
   - {'name': 'Crăciunul', 'fixed_date': [12, 25]}
   - {'name': 'A doua zi de Crăciun', 'fixed_date': [12, 26]}
 
+# sources
 # https://www.edu.ro/ordinul-ministrului-educa%C8%9Biei-%C8%99i-cercet%C4%83rii-nr-31252020-privind-structura-anului-%C8%99colar-2020-2021
+# https://www.edu.ro/structura_anului_scolar_2021_2022
 SH:
   - name: 'Vacanţa intersemestrială'
     '2015': [1, 31, 2, 8]
@@ -31,7 +33,9 @@ SH:
   - name: 'Vacanța de vară'
     '2015': [6, 20, 9, 13]
     '2016': [6, 18, 9, 4]
+    '2021': [6, 26, 9, 13]
   - name: 'Vacanța de iarnă'
     '2014': [12, 20, 1, 4]
     '2015': [12, 19, 1, 3]
     '2020': [12, 23, 01, 10]
+    '2021': [12, 23, 01, 9]


### PR DESCRIPTION
Hi, I finally got around to add missing vacation dates for Romania in 2021. 

Source used: https://www.edu.ro/structura_anului_scolar_2021_2022