### PR TITLE
refactor(build): use .mjs extension for ESM build output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,13 +77,13 @@ list:
 .PHONY: build
 build: build/opening_hours.js \
 		build/opening_hours.min.js \
-		build/opening_hours.esm.js \
+		build/opening_hours.esm.mjs \
 		build/opening_hours+deps.js \
 		build/opening_hours+deps.min.js
 
 build/opening_hours.js \
 build/opening_hours.min.js \
-build/opening_hours.esm.js \
+build/opening_hours.esm.mjs \
 build/opening_hours+deps.js \
 build/opening_hours+deps.min.js: src/index.js
 	node_modules/.bin/rollup -c

--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "description": "Library to parse and process opening_hours tag from OpenStreetMap data",
   "version": "3.9.0",
   "main": "./build/opening_hours.js",
-  "module": "./build/opening_hours.esm.js",
+  "module": "./build/opening_hours.esm.mjs",
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": "./build/opening_hours.esm.js",
+      "import": "./build/opening_hours.esm.mjs",
       "require": "./build/opening_hours.js",
       "types": "./types/index.d.ts"
     },
@@ -36,8 +36,8 @@
   "license": "LGPL-3.0-only",
   "files": [
     "Makefile",
-    "build/opening_hours.esm.js",
-    "build/opening_hours.esm.js.map",
+    "build/opening_hours.esm.mjs",
+    "build/opening_hours.esm.mjs.map",
     "CHANGELOG.md",
     "LICENSES/",
     "site/js/",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -36,7 +36,7 @@ const configWithoutDeps = {
     output: [
         // ESM build
         {
-            file: 'build/opening_hours.esm.js',
+            file: 'build/opening_hours.esm.mjs',
             format: 'esm',
             sourcemap: true,
         },


### PR DESCRIPTION
The .mjs extension is necessary because `package.json` specifies `"type": "commonjs"`. Without .mjs, Node.js would treat the ESM build as CommonJS, causing module errors.