### PR TITLE
fix(parser): don't match when nth weekday overflows to next month

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2220,6 +2220,11 @@ export default function(value, nominatim_object, optional_conf_parm) {
                             // The target day is in the next month. If the target day without the added days is not in this month
                             if (target_day_this_month.getTime() >= start_of_next_month.getTime())
                                 return [false, start_of_next_month];
+                        } else if (target_day_this_month.getTime() >= start_of_next_month.getTime()) {
+                            // The nth weekday overflows to next month (e.g. no 5th Sunday in February),
+                            // but negative add_days pulled the result back into this month.
+                            // The nth weekday still does not exist this month, so do not match.
+                            return [false, start_of_next_month];
                         }
 
                         let target_day_with_added_moved_days_this_month;

--- a/test/test.de.log
+++ b/test/test.de.log
@@ -964,6 +964,8 @@ With [34m[1mwarnings[22m[39m:
 	*Aug Su[-1] +1 day <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
 "Constrained weekday (complex real world example)" for "Apr-Oct: Su[2] 14:00-18:00; Aug Su[-1] -1 day 10:00-18:00, Aug: Su[-1] 10:00-18:00": [32m[1mPASSED[22m[39m
 "Constrained weekday (complex real world example)" for "Apr-Oct: Su[2] 14:00-18:00; Aug Su[-1] -1 day 10:00-18:00; Aug: Su[-1] 10:00-18:00": [32m[1mPASSED[22m[39m
+"Calculations based on constrained weekdays: issue #444, no 5th Sunday in Feb 2020" for "Feb: Su[5] -1 day 12:00-22:00": [32m[1mPASSED[22m[39m
+"Calculations based on constrained weekdays: issue #444, 5th Sunday exists in Feb 2032" for "Feb: Su[5] -1 day 12:00-22:00": [32m[1mPASSED[22m[39m
 "Additional rules" for "Mo-Fr 10:00-16:00, We 12:00-18:00": [32m[1mPASSED[22m[39m
 "Additional rules" for "Mo-Fr 08:00-12:00, We 14:00-18:00": [32m[1mPASSED[22m[39m
 "Additional rules" for "Mo-Fr 08:00-12:00, We 14:00-18:00; Su off": [32m[1mPASSED[22m[39m
@@ -2562,7 +2564,7 @@ Der optional_conf_parm["tag_key"] fehlt, ist aber notwendig wegen optional_conf_
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-974/978 tests passed. 4 did not pass.
+976/980 tests passed. 4 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.en.log
+++ b/test/test.en.log
@@ -964,6 +964,8 @@ With [34m[1mwarnings[22m[39m:
 	*Aug Su[-1] +1 day <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
 "Constrained weekday (complex real world example)" for "Apr-Oct: Su[2] 14:00-18:00; Aug Su[-1] -1 day 10:00-18:00, Aug: Su[-1] 10:00-18:00": [32m[1mPASSED[22m[39m
 "Constrained weekday (complex real world example)" for "Apr-Oct: Su[2] 14:00-18:00; Aug Su[-1] -1 day 10:00-18:00; Aug: Su[-1] 10:00-18:00": [32m[1mPASSED[22m[39m
+"Calculations based on constrained weekdays: issue #444, no 5th Sunday in Feb 2020" for "Feb: Su[5] -1 day 12:00-22:00": [32m[1mPASSED[22m[39m
+"Calculations based on constrained weekdays: issue #444, 5th Sunday exists in Feb 2032" for "Feb: Su[5] -1 day 12:00-22:00": [32m[1mPASSED[22m[39m
 "Additional rules" for "Mo-Fr 10:00-16:00, We 12:00-18:00": [32m[1mPASSED[22m[39m
 "Additional rules" for "Mo-Fr 08:00-12:00, We 14:00-18:00": [32m[1mPASSED[22m[39m
 "Additional rules" for "Mo-Fr 08:00-12:00, We 14:00-18:00; Su off": [32m[1mPASSED[22m[39m
@@ -2555,7 +2557,7 @@ The optional_conf_parm["tag_key"] is missing, required by optional_conf_parm["ma
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-967/971 tests passed. 4 did not pass.
+969/973 tests passed. 4 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.js
+++ b/test/test.js
@@ -2770,6 +2770,20 @@ test.addTest('Constrained weekday (complex real world example)', [
         [ '2013-08-25 10:00', '2013-08-25 18:00' ],
         [ '2013-09-08 14:00', '2013-09-08 18:00' ],
     ], 1000 * 60 * 60 * (4 * 2 + 4 * 4), 0, false, {}, 'not last test');
+
+// issue #444: nth weekday overflows month but negative add_days pulls result back {{{
+test.addTest('Calculations based on constrained weekdays: issue #444, no 5th Sunday in Feb 2020', [
+        // Feb 2020: only 4 Sundays. Su[5] overflows to Mar 1; -1 day = Feb 29 — must not match.
+        'Feb: Su[5] -1 day 12:00-22:00',
+    ], '2020-02-01 0:00', '2020-03-01 0:00', [
+    ], 0, 0, false, {}, 'not last test');
+
+test.addTest('Calculations based on constrained weekdays: issue #444, 5th Sunday exists in Feb 2032', [
+        // Feb 2032 (leap year, Feb 1 = Sunday): 5th Sunday = Feb 29; -1 day = Feb 28.
+        'Feb: Su[5] -1 day 12:00-22:00',
+    ], '2032-02-27 0:00', '2032-03-01 0:00', [
+        [ '2032-02-28 12:00', '2032-02-28 22:00' ],
+    ], 1000 * 60 * 60 * 10, 0, false, {}, 'not last test');
 // }}}
 
 // additional rules {{{


### PR DESCRIPTION
`Feb: Su[5] -1 day 12:00-22:00` incorrectly returns open on February 29, 2020 - despite there being no 5th Sunday in that month.

The culprit: computing "the 5th Sunday" in a short month overflows into the next month (Mar 1), and then subtracting 1 day lands back on Feb 29 - a valid date, so the existing bounds checks don't catch it.

Fix is a single extra guard: if the nth weekday itself overflows, return no-match immediately, regardless of any day offset.

Fixes #444.