### PR TITLE
refactor: remove deprecated tag `opening_hours:covid19`

### DIFF
--- a/scripts/real_test.js
+++ b/scripts/real_test.js
@@ -59,9 +59,6 @@ test_framework.config = {
     },
     'opening_hours:warm_kitchen': {
     },
-    'opening_hours:covid19': {
-        manually_ignored: [ 'same', 'restricted' ],
-    },
     'smoking_hours': {
         manually_ignored: [ 'yes' ],
     },

--- a/scripts/related_tags.txt
+++ b/scripts/related_tags.txt
@@ -7,7 +7,6 @@
 opening_hours
 opening_hours:kitchen
 opening_hours:warm_kitchen
-opening_hours:covid19
 happy_hours
 delivery_hours
 opening_hours:delivery

--- a/taginfo.json
+++ b/taginfo.json
@@ -24,10 +24,6 @@
             "description": "Helps to write, auto correct, debug and validate this tag."
         },
         {
-            "key": "opening_hours:covid19",
-            "description": "Helps to write, auto correct, debug and validate this tag."
-        },
-        {
             "key": "happy_hours",
             "description": "Helps to write, auto correct, debug and validate this tag."
         },


### PR DESCRIPTION
The tag is deprecated since 2023 (https://wiki.openstreetmap.org/wiki/Key:opening_hours:covid19). I think we don't need it here anymore.