### PR TITLE
refactor: replace deprecated `optimist` with `yargs` for command line argument parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ work hours!
 - refactor: fix existing ESLint issues, add markdown linting, and enable new rules ([#506](https://github.com/opening-hours/opening_hours.js/pull/506))
 - refactor: optimize simple_index.html ([#502](https://github.com/opening-hours/opening_hours.js/pull/502))
 - refactor: overload getStateString for better return type ([#504](https://github.com/opening-hours/opening_hours.js/pull/504))
+- refactor: replace deprecated `optimist` with `yargs` for command line argument parsing ([#515](https://github.com/opening-hours/opening_hours.js/pull/515))
 
 - Public holiday definitions updated:
   - France ([#470](https://github.com/opening-hours/opening_hours.js/pull/470))

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
         "line-reader": "^0.4.0",
         "moment": "^2.30.1",
         "npm-check-updates": "^18.0.1",
-        "optimist": "^0.6.1",
         "package-json-validator": "^0.18.0",
         "pinst": "^3.0.0",
         "rollup": "^4.44.1",
@@ -47,7 +46,8 @@
         "timekeeper": "^2.3.1",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.35.0",
-        "yaml": "^2.8.0"
+        "yaml": "^2.8.0",
+        "yargs": "^17.7.2"
       },
       "engines": {
         "node": ">=12"
@@ -8685,34 +8685,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha512-snN4O4TkigujZphWLN0E//nQmm7790RYaE53DdL7ZYwee2D8DDo9/EyYiKUfN3rneWUjhJnueija3G9I2i0h3g==",
-      "dev": true,
-      "license": "MIT/X11",
-      "dependencies": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      }
-    },
-    "node_modules/optimist/node_modules/minimist": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-      "integrity": "sha512-iotkTvxc+TwOm5Ieim8VnSNvCDjCK9S8G3scJ50ZthspSxa7jx50jkhYduuAtAjvfDUwSgOwf8+If99AlOEhyw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/optimist/node_modules/wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/optionator": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "line-reader": "^0.4.0",
     "moment": "^2.30.1",
     "npm-check-updates": "^18.0.1",
-    "optimist": "^0.6.1",
     "package-json-validator": "^0.18.0",
     "pinst": "^3.0.0",
     "rollup": "^4.44.1",
@@ -91,7 +90,8 @@
     "timekeeper": "^2.3.1",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.35.0",
-    "yaml": "^2.8.0"
+    "yaml": "^2.8.0",
+    "yargs": "^17.7.2"
   },
   "engines": {
     "node": ">=12"

--- a/scripts/PH_SH_exporter.js
+++ b/scripts/PH_SH_exporter.js
@@ -27,14 +27,14 @@ const YAML          = require('yaml');
 /* }}} */
 
 /* Parameter handling {{{ */
-const optimist = require('optimist')
+const yargs = require('yargs')
     .usage('Usage: $0 export_list.conf')
     .describe('h', 'Display the usage')
     .describe('v', 'Verbose output')
     .describe('f', 'From year (including)')
-    .demand('f')
+    .demandOption('f')
     .describe('t', 'Until year (including)')
-    .demand('t')
+    .demandOption('t')
     .describe('p', 'Export public holidays. Can not be used together with --school-holidays.')
     // .default('p', true)
     .describe('s', 'Export school holidays. Can not be used together with --public-holidays.')
@@ -55,12 +55,13 @@ const optimist = require('optimist')
     .alias('r', 'state')
     .alias('a', 'all-locations')
     .string(['c', 'r', ])
-    .alias('o', 'omit-date-hyphens');
+    .alias('o', 'omit-date-hyphens')
+    .help(false);
 
-const argv = optimist.argv;
+const argv = yargs.parse();
 
 if (argv.help || argv._.length === 0) {
-    optimist.showHelp();
+    yargs.showHelp();
     process.exit(0);
 }
 

--- a/scripts/gen_taginfo_json.js
+++ b/scripts/gen_taginfo_json.js
@@ -24,20 +24,21 @@ const fs = require('node:fs');
 /* }}} */
 
 /* Parameter handling {{{ */
-const optimist = require('optimist')
+const yargs = require('yargs')
     .usage('Usage: $0 -')
     .describe('h', 'Display the usage')
     .describe('k', 'File containing the list of supported keys')
-    .demand('k')
+    .demandOption('k')
     .describe('i', 'Template taginfo.json which is used to merge with the list of keys')
     .alias('h', 'help')
     .alias('k', 'key-file')
-    .alias('i', 'template-file');
+    .alias('i', 'template-file')
+    .help(false);
 
-const argv = optimist.argv;
+const argv = yargs.parse();
 
 if (argv.help) {
-    optimist.showHelp();
+    yargs.showHelp();
     process.exit(0);
 }
 /* }}} */

--- a/scripts/interactive_testing.js
+++ b/scripts/interactive_testing.js
@@ -4,7 +4,7 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-only
 
-const optimist = require('optimist')
+const yargs = require('yargs')
     .usage('Usage: $0 [optional parameters] [server_listening_ports]')
     .describe('h', 'Display the usage')
     // .describe('v', 'Verbose output')
@@ -20,12 +20,13 @@ const optimist = require('optimist')
     .alias('V', 'value')
     .default('f', '../build/opening_hours.js')
     .default('l', 'en')
-    .default('L', 'en');
+    .default('L', 'en')
+    .help(false);
 
-const argv = optimist.argv;
+const argv = yargs.parse();
 
 if (argv.help) {
-    optimist.showHelp();
+    yargs.showHelp();
     process.exit(0);
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -36,7 +36,7 @@
 // preamble {{{
 
 /* Parameter handling {{{ */
-const optimist = require('optimist')
+const yargs = require('yargs')
     .usage('Usage: $0 [optional parameters]')
     .describe('h', 'Display the usage')
     // .describe('v', 'Verbose output')
@@ -47,12 +47,13 @@ const optimist = require('optimist')
     .alias('f', 'library-file')
     .alias('l', 'locale')
     .default('f', './opening_hours.js')
-    .default('l', 'en');
+    .default('l', 'en')
+    .help(false);
 
-const argv = optimist.argv;
+const argv = yargs.parse();
 
 if (argv.help) {
-    optimist.showHelp();
+    yargs.showHelp();
     process.exit(0);
 }
 /* }}} */


### PR DESCRIPTION
I could only use version 17 of yargs, as version 18 is ESM only. We'll take care of converting the scripts to ESM another time :slightly_smiling_face: