### PR TITLE
Fixed some TypeScript types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -25,7 +25,7 @@ declare module 'opening_hours' {
     getWarnings(): string[]
     isEqualTo(
       second_oh_object: opening_hours,
-      start_date: opening_hours
+      start_date?: Date
     ): boolean
     isWeekStable(): boolean
     prettifyValue(argument_hash: argument_hash): string

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -18,10 +18,7 @@ declare module 'opening_hours' {
     getOpenIntervals(
       from: Date,
       to: Date
-    ): [
-      [Date, Date, boolean, string | undefined],
-      [Date, Date, boolean, string | undefined]
-    ]
+    ): [Date, Date, boolean, string | undefined][]
     getStatePair(
       date?: Date
     ): [boolean, Date, boolean, string | undefined, number | undefined]


### PR DESCRIPTION
The return type of  `opening_hours.getOpenIntervals` was declared as a tuple with two intervals instead of an array of intervals.
The `start_date` parameter of `opening_hours.isEqualTo` was declared as an `opening_hours` object instead of a `Date` object or undefined.

This PR fixes these errors.