### PR TITLE
fix prettifyValue typescript description

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -28,7 +28,7 @@ declare module 'opening_hours' {
       start_date?: Date
     ): boolean
     isWeekStable(): boolean
-    prettifyValue(argument_hash: argument_hash): string
+    prettifyValue(argument_hash?: argument_hash): string
     getIterator(date?: Date): opening_hours_iterator
   }
   export default opening_hours


### PR DESCRIPTION
The documentation mentions that the prettifyValue function takes an optional argument.

> The function accepts an optional hash.

This PR fixes the typescript description to reflect the documentation.