### PR TITLE
refactor: replace `optimist` with `yargs` for command-line argument parsing

### DIFF
--- a/scripts/check_for_new_taginfo_data.js
+++ b/scripts/check_for_new_taginfo_data.js
@@ -10,23 +10,26 @@ const exit_code_new = 0;
 let exit_code_not_new = 1;
 
 /* Parameter handling {{{ */
-const optimist = require('optimist')
+const yargs = require('yargs/yargs');
+const { hideBin } = require('yargs/helpers');
+
+const argv = yargs(hideBin(process.argv))
     .usage('Usage: $0')
     .describe('h', 'Display the usage')
     .describe('E', 'Specify the exit code in case there is no new data. The default value is ' + exit_code_not_new + '.')
     .alias('h', 'help')
-    .alias('E', 'exit-code-not-new');
+    .alias('E', 'exit-code-not-new')
+    .argv;
 
-const argv = optimist.argv;
 if (argv.help) {
-    optimist.showHelp();
+    yargs.showHelp();
     process.exit(0);
 }
 
 if (typeof argv.E === 'number') {
     exit_code_not_new = argv.E;
 } else if (typeof argv.E !== 'undefined') {
-    optimist.showHelp();
+    yargs.showHelp();
     process.exit(0);
 }
 /* }}} */

--- a/scripts/real_test.js
+++ b/scripts/real_test.js
@@ -108,7 +108,10 @@ test_framework.config = {
 /* }}} */
 
 /* Parameter handling {{{ */
-const optimist = require('optimist')
+const yargs = require('yargs/yargs');
+const { hideBin } = require('yargs/helpers');
+
+const argv = yargs(hideBin(process.argv))
     .usage('Usage: $0 export*.json [export*.json]')
     .describe('h', 'Display the usage')
     .describe('v', 'Verbose output')
@@ -126,12 +129,11 @@ const optimist = require('optimist')
     .alias('I', 'ignore-manual-values')
     .alias('i', 'ignore-bad-oh-values')
     .alias('p', 'punchcard')
-    .alias('m', 'map-bad-oh-values');
-
-const argv = optimist.argv;
+    .alias('m', 'map-bad-oh-values')
+    .argv;
 
 if (argv.help || argv._.length === 0) {
-    optimist.showHelp();
+    yargs.showHelp();
     process.exit(0);
 }
 /* }}} */


### PR DESCRIPTION
I had missed these two spots. Should have been done with 711d8b8face93681d948acfbb50db34c083fe865.