### PR TITLE
data:  update the holidays for the year 2026 in Argentina

### DIFF
--- a/src/holidays/ar.yaml
+++ b/src/holidays/ar.yaml
@@ -3,27 +3,29 @@
 _nominatim_url: 'https://nominatim.openstreetmap.org/reverse?format=json&lat=-34.60377&lon=-58.38159&zoom=16&addressdetails=1&accept-language=es'
 
 # https://www.argentina.gob.ar/feriados
+# https://www.boletinoficial.gob.ar/detalleAviso/primera/336753/20251226
+
 
 PH:
   - {'name': 'Año Nuevo', 'fixed_date': [1, 1]}
-  - {'name': 'Carnaval', 'variable_date': easter, 'offset': -48}
-  - {'name': 'Carnaval', 'variable_date': easter, 'offset': -47}
+  - {'name': 'Carnaval I', 'variable_date': easter, 'offset': -48}
+  - {'name': 'Carnaval II', 'variable_date': easter, 'offset': -47}
+  - {'name': 'Feriado con fines turísticos', 'fixed_date': [3, 23]}
   - {'name': 'Día Nacional de la Memoria por la Verdad y la Justicia', 'fixed_date': [3, 24]}
   - {'name': 'Viernes Santo', 'variable_date': easter, 'offset': -2}
-  - {'name': 'Feriado con fines turísticos', 'fixed_date': [4, 1]}
   - {'name': 'Día del Veterano y de los Caídos en la Guerra de Malvinas', 'fixed_date': [4, 2]}
   - {'name': 'Día del Trabajador', 'fixed_date': [5, 1]}
   - {'name': 'Día de la Revolución de Mayo', 'fixed_date': [5, 25]}
-  # Paso a la Inmortalidad del Gral. Don Martín Miguel de Güemes - 17 de Junio - Dia variable, si cae martes o miecoles se mueve al lunes, si cae jueves o viernes se mueve al lunes siguiente. TODO
-  - {'name': 'Paso a la Inmortalidad del Gral. Don Martín Miguel de Güemes', 'fixed_date': [6, 17]}
+  # Paso a la Inmortalidad del Gral. Don Martín Miguel de Güemes - 17 de Junio - Dia variable, si cae martes o miecoles se mueve al lunes anterior, si cae jueves o viernes se mueve al lunes siguiente. TODO
+  - {'name': 'Paso a la Inmortalidad del Gral. Don Martín Miguel de Güemes', 'fixed_date': [6, 15]}
   - {'name': 'Paso a la Inmortalidad del General Manuel Belgrano', 'fixed_date': [6, 20]}
-  - {'name': 'Feriado con fines turísticos', 'fixed_date': [6, 21]}
   - {'name': 'Día de la Independencia', 'fixed_date': [7, 9]}
-  # Paso a la Inmortalidad del Gral. José de San Martín - 17 de Agosto - Dia variable, si cae martes o miecoles se mueve al lunes, si cae jueves o viernes se mueve al lunes siguiente. TODO
+  - {'name': 'Feriado con fines turísticos', 'fixed_date': [7, 10]}
+  # Paso a la Inmortalidad del Gral. José de San Martín - 17 de Agosto - Dia variable, si cae martes o miecoles se mueve al lunes anterior, si cae jueves o viernes se mueve al lunes siguiente. TODO
   - {'name': 'Paso a la Inmortalidad del Gral. José de San Martín', 'fixed_date': [8, 17]}
-  - {'name': 'Feriado con fines turísticos', 'fixed_date': [10, 11]}
   - {'name': 'Día del Respeto a la Diversidad Cultural', 'fixed_date': [10, 12]}
-  # Día de la Soberanía Nacional - 20 de noviembre - Dia variable, si cae martes o miecoles se mueve al lunes, si cae jueves o viernes se mueve al lunes siguiente. TODO
-  - {'name': 'Día de la Soberanía Nacional', 'fixed_date': [11, 18]}
+  # Día de la Soberanía Nacional - 20 de noviembre - Dia variable, si cae martes o miecoles se mueve al lunes anterior, si cae jueves o viernes se mueve al lunes siguiente. TODO
+  - {'name': 'Día de la Soberanía Nacional', 'fixed_date': [11, 23]}
+  - {'name': 'Feriado con fines turísticos', 'fixed_date': [12, 7]}
   - {'name': 'Inmaculada Concepción de María', 'fixed_date': [12, 8]}
   - {'name': 'Navidad', 'fixed_date': [12, 25]}


### PR DESCRIPTION
Today, the Argentine government published the holiday calendar for 2026.