### PR TITLE
fix: update script paths, use python for regex search execution and update syntax in `regex_search.py`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,7 @@ work hours!
 - fix: use full date comparison for constrained weekday matching ([#514](https://github.com/opening-hours/opening_hours.js/pull/514))
 - fix(test): localize expected test strings for German locale ([#512](https://github.com/opening-hours/opening_hours.js/pull/512))
 - fix(test): correct two `sunrise` test expectations to match SunCalc output ([#513](https://github.com/opening-hours/opening_hours.js/pull/513))
+- fix: update script paths and use python for regex search execution ([#516](https://github.com/opening-hours/opening_hours.js/pull/516))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,7 @@ work hours!
 - fix(test): localize expected test strings for German locale ([#512](https://github.com/opening-hours/opening_hours.js/pull/512))
 - fix(test): correct two `sunrise` test expectations to match SunCalc output ([#513](https://github.com/opening-hours/opening_hours.js/pull/513))
 - fix: update script paths and use python for regex search execution ([#516](https://github.com/opening-hours/opening_hours.js/pull/516))
+- fix: update syntax in `regex_search.py` ([#516](https://github.com/opening-hours/opening_hours.js/pull/516))
 
 ### Removed
 

--- a/Makefile
+++ b/Makefile
@@ -131,11 +131,11 @@ ready-for-hosting: dependencies-get build/opening_hours+deps.min.js
 
 ## command line programs {{{
 .PHONY: run-regex_search
-run-regex_search: export.$(SEARCH).json interactive_testing.js regex_search.py
-	$(NODEJS) regex_search.py "$<"
+run-regex_search: export.$(SEARCH).json ./scripts/interactive_testing.js scripts/regex_search.py
+	python3 ./scripts/regex_search.py "$<"
 
 .PHONY: run-interactive_testing
-run-interactive_testing: interactive_testing.js opening_hours.js
+run-interactive_testing: ./scripts/interactive_testing.js ./build/opening_hours.js
 	$(NODEJS) "$<" --locale "$(CHECK_LANG)"
 ## }}}
 

--- a/scripts/regex_search.py
+++ b/scripts/regex_search.py
@@ -34,7 +34,7 @@ class OpeningHoursRegexSearch: # {{{
                 + '?template=key-value&key=%s&value=' % key
         self.taginfo_url = 'https://taginfo.openstreetmap.org/tags/%s=' % key
         self.josm_remote_url = 'http://localhost:8111/import?url=%s' % (
-                self._url_encode(u'https://overpass-api.de/api/xapi_meta?*[%s=' % key)
+                self._url_encode('https://overpass-api.de/api/xapi_meta?*[%s=' % key)
             )
 
     # helper functions for the user of the package {{{
@@ -83,7 +83,7 @@ class OpeningHoursRegexSearch: # {{{
             try:
                 user_reg = re.compile('(?P<pre>.*?)(?P<match>'+user_regex+')(?P<post>.*)',
                         re.IGNORECASE)
-            except re.error, err:
+            except re.error as err:
                 logging.error('Your regular expression did not compile: %s', err)
                 continue
             # }}}
@@ -206,7 +206,7 @@ class OpeningHoursRegexSearch: # {{{
                                 if (josm_load_not_repeat and taginfo_hash['value'] not in do_not_load_values_again) or josm_load_not_repeat != True:
                                     if josm_load_not_repeat:
                                         do_not_load_values_again.append(taginfo_hash['value'])
-                                    josm_remote_url_for_value = '%s%s' % (self.josm_remote_url, self._url_encode('%s%s' % (taginfo_hash['value'], u']')))
+                                    josm_remote_url_for_value = '%s%s' % (self.josm_remote_url, self._url_encode('%s%s' % (taginfo_hash['value'], ']')))
                                     try:
                                         josm_return = urllib.urlopen(josm_remote_url_for_value)
                                         if josm_return.getcode() != 200:
@@ -238,8 +238,8 @@ def main():
     def signal_handler(signal, frame):
         """Called on SIGINT to exit gracefully."""
 
-        print ''
-        logging.info(u'Bye')
+        print ('')
+        logging.info('Bye')
         sys.exit(0)
     signal.signal(signal.SIGINT, signal_handler)
     # }}}
@@ -301,7 +301,7 @@ def main():
     if len(sys.argv) > 1:
         json_file = sys.argv[1]
     taginfo_tag_export = regex_search.load_json_file(json_file)
-    logging.info(u'Loaded %s.' % json_file)
+    logging.info('Loaded %s.' % json_file)
     # }}}
 
     key = ''


### PR DESCRIPTION
About the second commit:

Since `pyopening_hours` cannot be installed at the moment (see https://github.com/opening-hours/pyopening_hours/issues/3), the script still does not work.

The intention of the commit is to ensure that no one is distracted by syntax errors and that the main problem is immediately clear.