### PR TITLE
fix: use full date comparison for constrained weekday matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,7 @@ work hours!
 ### Fixed
 
 - fix: add missing `country_code` to `xa.yaml` ([#499](https://github.com/opening-hours/opening_hours.js/pull/499))
+- fix: use full date comparison for constrained weekday matching ([#514](https://github.com/opening-hours/opening_hours.js/pull/514))
 - fix(test): localize expected test strings for German locale ([#512](https://github.com/opening-hours/opening_hours.js/pull/512))
 - fix(test): correct two `sunrise` test expectations to match SunCalc output ([#513](https://github.com/opening-hours/opening_hours.js/pull/513))
 

--- a/src/index.js
+++ b/src/index.js
@@ -2218,12 +2218,15 @@ export default function(value, nominatim_object, optional_conf_parm) {
                         }
 
                         // we hit the target day
-                        if (date.getDate() === target_day_with_added_days_this_month.getDate()) {
+                        const currentDateOnly = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+                        const targetDateOnly = new Date(target_day_with_added_days_this_month.getFullYear(), target_day_with_added_days_this_month.getMonth(), target_day_with_added_days_this_month.getDate());
+                        
+                        if (currentDateOnly.getTime() === targetDateOnly.getTime()) {
                             return [true, dateAtDayMinutes(date, minutes_in_day)];
                         }
 
                         // we're before target day
-                        if (date.getDate() < target_day_with_added_days_this_month.getDate()) {
+                        if (currentDateOnly.getTime() < targetDateOnly.getTime()) {
                             return [false, target_day_with_added_days_this_month];
                         }
 

--- a/test/test.de.log
+++ b/test/test.de.log
@@ -978,34 +978,8 @@ With [1m[34mwarnings[39m[22m:
 "Constrained weekdays" for "We[4],We[5] 10:00-12:00": [1m[32mPASSED[39m[22m
 "Constrained weekdays" for "We[4] 10:00-12:00; We[-1] 10:00-12:00": [1m[32mPASSED[39m[22m
 "Constrained weekdays" for "We[-1,-2] 10:00-12:00": [1m[32mPASSED[39m[22m
-"Calculations based on constrained weekdays" for "Sa[-1] +3 days 10:00-12:00": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2013-09-01 10:00', '2013-09-01 12:00', false, undefined ],
-[ '2013-10-01 10:00', '2013-10-01 12:00', false, undefined ],
-[ '2013-10-29 10:00', '2013-10-29 12:00', false, undefined ],
-[ '2013-12-03 10:00', '2013-12-03 12:00', false, undefined ],
-[ '2013-12-31 10:00', '2013-12-31 12:00', false, undefined ],
-[ '2014-01-28 10:00', '2014-01-28 12:00', false, undefined ],
-expected:
-[ '2013-09-03 10:00', '2013-09-03 12:00', false, undefined ],
-[ '2013-10-01 10:00', '2013-10-01 12:00', false, undefined ],
-[ '2013-10-29 10:00', '2013-10-29 12:00', false, undefined ],
-[ '2013-12-03 10:00', '2013-12-03 12:00', false, undefined ],
-[ '2013-12-31 10:00', '2013-12-31 12:00', false, undefined ],
-[ '2014-01-28 10:00', '2014-01-28 12:00', false, undefined ],
-"Calculations based on constrained weekdays" for "Sa[-1] +3 day 10:00-12:00": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2013-09-01 10:00', '2013-09-01 12:00', false, undefined ],
-[ '2013-10-01 10:00', '2013-10-01 12:00', false, undefined ],
-[ '2013-10-29 10:00', '2013-10-29 12:00', false, undefined ],
-[ '2013-12-03 10:00', '2013-12-03 12:00', false, undefined ],
-[ '2013-12-31 10:00', '2013-12-31 12:00', false, undefined ],
-[ '2014-01-28 10:00', '2014-01-28 12:00', false, undefined ],
-expected:
-[ '2013-09-03 10:00', '2013-09-03 12:00', false, undefined ],
-[ '2013-10-01 10:00', '2013-10-01 12:00', false, undefined ],
-[ '2013-10-29 10:00', '2013-10-29 12:00', false, undefined ],
-[ '2013-12-03 10:00', '2013-12-03 12:00', false, undefined ],
-[ '2013-12-31 10:00', '2013-12-31 12:00', false, undefined ],
-[ '2014-01-28 10:00', '2014-01-28 12:00', false, undefined ],
+"Calculations based on constrained weekdays" for "Sa[-1] +3 days 10:00-12:00": [1m[32mPASSED[39m[22m
+"Calculations based on constrained weekdays" for "Sa[-1] +3 day 10:00-12:00": [1m[32mPASSED[39m[22m
 "Calculations based on constrained weekdays: last weekend in month" for "Sa[-1],Sa[-1] +1 day 10:00-12:00": [1m[32mPASSED[39m[22m
 "Calculations based on constrained weekdays: last weekend in month" for "Sa[-1],Sa[-1] +1 day": [1m[32mPASSED[39m[22m
 With [1m[34mwarnings[39m[22m:
@@ -2731,7 +2705,7 @@ Der optional_conf_parm["tag_key"] fehlt, ist aber notwendig wegen optional_conf_
 "Test isEqualTo function" for "Mo 10:00-20:00; We-Fr 10:00-20:01": [1m[32mPASSED[39m[22m
 "Test isEqualTo function" for "Mo 10:00-20:00; We-Fr 10:00-19:59": [1m[32mPASSED[39m[22m
 "Test isEqualTo function" for "closed; Sa unknown "comment"": [1m[32mPASSED[39m[22m
-934/946 tests passed. 12 did not pass.
+936/946 tests passed. 10 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.en.log
+++ b/test/test.en.log
@@ -978,34 +978,8 @@ With [1m[34mwarnings[39m[22m:
 "Constrained weekdays" for "We[4],We[5] 10:00-12:00": [1m[32mPASSED[39m[22m
 "Constrained weekdays" for "We[4] 10:00-12:00; We[-1] 10:00-12:00": [1m[32mPASSED[39m[22m
 "Constrained weekdays" for "We[-1,-2] 10:00-12:00": [1m[32mPASSED[39m[22m
-"Calculations based on constrained weekdays" for "Sa[-1] +3 days 10:00-12:00": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2013-09-01 10:00', '2013-09-01 12:00', false, undefined ],
-[ '2013-10-01 10:00', '2013-10-01 12:00', false, undefined ],
-[ '2013-10-29 10:00', '2013-10-29 12:00', false, undefined ],
-[ '2013-12-03 10:00', '2013-12-03 12:00', false, undefined ],
-[ '2013-12-31 10:00', '2013-12-31 12:00', false, undefined ],
-[ '2014-01-28 10:00', '2014-01-28 12:00', false, undefined ],
-expected:
-[ '2013-09-03 10:00', '2013-09-03 12:00', false, undefined ],
-[ '2013-10-01 10:00', '2013-10-01 12:00', false, undefined ],
-[ '2013-10-29 10:00', '2013-10-29 12:00', false, undefined ],
-[ '2013-12-03 10:00', '2013-12-03 12:00', false, undefined ],
-[ '2013-12-31 10:00', '2013-12-31 12:00', false, undefined ],
-[ '2014-01-28 10:00', '2014-01-28 12:00', false, undefined ],
-"Calculations based on constrained weekdays" for "Sa[-1] +3 day 10:00-12:00": [1m[31mFAILED[39m[22m, bad intervals: 
-[ '2013-09-01 10:00', '2013-09-01 12:00', false, undefined ],
-[ '2013-10-01 10:00', '2013-10-01 12:00', false, undefined ],
-[ '2013-10-29 10:00', '2013-10-29 12:00', false, undefined ],
-[ '2013-12-03 10:00', '2013-12-03 12:00', false, undefined ],
-[ '2013-12-31 10:00', '2013-12-31 12:00', false, undefined ],
-[ '2014-01-28 10:00', '2014-01-28 12:00', false, undefined ],
-expected:
-[ '2013-09-03 10:00', '2013-09-03 12:00', false, undefined ],
-[ '2013-10-01 10:00', '2013-10-01 12:00', false, undefined ],
-[ '2013-10-29 10:00', '2013-10-29 12:00', false, undefined ],
-[ '2013-12-03 10:00', '2013-12-03 12:00', false, undefined ],
-[ '2013-12-31 10:00', '2013-12-31 12:00', false, undefined ],
-[ '2014-01-28 10:00', '2014-01-28 12:00', false, undefined ],
+"Calculations based on constrained weekdays" for "Sa[-1] +3 days 10:00-12:00": [1m[32mPASSED[39m[22m
+"Calculations based on constrained weekdays" for "Sa[-1] +3 day 10:00-12:00": [1m[32mPASSED[39m[22m
 "Calculations based on constrained weekdays: last weekend in month" for "Sa[-1],Sa[-1] +1 day 10:00-12:00": [1m[32mPASSED[39m[22m
 "Calculations based on constrained weekdays: last weekend in month" for "Sa[-1],Sa[-1] +1 day": [1m[32mPASSED[39m[22m
 With [1m[34mwarnings[39m[22m:
@@ -2724,7 +2698,7 @@ The optional_conf_parm["tag_key"] is missing, required by optional_conf_parm["ma
 "Test isEqualTo function" for "Mo 10:00-20:00; We-Fr 10:00-20:01": [1m[32mPASSED[39m[22m
 "Test isEqualTo function" for "Mo 10:00-20:00; We-Fr 10:00-19:59": [1m[32mPASSED[39m[22m
 "Test isEqualTo function" for "closed; Sa unknown "comment"": [1m[32mPASSED[39m[22m
-927/939 tests passed. 12 did not pass.
+929/939 tests passed. 10 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet


### PR DESCRIPTION
Replace day-of-month comparison with full date comparison in `parseWeekdayRange` function for constrained weekdays with `add_days`.

The previous implementation only compared the day number (`getDate()`) instead of the complete date, causing incorrect matches when the target date falls in a different month than the current date.

For example, "Sa[-1] +3 days" in August 2013:
- Last Saturday of August: August 31
- August 31 + 3 days: September 3
- Previously matched September 1 (day 1) instead of September 3

The corresponding test, which previously failed, now works with the fix.