### PR TITLE
Add Scotland and Northern Ireland public holidays

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,7 +584,7 @@ Almost everything from opening_hours definition is supported, as well as some ex
     - [Canada][ph-ca]
     - [Czech Republic][ph-cz]
     - [Denmark][ph-dk]
-    - [England and Wales][ph-gb]
+    - [England, Wales, Scotland and Northern Ireland][ph-gb]
     - [France][ph-fr]
     - [Germany][ph-de] ([footnotes][ph-de] are ignored)
     - [Hungary][ph-hu]

--- a/src/holidays/gb.yaml
+++ b/src/holidays/gb.yaml
@@ -22,3 +22,28 @@
     - {'name': 'Summer bank holiday', 'variable_date': lastAugustMonday}
     - {'name': 'Christmas', 'fixed_date': [12, 25]}
     - {'name': 'Boxing Day', 'fixed_date': [12, 26]}
+'Northern Ireland':  # https://www.gov.uk/bank-holidays#northern-ireland
+  _nominatim_url: https://nominatim.openstreetmap.org/reverse?format=json&lat=54.5950675&lon=-5.9298401&zoom=18&addressdetails=1&accept-language=en
+  PH:
+    - {'name': 'New Year’s Day', 'fixed_date': [1, 1]}
+    - {'name': 'St Patrick’s Day', 'variable_date': 'nextMo-Fr17March'}
+    - {'name': 'Good Friday', 'variable_date': easter, 'offset': -2}
+    - {'name': 'Easter Monday', 'variable_date': easter, 'offset': 1}
+    - {'name': 'Early May bank holiday', 'variable_date': firstMayMonday}
+    - {'name': 'Spring bank holiday', 'variable_date': lastMayMonday}
+    - {'name': 'Battle of the Boyne', 'variable_date': 'nextMo-Fr12July'}
+    - {'name': 'Summer bank holiday', 'variable_date': lastAugustMonday}
+    - {'name': 'Christmas', 'fixed_date': [12, 25]}
+    - {'name': 'Boxing Day', 'fixed_date': [12, 26]}
+'Scotland':  # https://www.gov.uk/bank-holidays#scotland
+  _nominatim_url: https://nominatim.openstreetmap.org/reverse?format=json&lat=55.9557307&lon=-3.1976026&zoom=18&addressdetails=1&accept-language=en
+  PH:
+    - {'name': 'New Year’s Day', 'fixed_date': [1, 1]}
+    - {'name': '2nd January', 'fixed_date': [1, 2]}
+    - {'name': 'Good Friday', 'variable_date': easter, 'offset': -2}
+    - {'name': 'Early May bank holiday', 'variable_date': firstMayMonday}
+    - {'name': 'Spring bank holiday', 'variable_date': lastMayMonday}
+    - {'name': 'Summer bank holiday', 'variable_date': lastAugustMonday}
+    - {'name': 'St. Andrew’s Day', 'variable_date': 'nextMo-Fr30November'}
+    - {'name': 'Christmas', 'fixed_date': [12, 25]}
+    - {'name': 'Boxing Day', 'fixed_date': [12, 26]}

--- a/src/index.js
+++ b/src/index.js
@@ -2764,7 +2764,9 @@ export default function(value, nominatim_object, optional_conf_parm) {
             'nextWednesday16Nov'    : getDateOfWeekdayInDateRange(3, new Date(year, 10, 16)),
             'nextMo-Fr17March'      : getDateOfNextWeekdayRange(1, 5, new Date(year, 2, 17)),
             'nextMo-Sa01May'        : getDateOfNextWeekdayRange(1, 6, new Date(year, 4, 1)),
+            'nextMo-Fr12July'       : getDateOfNextWeekdayRange(1, 5, new Date(year, 6, 12)),
             'nextMo-Sa07August'     : getDateOfNextWeekdayRange(1, 6, new Date(year, 7, 7)),
+            'nextMo-Fr30November'   : getDateOfNextWeekdayRange(1, 5, new Date(year, 10, 30)),
             'nextMo-Sa25December'   : getDateOfNextWeekdayRange(1, 6, new Date(year, 11, 25)),
         };
     }


### PR DESCRIPTION
Hi, I've added public holiday definitions for Scotland and Northern Ireland following the existing examples.

When creating these, I ran into a couple of things I wasn't sure how to deal with. These may be larger issues which could be saved for a different pull request.

1. In 2022 only, there's a UK-wide public holiday for the Queen's Diamond Jubilee. I couldn't spot another example of a one year only public holiday so didn't include it for now.
2. I wasn't sure the best way to handle substitute bank holidays. In the UK whenever a bank holiday would fall on a weekend, it gets moved to the next available weekday. There were some examples of this already happening (with the `nextMo-Fr17March` syntax). However I would have expected it to occur for every holiday (including Christmas, etc.). In this pull request I decided to follow the existing examples and leave the Christmas/New Year ones as fixed dates but add the other variable ones correctly shifting to the next available Monday.