### PR TITLE
chore: drop the `git stash` and `git add` magic from commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,10 +1,6 @@
 #!/bin/sh
-git stash -q --keep-index
 
 # # Redirect output to stderr.
 # exec 1>&2
 
-npm run test-quick
-git add test/test.*.log
-
-git stash pop -q
+make check


### PR DESCRIPTION
They cause too many issues. Developers will need to manually add changed test logs. If they forget, the CI will catch it.