### PR TITLE
fix: handle unknown and *:conditional tag keys

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -106,6 +106,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
         'opening_hours:.+'    :  { 'mode' :  0, },
         '.+:opening_hours'    :  { 'mode' :  0, },
         '.+:opening_hours:.+' :  { 'mode' :  0, },
+        '.+:conditional'      :  { 'mode' :  0, },
         'smoking_hours'       :  { 'mode' :  0, },
         'service_times'       :  { 'mode' :  2, },
         'happy_hours'         :  { 'mode' :  0, },

--- a/src/index.js
+++ b/src/index.js
@@ -1076,6 +1076,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
                 && (
                         (
                             typeof oh_key === 'string'
+                            && oh_regex_key
                             && osm_tag_defaults[oh_regex_key]['warn_for_PH_missing']
                         )
                         || (typeof oh_key !== 'string')


### PR DESCRIPTION
This fixes two small `tag_key` issues from #480:

1. Unknown keys could crash `getWarnings()` when the PH warning code looked up a missing `osm_tag_defaults` entry.
2. `*:conditional` values, like `maxspeed:conditional`, got the missing-PH warning even though conditional restrictions do not need to mention `PH` by default.

The PH warning for normal `opening_hours` is unchanged. `PH` can still be used in conditional values; it is just no longer treated as missing when left out.