### PR TITLE
Set page language dynamically

### DIFF
--- a/site/css/main.css
+++ b/site/css/main.css
@@ -1,6 +1,4 @@
 body { font-family: sans-serif }
-q:before { content:"„"; }
-q:after { content:"“"; }
 
 .permalink {
     float: right;

--- a/site/index.html
+++ b/site/index.html
@@ -253,6 +253,7 @@
                 { href: 'https://wiki.openstreetmap.org/wiki/Key:opening_hours' }) + '<br />');
 
             document.write(i18next.t('texts.this website', { url: repo_url, hoster: 'GitHub' }));
+            document.body.parentElement.lang = i18next.language;
         </script>
         </div><!-- }}} -->
     <iframe style="visibility:hidden;display:none" name='hiddenframe'></iframe>


### PR DESCRIPTION
Set the page’s `lang` attribute dynamically depending on the localization. The browser automatically adapts the quotation marks around the `<q>` tag according to the page language, so there’s no need to hard-code German punctuation for all languages.