### PR TITLE
chore(contributing): add data type and document commit convention

### DIFF
--- a/.versionrc.json
+++ b/.versionrc.json
@@ -1,0 +1,48 @@
+{
+  "types": [
+    {
+      "type": "feat",
+      "section": "Features"
+    },
+    {
+      "type": "fix",
+      "section": "Bug Fixes"
+    },
+    {
+      "type": "data",
+      "section": "Data Updates"
+    },
+    {
+      "type": "chore",
+      "hidden": true
+    },
+    {
+      "type": "docs",
+      "section": "Documentation"
+    },
+    {
+      "type": "style",
+      "hidden": true
+    },
+    {
+      "type": "refactor",
+      "section": "Code Refactoring"
+    },
+    {
+      "type": "perf",
+      "hidden": true
+    },
+    {
+      "type": "test",
+      "hidden": true
+    },
+    {
+      "type": "build",
+      "hidden": true
+    },
+    {
+      "type": "ci",
+      "hidden": true
+    }
+  ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,72 @@ In case your holiday definition does only change the `holiday_definitions` varia
 Be sure to add one or more tests if you add new features or enhance error tolerance or the like.
 See under [testing][ohlib.testing].
 
+### Commit Message Convention
+
+We follow the [Conventional Commits](https://www.conventionalcommits.org/) specification. The minimum required format is:
+
+```text
+<type>[(optional scope)]: <subject>
+```
+
+Optionally with body and footer:
+
+```text
+<type>(<scope>): <subject>
+
+[optional body]
+
+[optional footer]
+```
+
+**Commit Types:**
+
+- `feat`: A new feature
+- `fix`: A bug fix
+- `data`: Updates to holiday/locale data files
+- `docs`: Documentation only changes
+- `style`: Code style changes (formatting, missing semicolons, etc.)
+- `refactor`: Code changes that neither fix bugs nor add features
+- `perf`: Performance improvements
+- `test`: Adding or updating tests
+- `build`: Changes to build system or dependencies
+- `ci`: Changes to CI configuration
+- `chore`: Other changes that don't modify src or test files
+
+**Scope (optional):**
+
+The scope indicates the part of the codebase being changed. Common scopes include:
+
+- `parser`: Parser/tokenizer changes
+- `holidays`: Holiday definition logic (not data updates)
+- `locales`: Translation/i18n changes
+- `build`: Build system (rollup, npm, etc.)
+- `test`: Test infrastructure
+- `deps`: Dependency updates
+- Country codes (`de`, `fr`, `us`, etc.): Country-specific changes
+
+**Examples:**
+
+```text
+feat(parser): add support for week ranges with step
+
+fix(holidays): correct Easter calculation for edge cases
+
+data(holidays): update Argentina 2026 public holidays
+
+data(de): update school holidays for Bavaria 2026
+
+docs(readme): add installation instructions for Deno
+
+build(rollup): migrate to ESM output format
+
+test: add coverage for periodic week schedules
+```
+
+**Note:** The scope is optional. When in doubt, omit it rather than guessing.
+
+The changelog is automatically generated from these commit messages. Only `feat`, `fix`, `data`, `docs`, and `refactor` commits appear in the changelog.
+
 ### Commit Hooks
 
 Note that there is a git pre-commit hook used to run and compare the test framework before each commit. Hooks are written as shell scripts using [husky][husky] and should be installed to git automatically when running `npm install`. If this does not happen, you can manually run `node --run postinstall`.

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,6 +1,24 @@
 export default {
   extends: ['@commitlint/config-conventional'],
   rules: {
-    'body-max-line-length': [2, 'always', 150]
+    'body-max-line-length': [2, 'always', 150],
+    'type-enum': [
+      2,
+      'always',
+      [
+        'build',
+        'chore',
+        'ci',
+        'data',
+        'docs',
+        'feat',
+        'fix',
+        'perf',
+        'refactor',
+        'revert',
+        'style',
+        'test'
+      ]
+    ]
   }
 };


### PR DESCRIPTION
Improve changelog organization and contributor guidance:

- Add custom 'data' type for holiday/locale updates (new changelog section)
- Configure .versionrc.json (previously used implicit defaults)
- Extend commitlint to validate 'data' type
- Document commit message convention in CONTRIBUTING.md

The 'data' type separates frequent data updates from code changes in release notes, making changelogs more useful.