### PR TITLE
fix: localize expected test strings for German locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,13 +117,14 @@ work hours!
 - Public holiday definitions updated:
   - France ([#470](https://github.com/opening-hours/opening_hours.js/pull/470))
   - Germany
-    - "Frauentag" is a public holiday in Mecklenburg-Vorpommern since 2023
+    - "Frauentag" is a public holiday in Mecklenburg-Vorpommern since 2023 ([#511](https://github.com/opening-hours/opening_hours.js/pull/511))
 - School holiday definitions updated:
   - Hungary ([#450](https://github.com/opening-hours/opening_hours.js/pull/450))
 
 ### Fixed
 
 - fix: add missing `country_code` to `xa.yaml` ([#499](https://github.com/opening-hours/opening_hours.js/pull/499))
+- fix: localize expected test strings for German locale ([#512](https://github.com/opening-hours/opening_hours.js/pull/512))
 
 ### Removed
 

--- a/test/test.de.log
+++ b/test/test.de.log
@@ -279,241 +279,62 @@ With [1m[34mwarnings[39m[22m:
 "Time ranges spanning midnight with date overwriting (complex real world example)" for "Su-Tu 11:00-01:00, We-Th 11:00-03:00, Fr 11:00-06:00, Sa 11:00-07:00": [1m[32mPASSED[39m[22m
 "Time ranges spanning midnight with date overwriting (complex real world example)" for "Su-Tu 11:00-01:00, We-Th11:00-03:00, Fr 11:00-06:00, Sa 11:00-07:00": [1m[32mPASSED[39m[22m
 "Time ranges spanning midnight (maximum supported)" for "Tu 23:59-48:00": [1m[32mPASSED[39m[22m
-"Time ranges spanning midnight with open ened (maximum supported)" for "Tu 23:59-40:00+": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2012-10-02 23:59', '2012-10-03 16:00', false, undefined ],
-[ '2012-10-03 16:00', '2012-10-04 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-expected:
-[ '2012-10-02 23:59', '2012-10-03 16:00', false, undefined ],
-[ '2012-10-03 16:00', '2012-10-04 00:00', true, 'Specified as open end. Closing time was guessed.' ],
+"Time ranges spanning midnight with open end (maximum supported)" for "Tu 23:59-40:00+": [1m[32mPASSED[39m[22m
 "Open end" for "07:00+ open "visit there website to know if they did already close"": [1m[32mPASSED[39m[22m
 "Open end" for "07:00+ unknown "visit there website to know if they did already close"": [1m[32mPASSED[39m[22m
-"Open end" for "17:00+": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2012-10-01 00:00', '2012-10-01 03:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2012-10-01 17:00', '2012-10-02 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-expected:
-[ '2012-10-01 00:00', '2012-10-01 03:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2012-10-01 17:00', '2012-10-02 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-"Open end" for "17:00-late": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2012-10-01 00:00', '2012-10-01 03:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2012-10-01 17:00', '2012-10-02 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-expected:
-[ '2012-10-01 00:00', '2012-10-01 03:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2012-10-01 17:00', '2012-10-02 00:00', true, 'Specified as open end. Closing time was guessed.' ],
+"Open end" for "17:00+": [1m[32mPASSED[39m[22m
+"Open end" for "17:00-late": [1m[32mPASSED[39m[22m
 With [1m[34mwarnings[39m[22m:
 	*17:00-late <--- ("-late" wird als "+" ("open end") interpretiert. Example: "12:00+".)
-"Open end" for "17:00 til late": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2012-10-01 00:00', '2012-10-01 03:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2012-10-01 17:00', '2012-10-02 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-expected:
-[ '2012-10-01 00:00', '2012-10-01 03:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2012-10-01 17:00', '2012-10-02 00:00', true, 'Specified as open end. Closing time was guessed.' ],
+"Open end" for "17:00 til late": [1m[32mPASSED[39m[22m
 With [1m[34mwarnings[39m[22m:
 	*17:00 til late <--- ("til late" wird als "+" ("open end") interpretiert. Example: "12:00+".)
-"Open end" for "17:00 till late": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2012-10-01 00:00', '2012-10-01 03:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2012-10-01 17:00', '2012-10-02 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-expected:
-[ '2012-10-01 00:00', '2012-10-01 03:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2012-10-01 17:00', '2012-10-02 00:00', true, 'Specified as open end. Closing time was guessed.' ],
+"Open end" for "17:00 till late": [1m[32mPASSED[39m[22m
 With [1m[34mwarnings[39m[22m:
 	*17:00 till late <--- ("till late" wird als "+" ("open end") interpretiert. Example: "12:00+".)
-"Open end" for "17:00 bis Open End": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2012-10-01 00:00', '2012-10-01 03:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2012-10-01 17:00', '2012-10-02 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-expected:
-[ '2012-10-01 00:00', '2012-10-01 03:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2012-10-01 17:00', '2012-10-02 00:00', true, 'Specified as open end. Closing time was guessed.' ],
+"Open end" for "17:00 bis Open End": [1m[32mPASSED[39m[22m
 With [1m[34mwarnings[39m[22m:
 	*17:00 bis Open End <--- ("bis open end" wird als "+" ("open end") interpretiert. Example: "12:00+".)
-"Open end" for "17:00-open end": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2012-10-01 00:00', '2012-10-01 03:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2012-10-01 17:00', '2012-10-02 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-expected:
-[ '2012-10-01 00:00', '2012-10-01 03:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2012-10-01 17:00', '2012-10-02 00:00', true, 'Specified as open end. Closing time was guessed.' ],
+"Open end" for "17:00-open end": [1m[32mPASSED[39m[22m
 With [1m[34mwarnings[39m[22m:
 	*17:00-open end <--- ("-open end" wird als "+" ("open end") interpretiert. Example: "12:00+".)
-"Open end" for "17:00-openend": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2012-10-01 00:00', '2012-10-01 03:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2012-10-01 17:00', '2012-10-02 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-expected:
-[ '2012-10-01 00:00', '2012-10-01 03:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2012-10-01 17:00', '2012-10-02 00:00', true, 'Specified as open end. Closing time was guessed.' ],
+"Open end" for "17:00-openend": [1m[32mPASSED[39m[22m
 With [1m[34mwarnings[39m[22m:
 	*17:00-openend <--- ("-openend" wird als "+" ("open end") interpretiert. Example: "12:00+".)
-"Open end" for "17:00+; 15:00-16:00 off": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2012-10-01 00:00', '2012-10-01 03:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2012-10-01 17:00', '2012-10-02 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-expected:
-[ '2012-10-01 00:00', '2012-10-01 03:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2012-10-01 17:00', '2012-10-02 00:00', true, 'Specified as open end. Closing time was guessed.' ],
+"Open end" for "17:00+; 15:00-16:00 off": [1m[32mPASSED[39m[22m
 With [1m[34mwarnings[39m[22m:
 	*17:00+; 15:00-16:00 off <--- (Diese Regel überschreibt Teile der vorherigen Regel. Der Grund dafür ist, dass normale Regeln auf den ganzen Tag zutreffen und alle Definitionen von vorhergehenden Regeln für diesen Tag überschreiben. Du kannst diese Regel als additive Regel deklarieren indem du ein "," anstelle des üblichen ";" für diese Regel verwendest. Beachte das die Überschreibung auch gewünscht sein kann und in so einem Fall diese Warnung ignoriert werden kann.)
-"Open end" for "15:00-16:00 off; 17:00+": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2012-10-01 00:00', '2012-10-01 03:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2012-10-01 17:00', '2012-10-02 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-expected:
-[ '2012-10-01 00:00', '2012-10-01 03:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2012-10-01 17:00', '2012-10-02 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-"Open end, variable time" for "sunrise+": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2012-10-01 07:22', '2012-10-02 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-expected:
-[ '2012-10-01 07:22', '2012-10-02 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-"Open end, variable time" for "(sunrise+01:00)+": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2012-10-01 08:22', '2012-10-02 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-expected:
-[ '2012-10-01 08:22', '2012-10-02 00:00', true, 'Specified as open end. Closing time was guessed.' ],
+"Open end" for "15:00-16:00 off; 17:00+": [1m[32mPASSED[39m[22m
+"Open end, variable time" for "sunrise+": [1m[32mPASSED[39m[22m
+"Open end, variable time" for "(sunrise+01:00)+": [1m[32mPASSED[39m[22m
 "Open end" for "17:00+ off": [1m[32mPASSED[39m[22m
 "Open end" for "17:00+off": [1m[32mPASSED[39m[22m
 "Open end" for "17:00-19:00 off": [1m[32mPASSED[39m[22m
-"Open end" for "07:00+,12:00-16:00": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2012-10-01 07:00', '2012-10-01 12:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2012-10-01 12:00', '2012-10-01 16:00', false, undefined ],
-expected:
-[ '2012-10-01 07:00', '2012-10-01 12:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2012-10-01 12:00', '2012-10-01 16:00', false, undefined ],
-"Open end" for "07:00+,12:00-13:00,13:00-16:00": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2012-10-01 07:00', '2012-10-01 12:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2012-10-01 12:00', '2012-10-01 16:00', false, undefined ],
-expected:
-[ '2012-10-01 07:00', '2012-10-01 12:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2012-10-01 12:00', '2012-10-01 16:00', false, undefined ],
-"Open end" for "07:00+,12:00-16:00; 16:00-24:00 closed "needed because of open end"": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2012-10-01 07:00', '2012-10-01 12:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2012-10-01 12:00', '2012-10-01 16:00', false, undefined ],
-expected:
-[ '2012-10-01 07:00', '2012-10-01 12:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2012-10-01 12:00', '2012-10-01 16:00', false, undefined ],
-"Open end" for "05:00-06:00,06:45-07:00+,13:00-16:00": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2012-10-01 05:00', '2012-10-01 06:00', false, undefined ],
-[ '2012-10-01 06:45', '2012-10-01 07:00', false, undefined ],
-[ '2012-10-01 07:00', '2012-10-01 13:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2012-10-01 13:00', '2012-10-01 16:00', false, undefined ],
-expected:
-[ '2012-10-01 05:00', '2012-10-01 06:00', false, undefined ],
-[ '2012-10-01 06:45', '2012-10-01 07:00', false, undefined ],
-[ '2012-10-01 07:00', '2012-10-01 13:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2012-10-01 13:00', '2012-10-01 16:00', false, undefined ],
-"Open end" for "06:45-07:00+,05:00-06:00,13:00-16:00": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2012-10-01 05:00', '2012-10-01 06:00', false, undefined ],
-[ '2012-10-01 06:45', '2012-10-01 07:00', false, undefined ],
-[ '2012-10-01 07:00', '2012-10-01 13:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2012-10-01 13:00', '2012-10-01 16:00', false, undefined ],
-expected:
-[ '2012-10-01 05:00', '2012-10-01 06:00', false, undefined ],
-[ '2012-10-01 06:45', '2012-10-01 07:00', false, undefined ],
-[ '2012-10-01 07:00', '2012-10-01 13:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2012-10-01 13:00', '2012-10-01 16:00', false, undefined ],
-"Open end" for "06:45-07:00+,05:00-06:00,13:00-14:00,14:00-16:00": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2012-10-01 05:00', '2012-10-01 06:00', false, undefined ],
-[ '2012-10-01 06:45', '2012-10-01 07:00', false, undefined ],
-[ '2012-10-01 07:00', '2012-10-01 13:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2012-10-01 13:00', '2012-10-01 16:00', false, undefined ],
-expected:
-[ '2012-10-01 05:00', '2012-10-01 06:00', false, undefined ],
-[ '2012-10-01 06:45', '2012-10-01 07:00', false, undefined ],
-[ '2012-10-01 07:00', '2012-10-01 13:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2012-10-01 13:00', '2012-10-01 16:00', false, undefined ],
+"Open end" for "07:00+,12:00-16:00": [1m[32mPASSED[39m[22m
+"Open end" for "07:00+,12:00-13:00,13:00-16:00": [1m[32mPASSED[39m[22m
+"Open end" for "07:00+,12:00-16:00; 16:00-24:00 closed "needed because of open end"": [1m[32mPASSED[39m[22m
+"Open end" for "05:00-06:00,06:45-07:00+,13:00-16:00": [1m[32mPASSED[39m[22m
+"Open end" for "06:45-07:00+,05:00-06:00,13:00-16:00": [1m[32mPASSED[39m[22m
+"Open end" for "06:45-07:00+,05:00-06:00,13:00-14:00,14:00-16:00": [1m[32mPASSED[39m[22m
 "Open end" for "17:00+,13:00-02:00; 02:00-03:00 closed "needed because of open end"": [1m[32mPASSED[39m[22m
 With [1m[34mwarnings[39m[22m:
 	*17:00+,13:00-02:00; 02:00-03:00 closed "needed because of open end" <--- (Diese Regel überschreibt Teile der vorherigen Regel. Der Grund dafür ist, dass normale Regeln auf den ganzen Tag zutreffen und alle Definitionen von vorhergehenden Regeln für diesen Tag überschreiben. Du kannst diese Regel als additive Regel deklarieren indem du ein "," anstelle des üblichen ";" für diese Regel verwendest. Beachte das die Überschreibung auch gewünscht sein kann und in so einem Fall diese Warnung ignoriert werden kann.)
 "Open end" for "17:00+,13:00-02:00; 02:00-03:00 closed "needed because of open end"": [1m[32mPASSED[39m[22m
 With [1m[34mwarnings[39m[22m:
 	*17:00+,13:00-02:00; 02:00-03:00 closed "needed because of open end" <--- (Diese Regel überschreibt Teile der vorherigen Regel. Der Grund dafür ist, dass normale Regeln auf den ganzen Tag zutreffen und alle Definitionen von vorhergehenden Regeln für diesen Tag überschreiben. Du kannst diese Regel als additive Regel deklarieren indem du ein "," anstelle des üblichen ";" für diese Regel verwendest. Beachte das die Überschreibung auch gewünscht sein kann und in so einem Fall diese Warnung ignoriert werden kann.)
-"Open end" for "13:00-17:00+": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2012-10-01 00:00', '2012-10-01 03:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2012-10-01 13:00', '2012-10-01 17:00', false, undefined ],
-[ '2012-10-01 17:00', '2012-10-02 03:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-expected:
-[ '2012-10-01 00:00', '2012-10-01 03:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2012-10-01 13:00', '2012-10-01 17:00', false, undefined ],
-[ '2012-10-01 17:00', '2012-10-02 03:00', true, 'Specified as open end. Closing time was guessed.' ],
-"Open end" for "13:00-17:00,17:00+": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2012-10-01 00:00', '2012-10-01 03:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2012-10-01 13:00', '2012-10-01 17:00', false, undefined ],
-[ '2012-10-01 17:00', '2012-10-02 03:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-expected:
-[ '2012-10-01 00:00', '2012-10-01 03:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2012-10-01 13:00', '2012-10-01 17:00', false, undefined ],
-[ '2012-10-01 17:00', '2012-10-02 03:00', true, 'Specified as open end. Closing time was guessed.' ],
-"Open end" for "13:00-02:00,17:00+": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2012-10-01 00:00', '2012-10-01 03:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2012-10-01 13:00', '2012-10-01 17:00', false, undefined ],
-[ '2012-10-01 17:00', '2012-10-02 03:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-expected:
-[ '2012-10-01 00:00', '2012-10-01 03:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2012-10-01 13:00', '2012-10-01 17:00', false, undefined ],
-[ '2012-10-01 17:00', '2012-10-02 03:00', true, 'Specified as open end. Closing time was guessed.' ],
-"Open end" for "13:00-17:00 open, 17:00+": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2012-10-01 00:00', '2012-10-01 03:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2012-10-01 13:00', '2012-10-01 17:00', false, undefined ],
-[ '2012-10-01 17:00', '2012-10-02 03:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-expected:
-[ '2012-10-01 00:00', '2012-10-01 03:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2012-10-01 13:00', '2012-10-01 17:00', false, undefined ],
-[ '2012-10-01 17:00', '2012-10-02 03:00', true, 'Specified as open end. Closing time was guessed.' ],
-"Fixed time followed by open end" for "14:00-17:00+": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2012-10-01 00:00', '2012-10-01 03:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2012-10-01 14:00', '2012-10-01 17:00', false, undefined ],
-[ '2012-10-01 17:00', '2012-10-02 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-expected:
-[ '2012-10-01 00:00', '2012-10-01 03:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2012-10-01 14:00', '2012-10-01 17:00', false, undefined ],
-[ '2012-10-01 17:00', '2012-10-02 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-"Fixed time followed by open end, wrapping over midnight" for "Mo 22:00-04:00+": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2012-10-01 22:00', '2012-10-02 04:00', false, undefined ],
-[ '2012-10-02 04:00', '2012-10-02 12:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-expected:
-[ '2012-10-01 22:00', '2012-10-02 04:00', false, undefined ],
-[ '2012-10-02 04:00', '2012-10-02 12:00', true, 'Specified as open end. Closing time was guessed.' ],
-"Fixed time followed by open end, wrapping over midnight" for "Mo 22:00-28:00+": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2012-10-01 22:00', '2012-10-02 04:00', false, undefined ],
-[ '2012-10-02 04:00', '2012-10-02 12:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-expected:
-[ '2012-10-01 22:00', '2012-10-02 04:00', false, undefined ],
-[ '2012-10-02 04:00', '2012-10-02 12:00', true, 'Specified as open end. Closing time was guessed.' ],
-"variable time range followed by open end" for "14:00-sunset+": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2012-10-01 00:00', '2012-10-01 04:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2012-10-01 14:00', '2012-10-01 19:00', false, undefined ],
-[ '2012-10-01 19:00', '2012-10-02 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-expected:
-[ '2012-10-01 00:00', '2012-10-01 04:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2012-10-01 14:00', '2012-10-01 19:00', false, undefined ],
-[ '2012-10-01 19:00', '2012-10-02 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-"variable time range followed by open end" for "sunrise-14:00+": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2012-10-01 07:22', '2012-10-01 14:00', false, undefined ],
-[ '2012-10-01 14:00', '2012-10-02 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-expected:
-[ '2012-10-01 07:22', '2012-10-01 14:00', false, undefined ],
-[ '2012-10-01 14:00', '2012-10-02 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-"variable time range followed by open end" for "sunrise-14:00,14:00+": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2012-10-01 07:22', '2012-10-01 14:00', false, undefined ],
-[ '2012-10-01 14:00', '2012-10-02 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-expected:
-[ '2012-10-01 07:22', '2012-10-01 14:00', false, undefined ],
-[ '2012-10-01 14:00', '2012-10-02 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-"variable time range followed by open end" for "sunrise-14:00 open, 14:00+": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2012-10-01 07:22', '2012-10-01 14:00', false, undefined ],
-[ '2012-10-01 14:00', '2012-10-02 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-expected:
-[ '2012-10-01 07:22', '2012-10-01 14:00', false, undefined ],
-[ '2012-10-01 14:00', '2012-10-02 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-"variable time range followed by open end" for "sunrise-(sunset+01:00)+": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2012-10-06 00:00', '2012-10-06 05:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2012-10-06 07:29', '2012-10-06 19:50', false, undefined ],
-[ '2012-10-06 19:50', '2012-10-07 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-expected:
-[ '2012-10-06 00:00', '2012-10-06 05:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2012-10-06 07:29', '2012-10-06 19:50', false, undefined ],
-[ '2012-10-06 19:50', '2012-10-07 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-"variable time range followed by open end" for "sunrise-(sunset+01:00)+; Su off": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2012-10-06 00:00', '2012-10-06 05:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2012-10-06 07:29', '2012-10-06 19:50', false, undefined ],
-[ '2012-10-06 19:50', '2012-10-07 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-expected:
-[ '2012-10-06 00:00', '2012-10-06 05:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2012-10-06 07:29', '2012-10-06 19:50', false, undefined ],
-[ '2012-10-06 19:50', '2012-10-07 00:00', true, 'Specified as open end. Closing time was guessed.' ],
+"Open end" for "13:00-17:00+": [1m[32mPASSED[39m[22m
+"Open end" for "13:00-17:00,17:00+": [1m[32mPASSED[39m[22m
+"Open end" for "13:00-02:00,17:00+": [1m[32mPASSED[39m[22m
+"Open end" for "13:00-17:00 open, 17:00+": [1m[32mPASSED[39m[22m
+"Fixed time followed by open end" for "14:00-17:00+": [1m[32mPASSED[39m[22m
+"Fixed time followed by open end, wrapping over midnight" for "Mo 22:00-04:00+": [1m[32mPASSED[39m[22m
+"Fixed time followed by open end, wrapping over midnight" for "Mo 22:00-28:00+": [1m[32mPASSED[39m[22m
+"variable time range followed by open end" for "14:00-sunset+": [1m[32mPASSED[39m[22m
+"variable time range followed by open end" for "sunrise-14:00+": [1m[32mPASSED[39m[22m
+"variable time range followed by open end" for "sunrise-14:00,14:00+": [1m[32mPASSED[39m[22m
+"variable time range followed by open end" for "sunrise-14:00 open, 14:00+": [1m[32mPASSED[39m[22m
+"variable time range followed by open end" for "sunrise-(sunset+01:00)+": [1m[32mPASSED[39m[22m
+"variable time range followed by open end" for "sunrise-(sunset+01:00)+; Su off": [1m[32mPASSED[39m[22m
 With [1m[34mwarnings[39m[22m:
 	*sunrise-(sunset+01:00)+; Su off <--- (Diese Regel überschreibt Teile der vorherigen Regel. Der Grund dafür ist, dass normale Regeln auf den ganzen Tag zutreffen und alle Definitionen von vorhergehenden Regeln für diesen Tag überschreiben. Du kannst diese Regel als additive Regel deklarieren indem du ein "," anstelle des üblichen ";" für diese Regel verwendest. Beachte das die Überschreibung auch gewünscht sein kann und in so einem Fall diese Warnung ignoriert werden kann.)
 "variable time range followed by open end, day wrap and different states" for "Fr 11:00-24:00+ open "geöffnet täglich von 11:00 Uhr bis tief in die Nacht"": [1m[32mPASSED[39m[22m
@@ -1638,62 +1459,10 @@ With [1m[34mwarnings[39m[22m:
 With [1m[34mwarnings[39m[22m:
 	*Aug,Dec 25-easter <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
 "Real world example: Was processed right (month range/monthday range with additional rule)" for "Nov-Mar Mo-Fr 11:30-17:00, Mo-Su 17:00-01:00": [1m[32mPASSED[39m[22m
-"Real world example: Was not processed right (month range/monthday range)" for "Mo-Sa 18:00+; SH off": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2014-09-14 00:00', '2014-09-14 04:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-09-15 18:00', '2014-09-16 04:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-09-16 18:00', '2014-09-17 04:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-09-17 18:00', '2014-09-18 04:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-09-18 18:00', '2014-09-19 04:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-09-19 18:00', '2014-09-20 04:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-09-20 18:00', '2014-09-21 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-expected:
-[ '2014-09-14 00:00', '2014-09-14 04:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-09-15 18:00', '2014-09-16 04:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-09-16 18:00', '2014-09-17 04:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-09-17 18:00', '2014-09-18 04:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-09-18 18:00', '2014-09-19 04:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-09-19 18:00', '2014-09-20 04:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-09-20 18:00', '2014-09-21 00:00', true, 'Specified as open end. Closing time was guessed.' ],
+"Real world example: Was not processed right (month range/monthday range)" for "Mo-Sa 18:00+; SH off": [1m[32mPASSED[39m[22m
 With [1m[34mwarnings[39m[22m:
 	*Mo-Sa 18:00+; SH off <--- (Diese Regel überschreibt Teile der vorherigen Regel. Der Grund dafür ist, dass normale Regeln auf den ganzen Tag zutreffen und alle Definitionen von vorhergehenden Regeln für diesen Tag überschreiben. Du kannst diese Regel als additive Regel deklarieren indem du ein "," anstelle des üblichen ";" für diese Regel verwendest. Beachte das die Überschreibung auch gewünscht sein kann und in so einem Fall diese Warnung ignoriert werden kann.)
-"Real world example: Was not processed right (month range/monthday range)" for "SH off; Mo-Sa 18:00+": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2014-09-01 18:00', '2014-09-02 04:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-09-02 18:00', '2014-09-03 04:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-09-03 18:00', '2014-09-04 04:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-09-04 18:00', '2014-09-05 04:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-09-05 18:00', '2014-09-06 04:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-09-06 18:00', '2014-09-07 04:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-09-08 18:00', '2014-09-09 04:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-09-09 18:00', '2014-09-10 04:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-09-10 18:00', '2014-09-11 04:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-09-11 18:00', '2014-09-12 04:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-09-12 18:00', '2014-09-13 04:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-09-13 18:00', '2014-09-14 04:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-09-15 18:00', '2014-09-16 04:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-09-16 18:00', '2014-09-17 04:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-09-17 18:00', '2014-09-18 04:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-09-18 18:00', '2014-09-19 04:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-09-19 18:00', '2014-09-20 04:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-09-20 18:00', '2014-09-21 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-expected:
-[ '2014-09-01 18:00', '2014-09-02 04:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-09-02 18:00', '2014-09-03 04:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-09-03 18:00', '2014-09-04 04:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-09-04 18:00', '2014-09-05 04:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-09-05 18:00', '2014-09-06 04:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-09-06 18:00', '2014-09-07 04:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-09-08 18:00', '2014-09-09 04:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-09-09 18:00', '2014-09-10 04:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-09-10 18:00', '2014-09-11 04:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-09-11 18:00', '2014-09-12 04:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-09-12 18:00', '2014-09-13 04:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-09-13 18:00', '2014-09-14 04:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-09-15 18:00', '2014-09-16 04:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-09-16 18:00', '2014-09-17 04:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-09-17 18:00', '2014-09-18 04:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-09-18 18:00', '2014-09-19 04:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-09-19 18:00', '2014-09-20 04:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-09-20 18:00', '2014-09-21 00:00', true, 'Specified as open end. Closing time was guessed.' ],
+"Real world example: Was not processed right (month range/monthday range)" for "SH off; Mo-Sa 18:00+": [1m[32mPASSED[39m[22m
 "Real world example: Was processed right (month range/monthday range)" for "Mo-Sa 17:15-01:00, PH,Su 17:15-24:00": [1m[32mPASSED[39m[22m
 "Real world example: Was not processed right (month range/monthday range)" for "Jun 15-Sep 15; Sep 16-Dec 31; Jan-Mar off; Dec 25-easter off": [1m[32mPASSED[39m[22m
 With [1m[34mwarnings[39m[22m:
@@ -1705,130 +1474,14 @@ With [1m[34mwarnings[39m[22m:
 "Real world example: Was not processed right" for "Mo, Tu, We, Th, Fr, Su 11:00-01:00; Sa 11:00-02:00": [1m[32mPASSED[39m[22m
 With [1m[34mwarnings[39m[22m:
 	*Mo, Tu, We, Th, Fr, Su 11:00-01:00; Sa 11:00-02:00 <--- (Diese Regel überschreibt Teile der vorherigen Regel. Der Grund dafür ist, dass normale Regeln auf den ganzen Tag zutreffen und alle Definitionen von vorhergehenden Regeln für diesen Tag überschreiben. Du kannst diese Regel als additive Regel deklarieren indem du ein "," anstelle des üblichen ";" für diese Regel verwendest. Beachte das die Überschreibung auch gewünscht sein kann und in so einem Fall diese Warnung ignoriert werden kann.)
-"Real world example: Was not processed right." for "Jan Su[-2]-Jan Su[-1]: Fr-Su 12:00+; Feb Su[-2]-Feb Su[-1]: Fr-Su 12:00+; Mar 01-Jul 31: Th-Su 12:00+; Aug 01-Nov 30,Dec: Tu-Su 12:00+; Dec 24-26,Dec 31: off": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2014-11-29 12:00', '2014-11-30 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-11-30 12:00', '2014-12-01 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-12-02 12:00', '2014-12-03 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-12-03 12:00', '2014-12-04 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-12-04 12:00', '2014-12-05 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-12-05 12:00', '2014-12-06 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-12-06 12:00', '2014-12-07 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-12-07 12:00', '2014-12-08 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-12-09 12:00', '2014-12-10 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-12-10 12:00', '2014-12-11 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-12-11 12:00', '2014-12-12 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-12-12 12:00', '2014-12-13 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-12-13 12:00', '2014-12-14 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-12-14 12:00', '2014-12-15 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-12-16 12:00', '2014-12-17 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-12-17 12:00', '2014-12-18 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-12-18 12:00', '2014-12-19 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-12-19 12:00', '2014-12-20 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-12-20 12:00', '2014-12-21 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-12-21 12:00', '2014-12-22 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-12-23 12:00', '2014-12-24 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-12-27 12:00', '2014-12-28 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-12-28 12:00', '2014-12-29 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-12-30 12:00', '2014-12-31 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-expected:
-[ '2014-11-29 12:00', '2014-11-30 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-11-30 12:00', '2014-12-01 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-12-02 12:00', '2014-12-03 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-12-03 12:00', '2014-12-04 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-12-04 12:00', '2014-12-05 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-12-05 12:00', '2014-12-06 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-12-06 12:00', '2014-12-07 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-12-07 12:00', '2014-12-08 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-12-09 12:00', '2014-12-10 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-12-10 12:00', '2014-12-11 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-12-11 12:00', '2014-12-12 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-12-12 12:00', '2014-12-13 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-12-13 12:00', '2014-12-14 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-12-14 12:00', '2014-12-15 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-12-16 12:00', '2014-12-17 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-12-17 12:00', '2014-12-18 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-12-18 12:00', '2014-12-19 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-12-19 12:00', '2014-12-20 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-12-20 12:00', '2014-12-21 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-12-21 12:00', '2014-12-22 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-12-23 12:00', '2014-12-24 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-12-27 12:00', '2014-12-28 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-12-28 12:00', '2014-12-29 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-12-30 12:00', '2014-12-31 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-"Real world example: Was not processed right." for "Jan Su[-2]-Jan Su[-1],Feb Su[-2]-Feb Su[-1]: Fr-Su 12:00+; Mar 01-Dec 31: Tu-Su 12:00+; Dec 24-26,Dec 31: off": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2014-11-29 12:00', '2014-11-30 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-11-30 12:00', '2014-12-01 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-12-02 12:00', '2014-12-03 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-12-03 12:00', '2014-12-04 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-12-04 12:00', '2014-12-05 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-12-05 12:00', '2014-12-06 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-12-06 12:00', '2014-12-07 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-12-07 12:00', '2014-12-08 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-12-09 12:00', '2014-12-10 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-12-10 12:00', '2014-12-11 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-12-11 12:00', '2014-12-12 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-12-12 12:00', '2014-12-13 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-12-13 12:00', '2014-12-14 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-12-14 12:00', '2014-12-15 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-12-16 12:00', '2014-12-17 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-12-17 12:00', '2014-12-18 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-12-18 12:00', '2014-12-19 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-12-19 12:00', '2014-12-20 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-12-20 12:00', '2014-12-21 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-12-21 12:00', '2014-12-22 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-12-23 12:00', '2014-12-24 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-12-27 12:00', '2014-12-28 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-12-28 12:00', '2014-12-29 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-12-30 12:00', '2014-12-31 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-expected:
-[ '2014-11-29 12:00', '2014-11-30 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-11-30 12:00', '2014-12-01 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-12-02 12:00', '2014-12-03 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-12-03 12:00', '2014-12-04 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-12-04 12:00', '2014-12-05 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-12-05 12:00', '2014-12-06 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-12-06 12:00', '2014-12-07 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-12-07 12:00', '2014-12-08 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-12-09 12:00', '2014-12-10 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-12-10 12:00', '2014-12-11 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-12-11 12:00', '2014-12-12 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-12-12 12:00', '2014-12-13 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-12-13 12:00', '2014-12-14 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-12-14 12:00', '2014-12-15 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-12-16 12:00', '2014-12-17 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-12-17 12:00', '2014-12-18 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-12-18 12:00', '2014-12-19 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-12-19 12:00', '2014-12-20 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-12-20 12:00', '2014-12-21 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-12-21 12:00', '2014-12-22 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-12-23 12:00', '2014-12-24 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-12-27 12:00', '2014-12-28 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-12-28 12:00', '2014-12-29 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-12-30 12:00', '2014-12-31 00:00', true, 'Specified as open end. Closing time was guessed.' ],
+"Real world example: Was not processed right." for "Jan Su[-2]-Jan Su[-1]: Fr-Su 12:00+; Feb Su[-2]-Feb Su[-1]: Fr-Su 12:00+; Mar 01-Jul 31: Th-Su 12:00+; Aug 01-Nov 30,Dec: Tu-Su 12:00+; Dec 24-26,Dec 31: off": [1m[32mPASSED[39m[22m
+"Real world example: Was not processed right." for "Jan Su[-2]-Jan Su[-1],Feb Su[-2]-Feb Su[-1]: Fr-Su 12:00+; Mar 01-Dec 31: Tu-Su 12:00+; Dec 24-26,Dec 31: off": [1m[32mPASSED[39m[22m
 "Simplifed real world example: Was not processed right." for "Nov 01-20,Dec": [1m[32mPASSED[39m[22m
 With [1m[34mwarnings[39m[22m:
 	*Nov 01-20,Dec <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
-"Real world example: Was processed right form library." for "Mo 19:00+; We 14:00+; Su 10:00+ || "Führung, Sonderführungen nach Vereinbarung."": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2014-01-06 00:00', '2014-01-06 19:00', true, 'Führung, Sonderführungen nach Vereinbarung.' ],
-[ '2014-01-06 19:00', '2014-01-07 05:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-01-07 05:00', '2014-01-08 14:00', true, 'Führung, Sonderführungen nach Vereinbarung.' ],
-[ '2014-01-08 14:00', '2014-01-09 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-01-09 00:00', '2014-01-12 10:00', true, 'Führung, Sonderführungen nach Vereinbarung.' ],
-[ '2014-01-12 10:00', '2014-01-13 00:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-expected:
-[ '2014-01-06 00:00', '2014-01-06 19:00', true, 'Führung, Sonderführungen nach Vereinbarung.' ],
-[ '2014-01-06 19:00', '2014-01-07 05:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-01-07 05:00', '2014-01-08 14:00', true, 'Führung, Sonderführungen nach Vereinbarung.' ],
-[ '2014-01-08 14:00', '2014-01-09 00:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-01-09 00:00', '2014-01-12 10:00', true, 'Führung, Sonderführungen nach Vereinbarung.' ],
-[ '2014-01-12 10:00', '2014-01-13 00:00', true, 'Specified as open end. Closing time was guessed.' ],
+"Real world example: Was processed right form library." for "Mo 19:00+; We 14:00+; Su 10:00+ || "Führung, Sonderführungen nach Vereinbarung."": [1m[32mPASSED[39m[22m
 "Real world example: Was processed right form library." for "Mo 19:00-05:00 || "Sonderführungen nach Vereinbarung."": [1m[32mPASSED[39m[22m
-"Real world example: Was processed right form library." for "Mo 19:00+ || "Sonderführungen nach Vereinbarung."": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2014-01-07 01:00', '2014-01-07 05:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2014-01-07 05:00', '2014-01-13 00:00', true, 'Sonderführungen nach Vereinbarung.' ],
-expected:
-[ '2014-01-07 01:00', '2014-01-07 05:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2014-01-07 05:00', '2014-01-13 00:00', true, 'Sonderführungen nach Vereinbarung.' ],
+"Real world example: Was processed right form library." for "Mo 19:00+ || "Sonderführungen nach Vereinbarung."": [1m[32mPASSED[39m[22m
 "Real world example: Was not processed right." for "Jun 15-Sep 15: Th-Su 16:00-19:00; Sep 16-Dec 31: Sa,Su 16:00-19:00; Jan,Feb,Mar off; Dec 25,easter off": [1m[32mPASSED[39m[22m
 "Based on real world example: Is processed right." for "Nov-Dec Sa,Su 16:00-19:00; Dec 22 off": [1m[32mPASSED[39m[22m
 "Based on real world example: Is processed right." for "May-Sep: 00:00-24:00, Apr-Oct: Sa-Su 08:00-15:00": [1m[32mPASSED[39m[22m
@@ -1851,78 +1504,18 @@ With [1m[34mwarnings[39m[22m:
 "Real world example: Problem with <additional_rule_separator> in holiday parser" for "PH; Aug-Sep 00:00-24:00": [1m[32mPASSED[39m[22m
 With [1m[34mwarnings[39m[22m:
 	*PH <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
-"Real world example: Problem with <additional_rule_separator> in holiday parser" for "We off; Mo,Tu,Th-Su,PH; Jun-Aug We 11:00-14:00,17:00+": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2015-05-25 00:00', '2015-05-26 00:00', false, 'Pfingstmontag' ],
-[ '2015-05-26 00:00', '2015-05-27 00:00', false, undefined ],
-[ '2015-05-28 00:00', '2015-06-03 00:00', false, undefined ],
-[ '2015-06-03 11:00', '2015-06-03 14:00', false, undefined ],
-[ '2015-06-03 17:00', '2015-06-04 03:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2015-06-04 03:00', '2015-06-05 00:00', false, 'Fronleichnam' ],
-[ '2015-06-05 00:00', '2015-06-10 00:00', false, undefined ],
-expected:
-[ '2015-05-25 00:00', '2015-05-26 00:00', false, 'Pfingstmontag' ],
-[ '2015-05-26 00:00', '2015-05-27 00:00', false, undefined ],
-[ '2015-05-28 00:00', '2015-06-03 00:00', false, undefined ],
-[ '2015-06-03 11:00', '2015-06-03 14:00', false, undefined ],
-[ '2015-06-03 17:00', '2015-06-04 03:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2015-06-04 03:00', '2015-06-05 00:00', false, 'Fronleichnam' ],
-[ '2015-06-05 00:00', '2015-06-10 00:00', false, undefined ],
+"Real world example: Problem with <additional_rule_separator> in holiday parser" for "We off; Mo,Tu,Th-Su,PH; Jun-Aug We 11:00-14:00,17:00+": [1m[32mPASSED[39m[22m
 With [1m[34mwarnings[39m[22m:
 	*We off; Mo,Tu,Th-Su,PH <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
-"Real world example: Problem with <additional_rule_separator> in holiday parser" for "We off; Mo,Tu,Th-Su,PH; Sommer We 11:00-14:00,17:00+": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2015-05-25 00:00', '2015-05-26 00:00', false, 'Pfingstmontag' ],
-[ '2015-05-26 00:00', '2015-05-27 00:00', false, undefined ],
-[ '2015-05-28 00:00', '2015-06-03 00:00', false, undefined ],
-[ '2015-06-03 11:00', '2015-06-03 14:00', false, undefined ],
-[ '2015-06-03 17:00', '2015-06-04 03:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2015-06-04 03:00', '2015-06-05 00:00', false, 'Fronleichnam' ],
-[ '2015-06-05 00:00', '2015-06-10 00:00', false, undefined ],
-expected:
-[ '2015-05-25 00:00', '2015-05-26 00:00', false, 'Pfingstmontag' ],
-[ '2015-05-26 00:00', '2015-05-27 00:00', false, undefined ],
-[ '2015-05-28 00:00', '2015-06-03 00:00', false, undefined ],
-[ '2015-06-03 11:00', '2015-06-03 14:00', false, undefined ],
-[ '2015-06-03 17:00', '2015-06-04 03:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2015-06-04 03:00', '2015-06-05 00:00', false, 'Fronleichnam' ],
-[ '2015-06-05 00:00', '2015-06-10 00:00', false, undefined ],
+"Real world example: Problem with <additional_rule_separator> in holiday parser" for "We off; Mo,Tu,Th-Su,PH; Sommer We 11:00-14:00,17:00+": [1m[32mPASSED[39m[22m
 With [1m[34mwarnings[39m[22m:
 	*We off; Mo,Tu,Th-Su,PH; Sommer <--- ("sommer" wird als "Jun-Aug" interpretiert.)
 	*We off; Mo,Tu,Th-Su,PH <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
-"Real world example: Problem with <additional_rule_separator> in holiday parser" for "We off; Mo,Tu,Th-Su,PH; sommer We 11:00-14:00,17:00+": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2015-05-25 00:00', '2015-05-26 00:00', false, 'Pfingstmontag' ],
-[ '2015-05-26 00:00', '2015-05-27 00:00', false, undefined ],
-[ '2015-05-28 00:00', '2015-06-03 00:00', false, undefined ],
-[ '2015-06-03 11:00', '2015-06-03 14:00', false, undefined ],
-[ '2015-06-03 17:00', '2015-06-04 03:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2015-06-04 03:00', '2015-06-05 00:00', false, 'Fronleichnam' ],
-[ '2015-06-05 00:00', '2015-06-10 00:00', false, undefined ],
-expected:
-[ '2015-05-25 00:00', '2015-05-26 00:00', false, 'Pfingstmontag' ],
-[ '2015-05-26 00:00', '2015-05-27 00:00', false, undefined ],
-[ '2015-05-28 00:00', '2015-06-03 00:00', false, undefined ],
-[ '2015-06-03 11:00', '2015-06-03 14:00', false, undefined ],
-[ '2015-06-03 17:00', '2015-06-04 03:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2015-06-04 03:00', '2015-06-05 00:00', false, 'Fronleichnam' ],
-[ '2015-06-05 00:00', '2015-06-10 00:00', false, undefined ],
+"Real world example: Problem with <additional_rule_separator> in holiday parser" for "We off; Mo,Tu,Th-Su,PH; sommer We 11:00-14:00,17:00+": [1m[32mPASSED[39m[22m
 With [1m[34mwarnings[39m[22m:
 	*We off; Mo,Tu,Th-Su,PH; sommer <--- ("sommer" wird als "Jun-Aug" interpretiert.)
 	*We off; Mo,Tu,Th-Su,PH <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
-"Real world example: Problem with <additional_rule_separator> in holiday parser" for "Mo,Tu,Th-Su,PH 00:00-24:00; Jun-Aug We 11:00-14:00,17:00+": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2015-05-25 00:00', '2015-05-26 00:00', false, 'Pfingstmontag' ],
-[ '2015-05-26 00:00', '2015-05-27 00:00', false, undefined ],
-[ '2015-05-28 00:00', '2015-06-03 00:00', false, undefined ],
-[ '2015-06-03 11:00', '2015-06-03 14:00', false, undefined ],
-[ '2015-06-03 17:00', '2015-06-04 03:00', true, 'Angegeben als "open end". Schließzeit wurde geraten.' ],
-[ '2015-06-04 03:00', '2015-06-05 00:00', false, 'Fronleichnam' ],
-[ '2015-06-05 00:00', '2015-06-10 00:00', false, undefined ],
-expected:
-[ '2015-05-25 00:00', '2015-05-26 00:00', false, 'Pfingstmontag' ],
-[ '2015-05-26 00:00', '2015-05-27 00:00', false, undefined ],
-[ '2015-05-28 00:00', '2015-06-03 00:00', false, undefined ],
-[ '2015-06-03 11:00', '2015-06-03 14:00', false, undefined ],
-[ '2015-06-03 17:00', '2015-06-04 03:00', true, 'Specified as open end. Closing time was guessed.' ],
-[ '2015-06-04 03:00', '2015-06-05 00:00', false, 'Fronleichnam' ],
-[ '2015-06-05 00:00', '2015-06-10 00:00', false, undefined ],
+"Real world example: Problem with <additional_rule_separator> in holiday parser" for "Mo,Tu,Th-Su,PH 00:00-24:00; Jun-Aug We 11:00-14:00,17:00+": [1m[32mPASSED[39m[22m
 "Real world example: Problem with daylight saving?" for "Mo-Su,PH 15:00-03:00; easter -2 days 15:00-24:00": [1m[32mPASSED[39m[22m
 With [1m[34mwarnings[39m[22m:
 	*Mo-Su,PH 15:00-03:00; easter -2 days 15:00-24:00 <--- (Diese Regel überschreibt Teile der vorherigen Regel. Der Grund dafür ist, dass normale Regeln auf den ganzen Tag zutreffen und alle Definitionen von vorhergehenden Regeln für diesen Tag überschreiben. Du kannst diese Regel als additive Regel deklarieren indem du ein "," anstelle des üblichen ";" für diese Regel verwendest. Beachte das die Überschreibung auch gewünscht sein kann und in so einem Fall diese Warnung ignoriert werden kann.)
@@ -3159,7 +2752,7 @@ Der optional_conf_parm["tag_key"] fehlt, ist aber notwendig wegen optional_conf_
 "Test isEqualTo function" for "Mo 10:00-20:00; We-Fr 10:00-20:01": [1m[32mPASSED[39m[22m
 "Test isEqualTo function" for "Mo 10:00-20:00; We-Fr 10:00-19:59": [1m[32mPASSED[39m[22m
 "Test isEqualTo function" for "closed; Sa unknown "comment"": [1m[32mPASSED[39m[22m
-891/946 tests passed. 55 did not pass.
+932/946 tests passed. 14 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.en.log
+++ b/test/test.en.log
@@ -279,7 +279,7 @@ With [1m[34mwarnings[39m[22m:
 "Time ranges spanning midnight with date overwriting (complex real world example)" for "Su-Tu 11:00-01:00, We-Th 11:00-03:00, Fr 11:00-06:00, Sa 11:00-07:00": [1m[32mPASSED[39m[22m
 "Time ranges spanning midnight with date overwriting (complex real world example)" for "Su-Tu 11:00-01:00, We-Th11:00-03:00, Fr 11:00-06:00, Sa 11:00-07:00": [1m[32mPASSED[39m[22m
 "Time ranges spanning midnight (maximum supported)" for "Tu 23:59-48:00": [1m[32mPASSED[39m[22m
-"Time ranges spanning midnight with open ened (maximum supported)" for "Tu 23:59-40:00+": [1m[32mPASSED[39m[22m
+"Time ranges spanning midnight with open end (maximum supported)" for "Tu 23:59-40:00+": [1m[32mPASSED[39m[22m
 "Open end" for "07:00+ open "visit there website to know if they did already close"": [1m[32mPASSED[39m[22m
 "Open end" for "07:00+ unknown "visit there website to know if they did already close"": [1m[32mPASSED[39m[22m
 "Open end" for "17:00+": [1m[32mPASSED[39m[22m

--- a/test/test.js
+++ b/test/test.js
@@ -86,6 +86,11 @@ timekeeper.travel(timekeeperTime); // Travel to that date.
 
 const test = new opening_hours_test();
 
+// Localized expected strings based on locale
+const EXPECTED_OPEN_END_MESSAGE = argv.locale === 'de' 
+    ? 'Angegeben als "open end". Schließzeit wurde geraten.'
+    : 'Specified as open end. Closing time was guessed.';
+
 // test.extensive_testing = true;
 // FIXME: Do it.
 
@@ -443,12 +448,12 @@ test.addTest('Time ranges spanning midnight (maximum supported)', [
         [ '2012-10-02 23:59', '2012-10-04 00:00' ],
     ], 1000 * 60 * (24 * 60 + 1), 0, true, {}, 'not last test');
 
-test.addTest('Time ranges spanning midnight with open ened (maximum supported)', [
+test.addTest('Time ranges spanning midnight with open end (maximum supported)', [
         'Tu 23:59-40:00+',
         // 'Tu 23:59-00:00 open, 24:00-40:00 open, 40:00+ open, 40:00+',
     ], '2012-10-01 0:00', '2012-10-08 0:00', [
         [ '2012-10-02 23:59', '2012-10-03 16:00' ],
-        [ '2012-10-03 16:00', '2012-10-04 00:00', true,  'Specified as open end. Closing time was guessed.' ],
+        [ '2012-10-03 16:00', '2012-10-04 00:00', true,  EXPECTED_OPEN_END_MESSAGE ],
     ], 1000 * 60 * (16 * 60 + 1), 1000 * 60 * 60 * 8, true, {}, 'not only test');
 // }}}
 
@@ -474,20 +479,20 @@ test.addTest('Open end', [
         '17:00+; 15:00-16:00 off',
         '15:00-16:00 off; 17:00+',
     ], '2012-10-01 0:00', '2012-10-02 0:00', [
-        [ '2012-10-01 00:00', '2012-10-01 03:00', true, 'Specified as open end. Closing time was guessed.' ],
-        [ '2012-10-01 17:00', '2012-10-02 00:00', true, 'Specified as open end. Closing time was guessed.' ],
+        [ '2012-10-01 00:00', '2012-10-01 03:00', true, EXPECTED_OPEN_END_MESSAGE ],
+        [ '2012-10-01 17:00', '2012-10-02 00:00', true, EXPECTED_OPEN_END_MESSAGE ],
     ], 0, 1000 * 60 * 60 * (3 + 24 - 17), true, nominatim_default, 'not last test');
 
 test.addTest('Open end, variable time', [
         'sunrise+',
     ], '2012-10-01 0:00', '2012-10-02 0:00', [
-        [ '2012-10-01 07:22', '2012-10-02 00:00', true,  'Specified as open end. Closing time was guessed.' ],
+        [ '2012-10-01 07:22', '2012-10-02 00:00', true,  EXPECTED_OPEN_END_MESSAGE ],
     ], 0, 1000 * 60 * (60 * 16 + 60 - 22), false, nominatim_default, 'not last test');
 
 test.addTest('Open end, variable time', [
         '(sunrise+01:00)+',
     ], '2012-10-01 0:00', '2012-10-02 0:00', [
-        [ '2012-10-01 08:22', '2012-10-02 00:00', true,  'Specified as open end. Closing time was guessed.' ],
+        [ '2012-10-01 08:22', '2012-10-02 00:00', true,  EXPECTED_OPEN_END_MESSAGE ],
     ], 0, 1000 * 60 * (60 * 15 + 60 - 22), false, nominatim_default, 'not last test');
 
 test.addTest('Open end', [
@@ -503,7 +508,7 @@ test.addTest('Open end', [
         '07:00+,12:00-13:00,13:00-16:00',
         '07:00+,12:00-16:00; 16:00-24:00 closed "needed because of open end"', // Now obsolete: https://github.com/opening-hours/opening_hours.js/issues/48
     ], '2012-10-01 0:00', '2012-10-02 5:00', [
-        [ '2012-10-01 07:00', '2012-10-01 12:00', true,  'Specified as open end. Closing time was guessed.' ],
+        [ '2012-10-01 07:00', '2012-10-01 12:00', true,  EXPECTED_OPEN_END_MESSAGE ],
         [ '2012-10-01 12:00', '2012-10-01 16:00' ],
     ], 1000 * 60 * 60 * 4, 1000 * 60 * 60 * 5, true, {}, 'not only test');
 
@@ -514,7 +519,7 @@ test.addTest('Open end', [
     ], '2012-10-01 0:00', '2012-10-02 5:00', [
         [ '2012-10-01 05:00', '2012-10-01 06:00' ],
         [ '2012-10-01 06:45', '2012-10-01 07:00' ],
-        [ '2012-10-01 07:00', '2012-10-01 13:00', true,  'Specified as open end. Closing time was guessed.' ],
+        [ '2012-10-01 07:00', '2012-10-01 13:00', true,  EXPECTED_OPEN_END_MESSAGE ],
         [ '2012-10-01 13:00', '2012-10-01 16:00' ],
     ], 1000 * 60 * 60 * (4 + 0.25), 1000 * 60 * 60 * 6, true, {}, 'not only test');
 
@@ -535,9 +540,9 @@ test.addTest('Open end', [
         '13:00-02:00,17:00+', // Do not use.
         '13:00-17:00 open, 17:00+'
     ], '2012-10-01 0:00', '2012-10-02 5:00', [
-        [ '2012-10-01 00:00', '2012-10-01 03:00', true,  'Specified as open end. Closing time was guessed.' ],
+        [ '2012-10-01 00:00', '2012-10-01 03:00', true,  EXPECTED_OPEN_END_MESSAGE ],
         [ '2012-10-01 13:00', '2012-10-01 17:00' ],
-        [ '2012-10-01 17:00', '2012-10-02 03:00', true,  'Specified as open end. Closing time was guessed.' ],
+        [ '2012-10-01 17:00', '2012-10-02 03:00', true,  EXPECTED_OPEN_END_MESSAGE ],
     ], 1000 * 60 * 60 * 4, 1000 * 60 * 60 * (3 + (3+4+3)), true, {}, 'not only test');
 
 test.addTest('Open end', [
@@ -556,9 +561,9 @@ test.addTest('Open end', [
 test.addTest('Fixed time followed by open end', [
         '14:00-17:00+',
     ], '2012-10-01 0:00', '2012-10-02 0:00', [
-        [ '2012-10-01 00:00', '2012-10-01 03:00', true,  'Specified as open end. Closing time was guessed.' ],
+        [ '2012-10-01 00:00', '2012-10-01 03:00', true,  EXPECTED_OPEN_END_MESSAGE ],
         [ '2012-10-01 14:00', '2012-10-01 17:00' ],
-        [ '2012-10-01 17:00', '2012-10-02 00:00', true,  'Specified as open end. Closing time was guessed.' ],
+        [ '2012-10-01 17:00', '2012-10-02 00:00', true,  EXPECTED_OPEN_END_MESSAGE ],
     ], 1000 * 60 * 60 * 3, 1000 * 60 * 60 * (3 + 7), true, {}, 'not last test');
 
 test.addTest('Fixed time followed by open end, wrapping over midnight', [
@@ -566,15 +571,15 @@ test.addTest('Fixed time followed by open end, wrapping over midnight', [
         'Mo 22:00-28:00+',
     ], '2012-10-01 0:00', '2012-10-03 0:00', [
         [ '2012-10-01 22:00', '2012-10-02 04:00' ],
-        [ '2012-10-02 04:00', '2012-10-02 12:00', true,  'Specified as open end. Closing time was guessed.' ],
+        [ '2012-10-02 04:00', '2012-10-02 12:00', true,  EXPECTED_OPEN_END_MESSAGE ],
     ], 1000 * 60 * 60 * 6, 1000 * 60 * 60 * 8, true, {}, 'not last test');
 
 test.addTest('variable time range followed by open end', [
         '14:00-sunset+',
     ], '2012-10-01 0:00', '2012-10-02 0:00', [
-        [ '2012-10-01 00:00', '2012-10-01 04:00', true,  'Specified as open end. Closing time was guessed.' ],
+        [ '2012-10-01 00:00', '2012-10-01 04:00', true,  EXPECTED_OPEN_END_MESSAGE ],
         [ '2012-10-01 14:00', '2012-10-01 19:00' ],
-        [ '2012-10-01 19:00', '2012-10-02 00:00', true,  'Specified as open end. Closing time was guessed.' ],
+        [ '2012-10-01 19:00', '2012-10-02 00:00', true,  EXPECTED_OPEN_END_MESSAGE ],
     ], 1000 * 60 * 60 * 5, 1000 * 60 * 60 * (4 + 5), false, nominatim_default, 'not last test');
 
 test.addTest('variable time range followed by open end', [
@@ -583,16 +588,16 @@ test.addTest('variable time range followed by open end', [
         'sunrise-14:00 open, 14:00+',
     ], '2012-10-01 0:00', '2012-10-02 5:00', [
         [ '2012-10-01 07:22', '2012-10-01 14:00' ],
-        [ '2012-10-01 14:00', '2012-10-02 00:00', true,  'Specified as open end. Closing time was guessed.' ],
+        [ '2012-10-01 14:00', '2012-10-02 00:00', true,  EXPECTED_OPEN_END_MESSAGE ],
     ], 1000 * 60 * (38 + 60 * 6), 1000 * 60 * 60 * 10, false, nominatim_default, 'not only test');
 
 test.addTest('variable time range followed by open end', [
         'sunrise-(sunset+01:00)+',
         'sunrise-(sunset+01:00)+; Su off',
     ], '2012-10-06 0:00', '2012-10-07 0:00', [
-        [ '2012-10-06 00:00', '2012-10-06 05:00', true,  'Specified as open end. Closing time was guessed.' ],
+        [ '2012-10-06 00:00', '2012-10-06 05:00', true,  EXPECTED_OPEN_END_MESSAGE ],
         [ '2012-10-06 07:29', '2012-10-06 19:50' ],
-        [ '2012-10-06 19:50', '2012-10-07 00:00', true,  'Specified as open end. Closing time was guessed.' ],
+        [ '2012-10-06 19:50', '2012-10-07 00:00', true,  EXPECTED_OPEN_END_MESSAGE ],
     ], 1000 * 60 * (31 + (19 - 8) * 60 + 50), 1000 * 60 * (60 * 5 + 60 * 4 + 10), false, nominatim_default, 'not last test');
 
 test.addTest('variable time range followed by open end, day wrap and different states', [
@@ -3833,13 +3838,13 @@ test.addTest('Real world example: Was processed right (month range/monthday rang
 test.addTest('Real world example: Was not processed right (month range/monthday range)', [ // FIXME -> SH
           'Mo-Sa 18:00+; SH off',
     ], '2014-09-01 0:00', '2014-09-21 0:00', [
-        [ '2014-09-14 00:00', '2014-09-14 04:00', true,  'Specified as open end. Closing time was guessed.' ], // FIXME
-        [ '2014-09-15 18:00', '2014-09-16 04:00', true,  'Specified as open end. Closing time was guessed.' ],
-        [ '2014-09-16 18:00', '2014-09-17 04:00', true,  'Specified as open end. Closing time was guessed.' ],
-        [ '2014-09-17 18:00', '2014-09-18 04:00', true,  'Specified as open end. Closing time was guessed.' ],
-        [ '2014-09-18 18:00', '2014-09-19 04:00', true,  'Specified as open end. Closing time was guessed.' ],
-        [ '2014-09-19 18:00', '2014-09-20 04:00', true,  'Specified as open end. Closing time was guessed.' ],
-        [ '2014-09-20 18:00', '2014-09-21 00:00', true,  'Specified as open end. Closing time was guessed.' ],
+        [ '2014-09-14 00:00', '2014-09-14 04:00', true,  EXPECTED_OPEN_END_MESSAGE ], // FIXME
+        [ '2014-09-15 18:00', '2014-09-16 04:00', true,  EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-09-16 18:00', '2014-09-17 04:00', true,  EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-09-17 18:00', '2014-09-18 04:00', true,  EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-09-18 18:00', '2014-09-19 04:00', true,  EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-09-19 18:00', '2014-09-20 04:00', true,  EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-09-20 18:00', '2014-09-21 00:00', true,  EXPECTED_OPEN_END_MESSAGE ],
     ], 0, 1000 * 60 * 60 * (4 + (6 + 4) * 5 + 6), false, nominatim_default, 'not only test');
 
 test.addTest('Real world example: Was not processed right (month range/monthday range)', [
@@ -3849,24 +3854,24 @@ test.addTest('Real world example: Was not processed right (month range/monthday 
         // 'PH off; Mo-Sa 18:00-19:00',
         // 'Sep 01-14 "Sommerferien"; Mo-Sa 18:00+',
     ], '2014-09-01 0:00', '2014-09-21 0:00', [
-        [ '2014-09-01 18:00', '2014-09-02 04:00', true, 'Specified as open end. Closing time was guessed.' ],
-        [ '2014-09-02 18:00', '2014-09-03 04:00', true, 'Specified as open end. Closing time was guessed.' ],
-        [ '2014-09-03 18:00', '2014-09-04 04:00', true, 'Specified as open end. Closing time was guessed.' ],
-        [ '2014-09-04 18:00', '2014-09-05 04:00', true, 'Specified as open end. Closing time was guessed.' ],
-        [ '2014-09-05 18:00', '2014-09-06 04:00', true, 'Specified as open end. Closing time was guessed.' ],
-        [ '2014-09-06 18:00', '2014-09-07 04:00', true, 'Specified as open end. Closing time was guessed.' ],
-        [ '2014-09-08 18:00', '2014-09-09 04:00', true, 'Specified as open end. Closing time was guessed.' ],
-        [ '2014-09-09 18:00', '2014-09-10 04:00', true, 'Specified as open end. Closing time was guessed.' ],
-        [ '2014-09-10 18:00', '2014-09-11 04:00', true, 'Specified as open end. Closing time was guessed.' ],
-        [ '2014-09-11 18:00', '2014-09-12 04:00', true, 'Specified as open end. Closing time was guessed.' ],
-        [ '2014-09-12 18:00', '2014-09-13 04:00', true, 'Specified as open end. Closing time was guessed.' ],
-        [ '2014-09-13 18:00', '2014-09-14 04:00', true, 'Specified as open end. Closing time was guessed.' ],
-        [ '2014-09-15 18:00', '2014-09-16 04:00', true, 'Specified as open end. Closing time was guessed.' ],
-        [ '2014-09-16 18:00', '2014-09-17 04:00', true, 'Specified as open end. Closing time was guessed.' ],
-        [ '2014-09-17 18:00', '2014-09-18 04:00', true, 'Specified as open end. Closing time was guessed.' ],
-        [ '2014-09-18 18:00', '2014-09-19 04:00', true, 'Specified as open end. Closing time was guessed.' ],
-        [ '2014-09-19 18:00', '2014-09-20 04:00', true, 'Specified as open end. Closing time was guessed.' ],
-        [ '2014-09-20 18:00', '2014-09-21 00:00', true, 'Specified as open end. Closing time was guessed.' ],
+        [ '2014-09-01 18:00', '2014-09-02 04:00', true, EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-09-02 18:00', '2014-09-03 04:00', true, EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-09-03 18:00', '2014-09-04 04:00', true, EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-09-04 18:00', '2014-09-05 04:00', true, EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-09-05 18:00', '2014-09-06 04:00', true, EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-09-06 18:00', '2014-09-07 04:00', true, EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-09-08 18:00', '2014-09-09 04:00', true, EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-09-09 18:00', '2014-09-10 04:00', true, EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-09-10 18:00', '2014-09-11 04:00', true, EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-09-11 18:00', '2014-09-12 04:00', true, EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-09-12 18:00', '2014-09-13 04:00', true, EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-09-13 18:00', '2014-09-14 04:00', true, EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-09-15 18:00', '2014-09-16 04:00', true, EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-09-16 18:00', '2014-09-17 04:00', true, EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-09-17 18:00', '2014-09-18 04:00', true, EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-09-18 18:00', '2014-09-19 04:00', true, EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-09-19 18:00', '2014-09-20 04:00', true, EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-09-20 18:00', '2014-09-21 00:00', true, EXPECTED_OPEN_END_MESSAGE ],
     ], 0, 1000 * 60 * 60 * (17 * (6 + 4) + 6), false, nominatim_default, 'not only test');
 /* }}} */
 
@@ -3920,30 +3925,30 @@ test.addTest('Real world example: Was not processed right.', [
         'Jan Su[-2]-Jan Su[-1],Feb Su[-2]-Feb Su[-1]: Fr-Su 12:00+; Mar 01-Dec 31: Tu-Su 12:00+; Dec 24-26,Dec 31: off'
         // Optimized value. Should mean the same.
     ], '2014-11-29 0:00', '2015-01-11 0:00', [
-        [ '2014-11-29 12:00', '2014-11-30 00:00', true,  'Specified as open end. Closing time was guessed.' ],
-        [ '2014-11-30 12:00', '2014-12-01 00:00', true,  'Specified as open end. Closing time was guessed.' ],
-        [ '2014-12-02 12:00', '2014-12-03 00:00', true,  'Specified as open end. Closing time was guessed.' ],
-        [ '2014-12-03 12:00', '2014-12-04 00:00', true,  'Specified as open end. Closing time was guessed.' ],
-        [ '2014-12-04 12:00', '2014-12-05 00:00', true,  'Specified as open end. Closing time was guessed.' ],
-        [ '2014-12-05 12:00', '2014-12-06 00:00', true,  'Specified as open end. Closing time was guessed.' ],
-        [ '2014-12-06 12:00', '2014-12-07 00:00', true,  'Specified as open end. Closing time was guessed.' ],
-        [ '2014-12-07 12:00', '2014-12-08 00:00', true,  'Specified as open end. Closing time was guessed.' ],
-        [ '2014-12-09 12:00', '2014-12-10 00:00', true,  'Specified as open end. Closing time was guessed.' ],
-        [ '2014-12-10 12:00', '2014-12-11 00:00', true,  'Specified as open end. Closing time was guessed.' ],
-        [ '2014-12-11 12:00', '2014-12-12 00:00', true,  'Specified as open end. Closing time was guessed.' ],
-        [ '2014-12-12 12:00', '2014-12-13 00:00', true,  'Specified as open end. Closing time was guessed.' ],
-        [ '2014-12-13 12:00', '2014-12-14 00:00', true,  'Specified as open end. Closing time was guessed.' ],
-        [ '2014-12-14 12:00', '2014-12-15 00:00', true,  'Specified as open end. Closing time was guessed.' ],
-        [ '2014-12-16 12:00', '2014-12-17 00:00', true,  'Specified as open end. Closing time was guessed.' ],
-        [ '2014-12-17 12:00', '2014-12-18 00:00', true,  'Specified as open end. Closing time was guessed.' ],
-        [ '2014-12-18 12:00', '2014-12-19 00:00', true,  'Specified as open end. Closing time was guessed.' ],
-        [ '2014-12-19 12:00', '2014-12-20 00:00', true,  'Specified as open end. Closing time was guessed.' ],
-        [ '2014-12-20 12:00', '2014-12-21 00:00', true,  'Specified as open end. Closing time was guessed.' ],
-        [ '2014-12-21 12:00', '2014-12-22 00:00', true,  'Specified as open end. Closing time was guessed.' ],
-        [ '2014-12-23 12:00', '2014-12-24 00:00', true,  'Specified as open end. Closing time was guessed.' ],
-        [ '2014-12-27 12:00', '2014-12-28 00:00', true,  'Specified as open end. Closing time was guessed.' ],
-        [ '2014-12-28 12:00', '2014-12-29 00:00', true,  'Specified as open end. Closing time was guessed.' ],
-        [ '2014-12-30 12:00', '2014-12-31 00:00', true,  'Specified as open end. Closing time was guessed.' ],
+        [ '2014-11-29 12:00', '2014-11-30 00:00', true,  EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-11-30 12:00', '2014-12-01 00:00', true,  EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-12-02 12:00', '2014-12-03 00:00', true,  EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-12-03 12:00', '2014-12-04 00:00', true,  EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-12-04 12:00', '2014-12-05 00:00', true,  EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-12-05 12:00', '2014-12-06 00:00', true,  EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-12-06 12:00', '2014-12-07 00:00', true,  EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-12-07 12:00', '2014-12-08 00:00', true,  EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-12-09 12:00', '2014-12-10 00:00', true,  EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-12-10 12:00', '2014-12-11 00:00', true,  EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-12-11 12:00', '2014-12-12 00:00', true,  EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-12-12 12:00', '2014-12-13 00:00', true,  EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-12-13 12:00', '2014-12-14 00:00', true,  EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-12-14 12:00', '2014-12-15 00:00', true,  EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-12-16 12:00', '2014-12-17 00:00', true,  EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-12-17 12:00', '2014-12-18 00:00', true,  EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-12-18 12:00', '2014-12-19 00:00', true,  EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-12-19 12:00', '2014-12-20 00:00', true,  EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-12-20 12:00', '2014-12-21 00:00', true,  EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-12-21 12:00', '2014-12-22 00:00', true,  EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-12-23 12:00', '2014-12-24 00:00', true,  EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-12-27 12:00', '2014-12-28 00:00', true,  EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-12-28 12:00', '2014-12-29 00:00', true,  EXPECTED_OPEN_END_MESSAGE ],
+        [ '2014-12-30 12:00', '2014-12-31 00:00', true,  EXPECTED_OPEN_END_MESSAGE ],
     ], 0, 1000 * 60 * 60 * 12 * 24, false, {}, 'not last test');
 
 test.addTest('Simplifed real world example: Was not processed right.', [
@@ -3966,11 +3971,11 @@ test.addTest('Real world example: Was processed right form library.', [
         'Mo 19:00+; We 14:00+; Su 10:00+ || "Führung, Sonderführungen nach Vereinbarung."',
     ], '2014-01-06 0:00', '2014-01-13 0:00', [
         [ '2014-01-06 00:00', '2014-01-06 19:00', true, 'Führung, Sonderführungen nach Vereinbarung.' ],
-        [ '2014-01-06 19:00', '2014-01-07 05:00', true, 'Specified as open end. Closing time was guessed.' ],
+        [ '2014-01-06 19:00', '2014-01-07 05:00', true, EXPECTED_OPEN_END_MESSAGE ],
         [ '2014-01-07 05:00', '2014-01-08 14:00', true, 'Führung, Sonderführungen nach Vereinbarung.' ],
-        [ '2014-01-08 14:00', '2014-01-09 00:00', true, 'Specified as open end. Closing time was guessed.' ],
+        [ '2014-01-08 14:00', '2014-01-09 00:00', true, EXPECTED_OPEN_END_MESSAGE ],
         [ '2014-01-09 00:00', '2014-01-12 10:00', true, 'Führung, Sonderführungen nach Vereinbarung.' ],
-        [ '2014-01-12 10:00', '2014-01-13 00:00', true, 'Specified as open end. Closing time was guessed.' ],
+        [ '2014-01-12 10:00', '2014-01-13 00:00', true, EXPECTED_OPEN_END_MESSAGE ],
     ], 0, 1000 * 60 * 60 * 24 * 7, true, {}, 'not last test');
 
 test.addTest('Real world example: Was processed right form library.', [
@@ -3984,7 +3989,7 @@ test.addTest('Real world example: Was processed right form library.', [
 test.addTest('Real world example: Was processed right form library.', [
         'Mo 19:00+ || "Sonderführungen nach Vereinbarung."',
     ], '2014-01-07 1:00', '2014-01-13 0:00', [
-        [ '2014-01-07 01:00', '2014-01-07 05:00', true, 'Specified as open end. Closing time was guessed.' ],
+        [ '2014-01-07 01:00', '2014-01-07 05:00', true, EXPECTED_OPEN_END_MESSAGE ],
         [ '2014-01-07 05:00', '2014-01-13 00:00', true, 'Sonderführungen nach Vereinbarung.' ],
     ], 0, 1000 * 60 * 60 * (24 * 6 - 1), true, {}, 'not last test');
 // }}}
@@ -4345,7 +4350,7 @@ test.addTest('Real world example: Problem with <additional_rule_separator> in ho
         [ '2015-05-26 00:00', '2015-05-27 00:00' ], // Tu: 1
         [ '2015-05-28 00:00', '2015-06-03 00:00' ], // Th till Tu: 6
         [ '2015-06-03 11:00', '2015-06-03 14:00' ], // We
-        [ '2015-06-03 17:00', '2015-06-04 03:00', true, 'Specified as open end. Closing time was guessed.' ],
+        [ '2015-06-03 17:00', '2015-06-04 03:00', true, EXPECTED_OPEN_END_MESSAGE ],
         [ '2015-06-04 03:00', '2015-06-05 00:00', false, 'Fronleichnam' ], // Th
         [ '2015-06-05 00:00', '2015-06-10 00:00' ], // Fr-Tu: 5
     ], 1000 * 60 * 60 * (24 * (1 + 1 + 6 + 5) + 3 + (24 - 3)), 1000 * 60 * 60 * (24 - 17 + 3), false, nominatim_default, 'not last test');


### PR DESCRIPTION
Replace hardcoded English expected strings with locale-dependent variable. This reduces failing (german) tests from 51 to 10.