### PR TITLE
feat(build): add ESM build to npm package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,17 @@ list:
 ## defaults {{{
 .PHONY: build
 build: build/opening_hours.js \
-		build/opening_hours+deps.js
+		build/opening_hours.min.js \
+		build/opening_hours.esm.js \
+		build/opening_hours+deps.js \
+		build/opening_hours+deps.min.js
+
+build/opening_hours.js \
+build/opening_hours.min.js \
+build/opening_hours.esm.js \
+build/opening_hours+deps.js \
+build/opening_hours+deps.min.js: src/index.js
+	node_modules/.bin/rollup -c
 
 .PHONY: check
 check: qa-quick check-fast check-package.json
@@ -482,14 +492,6 @@ osm-tag-data-gen-stats-sort:
 		mv "$$file.tmp" "$$file"; \
 	done
 ## }}}
-
-build/opening_hours.js: build/opening_hours.min.js
-build/opening_hours.min.js: src/index.js
-	DEPS=NO node_modules/.bin/rollup -c
-
-build/opening_hours+deps.js: build/opening_hours+deps.min.js
-build/opening_hours+deps.min.js: src/index.js
-	DEPS=YES node_modules/.bin/rollup -c
 
 README.html:
 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,20 @@
 {
   "name": "opening_hours",
-  "main": "build/opening_hours.js",
   "type": "commonjs",
-  "typings": "./types/index.d.ts",
   "types": "./types/index.d.ts",
   "description": "Library to parse and process opening_hours tag from OpenStreetMap data",
   "version": "3.9.0",
+  "main": "./build/opening_hours.js",
+  "module": "./build/opening_hours.esm.js",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": "./build/opening_hours.esm.js",
+      "require": "./build/opening_hours.js",
+      "types": "./types/index.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "homepage": "https://github.com/opening-hours/opening_hours.js",
   "author": "Dmitry Marakasov <amdmi3@amdmi3.ru>",
   "maintainers": [
@@ -27,6 +36,8 @@
   "license": "LGPL-3.0-only",
   "files": [
     "Makefile",
+    "build/opening_hours.esm.js",
+    "build/opening_hours.esm.js.map",
     "CHANGELOG.md",
     "LICENSES/",
     "site/js/",


### PR DESCRIPTION
- Add ESM build (`opening_hours.esm.js`) for modern bundlers
- Modernize `package.json` with exports field, module field, and sideEffects
- Refactor rollup config to use config array instead of DEPS env var
- Streamline Makefile to single rollup invocation

Previously, no build outputs were included in the npm package. Now ships `opening_hours.esm.js` for modern bundler usage.

Note: UMD builds (`opening_hours.js`, `opening_hours+deps.js`) are unchanged and continue to be built.