### PR TITLE
fix(evaluation-tool): correct ISO week labels at year boundary

### DIFF
--- a/site/js/helpers.js
+++ b/site/js/helpers.js
@@ -46,15 +46,18 @@ export function josm(url_param) {
 }
 // }}}
 
-// add calculation for calendar week to date {{{
-export function dateAtWeek(date, week) {
-    const minutes_in_day = 60 * 24;
-    const msec_in_day    = 1000 * 60 * minutes_in_day;
-    const msec_in_week   = msec_in_day * 7;
+// ISO 8601 calendar week number {{{
+export function getISOWeekNumber(date) {
+    const millisecondsPerDay = 24 * 60 * 60 * 1000;
+    const utcDate = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
 
-    const tmpdate = new Date(date.getFullYear(), 0, 1);
-    tmpdate.setDate(1 - (tmpdate.getDay() + 6) % 7 + week * 7); // start of week n where week starts on Monday
-    return Math.floor((date - tmpdate) / msec_in_week);
+    // ISO week uses Monday=1..Sunday=7 and anchors weeks on Thursday.
+    const isoDay = utcDate.getUTCDay() || 7;
+    utcDate.setUTCDate(utcDate.getUTCDate() + 4 - isoDay);
+
+    const isoYearStart = new Date(Date.UTC(utcDate.getUTCFullYear(), 0, 1));
+    const dayOfYear = Math.floor((utcDate - isoYearStart) / millisecondsPerDay) + 1;
+    return Math.ceil(dayOfYear / 7);
 }
 // }}}
 

--- a/site/js/main.js
+++ b/site/js/main.js
@@ -1,7 +1,7 @@
 // Import all required modules
 import i18next from '../../node_modules/i18next/dist/esm/i18next.bundled.js';
 import { resources, detectLanguage, getUserSelectTranslateHTMLCode, changeLanguage } from './i18n-resources.js';
-import { Evaluate, EX, josm, toggle, dateAtWeek, newValue, currentDateTime } from './helpers.js';
+import { Evaluate, EX, josm, toggle, getISOWeekNumber, newValue, currentDateTime } from './helpers.js';
 
 // Configuration constants
 window.default_lat = 48.7769;
@@ -72,7 +72,7 @@ export function updateTimeButtonLabels(date) {
     if (minuteLabel) minuteLabel.textContent = u2(currentDateTime.minute);
 
     if (weekLabel && date) {
-        weekLabel.textContent = `W${u2(dateAtWeek(date, 0) + 1)}`;
+        weekLabel.textContent = `W${u2(getISOWeekNumber(date))}`;
     }
 
     if (wdayDisplay && date) {


### PR DESCRIPTION
Week label in the evaluation tool was off around New Year (e.g. 2026/2027), skipping W01 in some cases.
Switched to ISO-8601 week calculation (Thursday anchor, UTC-based), so week labels now match opening_hours semantics.

Closes #567

### Before

<img width="673" height="120" alt="bildo" src="https://github.com/user-attachments/assets/f5f8cfd8-ccf8-4fd2-b9be-ec7c798d38e4" />

### After

<img width="673" height="120" alt="bildo" src="https://github.com/user-attachments/assets/04ce8338-bc20-421d-8985-3ceb08c3ef14" />


