### PR TITLE
feat(DE): update Frauentag states to include Mecklenburg-Vorpommern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,8 @@ work hours!
 
 - Public holiday definitions updated:
   - France ([#470](https://github.com/opening-hours/opening_hours.js/pull/470))
+  - Germany
+    - "Frauentag" is a public holiday in Mecklenburg-Vorpommern since 2023
 - School holiday definitions updated:
   - Hungary ([#450](https://github.com/opening-hours/opening_hours.js/pull/450))
 

--- a/src/holidays/de.yaml
+++ b/src/holidays/de.yaml
@@ -5,7 +5,7 @@ _nominatim_url: 'https://nominatim.openstreetmap.org/reverse?format=json&lat=49.
 PH:  # https://de.wikipedia.org/wiki/Feiertage_in_Deutschland
   - {"name": "Neujahrstag", "fixed_date": [1, 1]}
   - {"name": "Heilige Drei Könige", "fixed_date": [1, 6], "only_states": [Baden-Württemberg, Bayern, Sachsen-Anhalt]}
-  - {"name": "Frauentag", "fixed_date": [3, 8], "only_states": [Berlin]}
+  - {"name": "Frauentag", "fixed_date": [3, 8], "only_states": [Berlin, Mecklenburg-Vorpommern]}
   - {"name": "Tag der Arbeit", "fixed_date": [5, 1]}
   - {"name": "Karfreitag", "variable_date": "easter", "offset": -2}
   - {"name": "Ostersonntag", "variable_date": "easter", "only_states": [Brandenburg]}


### PR DESCRIPTION
It is public holiday since 2023 there. Source: https://de.wikipedia.org/wiki/Feiertag_(Deutschland)