### PR TITLE
Added basic Argentina holidays

### DIFF
--- a/src/holidays/ar.yaml
+++ b/src/holidays/ar.yaml
@@ -1,0 +1,17 @@
+---
+
+_nominatim_url: 'https://nominatim.openstreetmap.org/reverse?format=json&lat=-34.60377&lon=-58.38159&zoom=16&addressdetails=1&accept-language=es'
+
+# https://www.argentina.gob.ar/interior/feriados-nacionales-2022
+
+PH:
+  - {'name': 'Año Nuevo', 'fixed_date': [1, 1]}
+  - {'name': 'Día Nacional de la Memoria por la Verdad y la Justicia', 'fixed_date': [3, 24]}
+  - {'name': 'Día del Veterano y de los Caídos en la Guerra de Malvinas', 'fixed_date': [4, 2]}
+    # Viernes Santo
+  - {'name': 'Día del Trabajador', 'fixed_date': [5, 1]}
+  - {'name': 'Día de la Revolución de Mayo', 'fixed_date': [5, 25]}
+  - {'name': 'Paso a la Inmortalidad del General Manuel Belgrano', 'fixed_date': [6, 20]}
+  - {'name': 'Día de la Independencia', 'fixed_date': [7, 9]}
+  - {'name': 'Inmaculada Concepción de María', 'fixed_date': [12, 8]}
+  - {'name': 'Navidad', 'fixed_date': [12, 25]}

--- a/src/holidays/index.js
+++ b/src/holidays/index.js
@@ -1,3 +1,4 @@
+export { default as ar } from "./ar.yaml";
 export { default as at } from "./at.yaml";
 export { default as au } from "./au.yaml";
 export { default as be } from "./be.yaml";


### PR DESCRIPTION
https://www.argentina.gob.ar/interior/feriados-nacionales-2022 used as reference.