### PR TITLE
Add check: don't crash if osm_tag_defaults[oh_regex_key] is undefined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -237,7 +237,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
     }
 
     if (typeof oh_mode === 'undefined') {
-        if (typeof oh_key === 'string') {
+        if (typeof oh_key === 'string' && osm_tag_defaults[oh_regex_key] !== undefined) {
             if (typeof osm_tag_defaults[oh_regex_key]['mode'] === 'number') {
                 oh_mode = osm_tag_defaults[oh_regex_key]['mode'];
             } else {


### PR DESCRIPTION
In MapComplete, it is possible to show opening hours for any tag. When a new key is passed (e.g. access:conditional:motorvehicle), this crashes the evaluator instead of defaulting to `oh_mode=0`.

This patch checks that osm_tag_defaults[oh_regex_key] exists