### PR TITLE
fix(evaluation-tool): update i18next import path for v24+

### DIFF
--- a/site/js/helpers.js
+++ b/site/js/helpers.js
@@ -1,5 +1,5 @@
 // Import dependencies
-import i18next from '../../node_modules/i18next/dist/esm/i18next.bundled.js';
+import i18next from '../../node_modules/i18next/dist/esm/i18next.js';
 import { OpeningHoursTable } from './opening_hours_table.js';
 import { mapCountryToLanguage } from './countryToLanguageMapping.js';
 import { updateTimeButtonLabels } from './main.js';

--- a/site/js/i18n-resources.js
+++ b/site/js/i18n-resources.js
@@ -1,5 +1,5 @@
 // Import i18next for use in helper functions
-import i18next from '../../node_modules/i18next/dist/esm/i18next.bundled.js';
+import i18next from '../../node_modules/i18next/dist/esm/i18next.js';
 
 // localization {{{
 export const resources = { // English is fallback language.

--- a/site/js/main.js
+++ b/site/js/main.js
@@ -1,5 +1,5 @@
 // Import all required modules
-import i18next from '../../node_modules/i18next/dist/esm/i18next.bundled.js';
+import i18next from '../../node_modules/i18next/dist/esm/i18next.js';
 import { resources, detectLanguage, getUserSelectTranslateHTMLCode, changeLanguage } from './i18n-resources.js';
 import { Evaluate, EX, josm, toggle, getISOWeekNumber, newValue, currentDateTime } from './helpers.js';
 

--- a/site/js/opening_hours_table.js
+++ b/site/js/opening_hours_table.js
@@ -1,5 +1,5 @@
 // Import dependencies
-import i18next from '../../node_modules/i18next/dist/esm/i18next.bundled.js';
+import i18next from '../../node_modules/i18next/dist/esm/i18next.js';
 
 export const OpeningHoursTable = {
 


### PR DESCRIPTION
i18next removed the bundled ESM variant (i18next.bundled.js) in v24. All site JS files now import from i18next.js instead.