### PR TITLE
Switch to http for JOSM

### DIFF
--- a/site/js/helpers.js
+++ b/site/js/helpers.js
@@ -15,7 +15,7 @@ var evaluation_tool_colors = {
 // FIXME: Warning in console. Encoding stuff.
 function josm(url_param) {
     var xhr = new XMLHttpRequest();
-    xhr.open('GET', 'https://localhost:8111/' + url_param, true);      // true makes this call asynchronous
+    xhr.open('GET', 'http://localhost:8111/' + url_param, true);      // true makes this call asynchronous
     xhr.onreadystatechange = function () {    // need eventhandler since our call is async
         if ( xhr.status !== 200 ) {
             alert(i18next.t('texts.JOSM remote conn error'));


### PR DESCRIPTION
1. `https` is not working for me
2. iD also uses http instead of `https`
3. The [documentation](https://wiki.openstreetmap.org/wiki/JOSM/RemoteControl) only mentions `http`