### PR TITLE
[Evaluation tool] Optimize "Error and warning messages" layout

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -187,6 +187,8 @@ Changed
 
   * Hungarian
 
+* [Evaluation tool] Optimize "Error and warning messages" layout
+
 Fixed
 ~~~~~
 

--- a/site/css/main.css
+++ b/site/css/main.css
@@ -12,9 +12,10 @@ p.value_explanation {
     padding: 6px 10px;
     border-radius: 5px;
 }
-/* See http://clrs.cc/ */
-.error       { background: #ff851b } /* Orange */
-.warning     { background: #ffdc00 } /* Yellow */
+/* See https://clrs.cc/ */
+.error       { background: #ff851b; padding: 3px; } /* Orange */
+.warning     { background: #ffdc00; padding: 3px; } /* Yellow */
+div.warning_error_message { margin: 5px 0 0 0; padding: 5px; background-color : white; opacity: 0.8; font-family: monospace;}
 span.year    { background: #ff851b } /* Orange */
 span.week    { background: #ffdc00 } /* Yellow */
 span.month   { background: #88ff88 }

--- a/site/js/helpers.js
+++ b/site/js/helpers.js
@@ -1,3 +1,5 @@
+/* global $, , default_lat, default_lon, i18next, jQuery, mapCountryToLanguage, opening_hours, OpeningHoursTable, specification_url, YoHoursChecker */
+
 /* Constants {{{ */
 var nominatim_api_url = 'https://nominatim.openstreetmap.org/reverse';
 // var nominatim_api_url = 'https://open.mapquestapi.com/nominatim/v1/reverse.php';
@@ -189,9 +191,10 @@ function Evaluate (offset, reset) {
         var it = oh.getIterator(date);
     } catch (err) {
         crashed = err;
-        show_warnings_or_errors.innerHTML = '<p class="error">' + i18next.t('texts.filter.error') + ':<br />'
-            + '<textarea rows="' + crashed.split('\n').length + 1 + '" style="width: 100%" name="WarnErrors" readonly="readonly">' + crashed
-            + '</textarea></p>';
+        show_warnings_or_errors.innerHTML = `
+            <div class="error"> ${i18next.t('texts.filter.error')}
+                <div class="warning_error_message"> ${crashed} </div>
+            </div>`;
         show_time_table.innerHTML = '';
         show_results.innerHTML    = '';
     }
@@ -331,15 +334,18 @@ function Evaluate (offset, reset) {
 
         var warnings = oh.getWarnings();
         if (warnings.length > 0) {
-            show_warnings_or_errors.innerHTML += '<p class="warning">' + i18next.t('texts.filter.error') + ':<br />'
-                + '<textarea rows="' + (warnings.length + 1)
-                + '" style="width: 100%" name="WarnErrors" readonly="readonly">' + warnings.join('\n')
-                + '</textarea></p>';
+            show_warnings_or_errors.innerHTML += `
+            <div class="warning"> ${i18next.t('texts.filter.error')}
+                <div class="warning_error_message"> ${warnings.join('\n')} </div>
+            </div>`;
         }
 
         if (prettified.length > 255) {
-            show_warnings_or_errors.innerHTML += '<p>' + i18next.t('texts.value to long for osm',
-                { pretLength: prettified.length, valLength: value.length, maxLength: 255 }) + '</p>';
+            show_warnings_or_errors.innerHTML += `
+            <div class="warning"> ${i18next.t('texts.filter.error')}
+                <div class="warning_error_message"> ${i18next.t('texts.value to long for osm',
+                    { pretLength: prettified.length, valLength: value.length, maxLength: 255 })} </div>
+            </div>`;
         }
 
         show_time_table.innerHTML += OpeningHoursTable.drawTableAndComments(oh, it);


### PR DESCRIPTION
To fix #464 I optimized the layout of the error and warning messages a bit.

|   | **before**  | **after**  |
|---|---|---|
| **Error**  | ![error_before](https://github.com/user-attachments/assets/1857a706-8068-4c87-9b26-e56cb1919f45) | ![error_after](https://github.com/user-attachments/assets/2e7b9592-6995-4836-9957-f5f92037348e) |
| **Warning** | ![warning_before](https://github.com/user-attachments/assets/dc761f0e-f3da-4978-9da4-81e837376242) | ![warning_after](https://github.com/user-attachments/assets/7c0e5d96-6ccf-4348-b8a0-e923513cbd35) |
| **Warning prettified length** | ![warning_prettified_length_before](https://github.com/user-attachments/assets/23ec4d74-c3bd-4186-aefd-b63a4ac1bc94)  |  ![warning_prettified_length_after](https://github.com/user-attachments/assets/33077199-2e80-4216-a1ae-405a12233911) |







