### PR TITLE
Correct Swedish and Finnish public holidays

### DIFF
--- a/src/holidays/fi.yaml
+++ b/src/holidays/fi.yaml
@@ -15,7 +15,7 @@ PH:
   - {'name': 'vappu - första maj', 'fixed_date': [5, 1]}
   - {'name': 'helatorstai - Kristi himmelsfärdsdag', 'variable_date': easter, 'offset': 39}
   - {'name': 'helluntai - pingst', 'variable_date': easter, 'offset': 49}
-  - {'name': 'juhannuspäivä - midsommarafton', 'variable_date': nextSaturday20Jun}
+  - {'name': 'juhannuspäivä - midsommardagen', 'variable_date': nextSaturday20Jun}
   - {'name': 'pyhäinpäivä - alla helgons dag', 'variable_date': nextSaturday31Oct}
   - {'name': 'itsenäisyyspäivä - självständighetsdagen', 'fixed_date': [12, 6]}
   - {'name': 'joulupäivä - juldagen', 'fixed_date': [12, 25]}

--- a/src/holidays/fi.yaml
+++ b/src/holidays/fi.yaml
@@ -13,6 +13,7 @@ PH:
   - {'name': 'pääsiäispäivä - påskdagen', 'variable_date': easter}
   - {'name': 'toinen pääsiäispäivä - annandag påsk', 'variable_date': easter, 'offset': 1}
   - {'name': 'vappu - första maj', 'fixed_date': [5, 1]}
+  - {'name': 'helatorstai - Kristi himmelsfärdsdag', 'variable_date': easter, 'offset': 39}
   - {'name': 'helluntai - pingst', 'variable_date': easter, 'offset': 49}
   - {'name': 'juhannuspäivä - midsommarafton', 'variable_date': nextSaturday20Jun}
   - {'name': 'pyhäinpäivä - alla helgons dag', 'variable_date': nextSaturday31Oct}

--- a/src/holidays/se.yaml
+++ b/src/holidays/se.yaml
@@ -11,6 +11,7 @@ PH:
   - {'name': 'påskdagen', 'variable_date': easter}
   - {'name': 'annandag påsk', 'variable_date': easter, 'offset': 1}
   - {'name': 'första maj', 'fixed_date': [5, 1]}
+  - {'name': 'Kristi himmelsfärdsdag', 'variable_date': easter, 'offset': 39}
   - {'name': 'pingstdagen', 'variable_date': easter, 'offset': 49}
   - {'name': 'nationaldagen', 'fixed_date': [6, 6]}
   - {'name': 'midsommardagen', 'variable_date': nextSaturday20Jun}

--- a/test/test.js
+++ b/test/test.js
@@ -2460,13 +2460,14 @@ test.addTest('Variable days: Swedish public holidays.', [
     [ '2015-04-05 00:00', '2015-04-06 00:00', false, 'påskdagen' ],
     [ '2015-04-06 00:00', '2015-04-07 00:00', false, 'annandag påsk' ],
     [ '2015-05-01 00:00', '2015-05-02 00:00', false, 'första maj' ],
+    [ '2015-05-14 00:00', '2015-05-15 00:00', false, 'Kristi himmelsfärdsdag' ],
     [ '2015-05-24 00:00', '2015-05-25 00:00', false, 'pingstdagen' ],
     [ '2015-06-06 00:00', '2015-06-07 00:00', false, 'nationaldagen' ],
     [ '2015-06-20 00:00', '2015-06-21 00:00', false, 'midsommardagen' ],
     [ '2015-10-31 00:00', '2015-11-01 00:00', false, 'alla helgons dag' ],
     [ '2015-12-25 00:00', '2015-12-26 00:00', false, 'juldagen' ],
     [ '2015-12-26 00:00', '2015-12-27 00:00', false, 'annandag jul' ],
-], 1000 * 60 * 60 * 24 * 12, 0, false, nominatim_by_loc.se, 'not last test');
+], 1000 * 60 * 60 * 24 * 13, 0, false, nominatim_by_loc.se, 'not last test');
 
 test.addTest('Variable days: Weekday in given week.', [
     'PH',


### PR DESCRIPTION
When public holidays were added for Sweden in #72, Ascension Day (Swedish: _Kristi himmelsfärdsdag_) was not included even though it is a holiday in Sweden and is listed as such in both sources cited in `src/holidays/se.yaml`. No reason was given for its exclusion. This mistake was seemingly carried over to the data for Finland in #294, as Ascension Day (Finnish: _helatorstai_, Swedish: _Kristi himmelsfärdsdag_) is a public holiday in Finland according to the sources cited in `src/holidays/fi.yaml`. The data for Finland also incorrectly lists the Swedish name of Midsummer Day (Finnish: _juhannuspäivä_, Swedish: _midsommardagen_) as _midsommarafton_, which means Midsummer Eve (Finnish: _juhannusaatto_), i.e. the Friday on the day before Midsummer Day. These errors are fixed by this PR.