### PR TITLE
fix: don't crash in formatWarnErrorMessage with Additional Rules

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -283,7 +283,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
         throw t('nothing');
     }
 
-    const parsing_warnings = []; // Elements are fed into function formatWarnErrorMessage(nrule, at, message)
+    const parsing_warnings = []; // Elements are arrays [nrule, at, message, tokens_to_use?] fed into formatWarnErrorMessage().
     let done_with_warnings = false; // The functions which returns warnings can be called multiple times.
     let done_with_selector_reordering = false;
     let done_with_selector_reordering_warnings = false;
@@ -471,9 +471,13 @@ export default function(value, nominatim_object, optional_conf_parm) {
     /* Format warning or error message for the user. {{{
      *
      * :param nrule: Rule number starting with 0.
-     * :param at: Token position at which the issue occurred.
+     *               -1: error during tokenization, `at` is remaining value.length.
+     *               string: prettified value, `at` is a byte offset into it.
+     * :param at: Token position. -1 means end of rule (no token at that position).
      * :param message: Human readable string with the message.
-     * :param tokens_to_use: List of token objects.
+     * :param tokens_to_use: Optional. Defaults to `tokens`. Pass `new_tokens` from
+     *               getWarnings() because new_tokens can have more entries than tokens
+     *               when Additional Rules are present.
      * :returns: String with position of the warning or error marked for the user.
      */
     function formatWarnErrorMessage(nrule, at, message, tokens_to_use) {
@@ -481,14 +485,20 @@ export default function(value, nominatim_object, optional_conf_parm) {
             tokens_to_use = tokens;
         }
         // console.log(`Called formatWarnErrorMessage: ${nrule}, ${at}, ${message}`);
-        // FIXME: Change to new_tokens.
         if (typeof nrule === 'number') {
             let pos;
-            if (nrule === -1) { // Usage of rule index not required because we do have access to value.length.
+            if (nrule === -1) {
+                // at is remaining value.length at the point of the error.
                 pos = value.length - at;
-            } else { // Issue occurred at a later time, position in string needs to be reconstructed.
+            } else {
+                if (typeof tokens_to_use[nrule] === 'undefined') {
+                    // Caller passed the wrong token array (tokens instead of new_tokens?).
+                    formatLibraryBugMessage('Bug in warning generation code: tokens_to_use[nrule] is undefined for nrule=' + nrule + '.');
+                    return value + ' <--- (' + message + ')';
+                }
                 if (typeof tokens_to_use[nrule][0][at] === 'undefined') {
                     if (typeof tokens_to_use[nrule][0] !== 'undefined' && at === -1) {
+                        // at === -1: point to end of rule, use offset of next rule entry if available.
                         pos = value.length;
                         if (typeof tokens_to_use[nrule+1] === 'object' && typeof tokens_to_use[nrule+1][2] === 'number') {
                             pos -= tokens_to_use[nrule+1][2];
@@ -496,13 +506,11 @@ export default function(value, nominatim_object, optional_conf_parm) {
                             pos -= tokens_to_use[nrule][2];
                         }
                     } else {
-                        // Given position is invalid.
-                        //
+                        // Token position is out of range. Run real_test regularly to catch this.
                         formatLibraryBugMessage('Bug in warning generation code which could not determine the exact position of the warning or error in value.');
                         pos = value.length;
                         if (typeof tokens_to_use[nrule][2] === 'number') {
-                            // Fallback: Point to last token in the rule which caused the problem.
-                            // Run real_test regularly to fix the problem before a user is confronted with it.
+                            // Fallback: point to last token in the rule which caused the problem.
                             pos -= tokens_to_use[nrule][2];
                             console.warn('Last token for rule: ' + JSON.stringify(tokens_to_use[nrule]));
                         } else {
@@ -522,6 +530,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
         } else if (typeof nrule === 'string') {
             return nrule.substring(0, at) + ' <--- (' + message + ')';
         }
+        return message;
     }
     /* }}} */
 
@@ -934,7 +943,8 @@ export default function(value, nominatim_object, optional_conf_parm) {
                                         :
                                         t('selector multi 2b', {'what': t(selector_type + (/^(?:month|weekday)$/.test(selector_type) ? 's' : ' ranges'))})
                                 )
-                            })]
+                            }),
+                            new_tokens]
                         );
                         done_with_selector_reordering = true; // Correcting the selector order makes no sense if this kind of issue exists.
                     }
@@ -945,7 +955,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
                     && Object.keys(used_selectors[nrule]).length === 1
                 ) {
                     if (nrule !== 0) {
-                        parsing_warnings.push([nrule, new_tokens[nrule][0].length - 1, t('default state')]);
+                        parsing_warnings.push([nrule, new_tokens[nrule][0].length - 1, t('default state'), new_tokens]);
                     }
                 /* }}} */
                 /* Check if a rule (with state open) has no time selector {{{ */
@@ -959,7 +969,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
                             typeof used_selectors[nrule]['24/7'] === 'undefined'
                     ) {
 
-                        parsing_warnings.push([nrule, new_tokens[nrule][0].length - 1, t('vague')]);
+                        parsing_warnings.push([nrule, new_tokens[nrule][0].length - 1, t('vague'), new_tokens]);
                     }
                 }
                 /* }}} */
@@ -968,7 +978,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
                     && new_tokens[nrule][0][used_selectors[nrule].comment[0]][0].length === 0
                 ) {
 
-                    parsing_warnings.push([nrule, used_selectors[nrule].comment[0], t('empty comment')]);
+                    parsing_warnings.push([nrule, used_selectors[nrule].comment[0], t('empty comment'), new_tokens]);
                 }
                 /* }}} */
                 /* Check for valid use of <separator_for_readability> {{{ */
@@ -983,7 +993,8 @@ export default function(value, nominatim_object, optional_conf_parm) {
 
                         if (new_tokens[nrule][0][used_selectors[nrule][selector_type][0]][0] === ':') {
                             parsing_warnings.push([nrule, used_selectors[nrule][selector_type][0],
-                                t('separator_for_readability')
+                                t('separator_for_readability'),
+                                new_tokens
                             ]);
                         }
                     }

--- a/test/test.de.log
+++ b/test/test.de.log
@@ -1462,10 +1462,7 @@ With [34m[1mwarnings[22m[39m:
 "Real world example: Was not processed right (test over a full year)" for "Jan off; Feb off; Mar off; Apr Tu-Su 10:00-14:30, May Tu-Su 10:00-14:30; Jun Tu-Su 09:00-16:00; Jul Tu-Su 10:00-17:00; Aug Tu-Su 10:00-17:00; Sep Tu-Su 10:00-14:30; Oct Tu-Su 10:00-14:30; Nov off; Dec off": [32m[1mPASSED[22m[39m
 "Real world example: Was not processed right (test over a full year)" for "Nov-Mar off; Apr,May,Sep,Oct Tu-Su 10:00-14:30; Jun Tu-Su 09:00-16:00; Jul,Aug Tu-Su 10:00-17:00": [32m[1mPASSED[22m[39m
 "Real world example: Was not processed right (test over a full year)" for "Nov-Mar off; Apr,May,Sep,Oct 10:00-14:30; Jun 09:00-16:00; Jul,Aug 10:00-17:00; Mo off": [32m[1mPASSED[22m[39m
-"Real world example: Was not processed right" for "Tu 10:00-12:00, Fr 16:00-18:00; unknown": [31m[1mFAILED[22m[39m, bad duration(s): 0,63072000000, expected 0,0, bad intervals: 
-[ '2014-01-01 00:00', '2016-01-01 00:00', true, undefined ],
-expected:
-(none), bad weekstable flag: true, expected false
+"Real world example: Was not processed right" for "Tu 10:00-12:00, Fr 16:00-18:00; unknown": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
 	*Tu 10:00-12:00, Fr 16:00-18:00; unknown <--- (Diese Regel, welche den Standard-Status (d.h. geschlossen) für alle folgenden Regeln ändert, ist nicht die erste Regel. Diese Regel überschreibt alle vorherigen Regeln. Es kann legitim sein, den Standard-Status z.B. auf geöffnet festzulegen und dann nur die Zeiten, zu denen geschlossen ist, anzugeben.)
 "Real world example: Problem with <additional_rule_separator> in holiday parser" for "PH; Aug-Sep 00:00-24:00": [32m[1mPASSED[22m[39m
@@ -2607,7 +2604,7 @@ Der optional_conf_parm["tag_key"] fehlt, ist aber notwendig wegen optional_conf_
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-984/986 tests passed. 2 did not pass.
+985/986 tests passed. 1 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.de.log
+++ b/test/test.de.log
@@ -1389,13 +1389,37 @@ With [34m[1mwarnings[22m[39m:
 "Complex example used in README and benchmark" for "Mo,Tu,Th,Fr 12:00-18:00; Sa,PH 12:00-17:00; Th[3] off; Th[-1] off": [32m[1mPASSED[22m[39m
 "Complex example used in README and benchmark" for "Mo,Tu,Th,Fr 12:00-18:00; Sa,PH 12:00-17:00; Th[3],Th[-1] off": [32m[1mPASSED[22m[39m
 "Warnings corrected to additional rule (real world example)" for "Mo-Fr 09:00-12:00, Mo,Tu,Th 15:00-18:00": [32m[1mPASSED[22m[39m
-"Warnings corrected to additional rule (real world example)" for "Mo – Fr: 9 – 12 Uhr und Mo, Di, Do: 15 – 18 Uhr": [35m[1mCRASHED[22m[39m, reason: TypeError: Cannot read properties of undefined (reading '0')
+"Warnings corrected to additional rule (real world example)" for "Mo – Fr: 9 – 12 Uhr und Mo, Di, Do: 15 – 18 Uhr": [32m[1mPASSED[22m[39m
+With [34m[1mwarnings[22m[39m:
+	*Mo – <--- (Bitte verwende "-" für "–". Auch wenn "–" typografisch korrekt ist, ist dies in der opening_hours Syntax nicht definiert. Korrekte Typographie sollte auf Anwendungsebene sichergestellt werden …)
+	*Mo – Fr: 9 – <--- (Bitte verwende "-" für "–". Auch wenn "–" typografisch korrekt ist, ist dies in der opening_hours Syntax nicht definiert. Korrekte Typographie sollte auf Anwendungsebene sichergestellt werden …)
+	*Mo – Fr: 9 – 12 Uhr <--- (Bitte verzichte auf "uhr".)
+	*Mo – Fr: 9 – 12 Uhr und <--- (Bitte verwende "," anstelle von "und".)
+	*Mo – Fr: 9 – 12 Uhr und Mo, Di <--- (Bitte benutze die englische Abkürzung "Tu" für "di".)
+	*Mo – Fr: 9 – 12 Uhr und Mo, Di, Do <--- (Bitte benutze die englische Abkürzung "Th" für "do".)
+	*Mo – Fr: 9 – 12 Uhr und Mo, Di, Do: 15 – <--- (Bitte verwende "-" für "–". Auch wenn "–" typografisch korrekt ist, ist dies in der opening_hours Syntax nicht definiert. Korrekte Typographie sollte auf Anwendungsebene sichergestellt werden …)
+	*Mo – Fr: 9 – 12 Uhr und Mo, Di, Do: 15 – 18 Uhr <--- (Bitte verzichte auf "uhr".)
+	*Mo – Fr: 9 – 12 Uhr  <--- (Zeitspanne ohne Minutenangabe angegeben. Das ist nicht sehr eindeutig! Bitte verwende stattdessen folgende Syntax "09:00-12:00".)
+	*Mo – Fr: 9 – 12 Uhr und Mo, Di, Do: 15 – 18 Uhr <--- (Zeitspanne ohne Minutenangabe angegeben. Das ist nicht sehr eindeutig! Bitte verwende stattdessen folgende Syntax "15:00-18:00".)
+	*Mo – Fr:  <--- (Du hast das optionale Symbol <separator_for_readability> an der falschen Stelle benutzt. Bitte lies die Syntax-Spezifikation um zu sehen, wo es verwendet werden kann, oder entferne es.)
+	*Mo – Fr: 9 – 12 Uhr und Mo, Di, Do:  <--- (Du hast das optionale Symbol <separator_for_readability> an der falschen Stelle benutzt. Bitte lies die Syntax-Spezifikation um zu sehen, wo es verwendet werden kann, oder entferne es.)
 "Real world example: Was not processed right." for "Mo off, Tu 14:00-18:00, We-Sa 10:00-18:00": [32m[1mPASSED[22m[39m
 "Real world example: Was not processed right." for "Mo geschl., Tu 14:00-18:00, We-Sa 10:00-18:00": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
 	*Mo geschl <--- (Bitte benutze "off" für "geschl". Beispiel: "Mo-Fr 08:00-12:00; Tu off".)
 	*Mo geschl. <--- (Bitte verzichte auf ".".)
-"Real world example: Was not processed right." for "Mo: geschlossen, Di: 14-18Uhr, Mi-Sa: 10-18Uhr": [35m[1mCRASHED[22m[39m, reason: TypeError: Cannot read properties of undefined (reading '0')
+"Real world example: Was not processed right." for "Mo: geschlossen, Di: 14-18Uhr, Mi-Sa: 10-18Uhr": [32m[1mPASSED[22m[39m
+With [34m[1mwarnings[22m[39m:
+	*Mo: geschlossen <--- (Bitte benutze "off" für "geschlossen". Beispiel: "Mo-Fr 08:00-12:00; Tu off".)
+	*Mo: geschlossen, Di <--- (Bitte benutze die englische Abkürzung "Tu" für "di".)
+	*Mo: geschlossen, Di: 14-18Uhr <--- (Bitte verzichte auf "uhr".)
+	*Mo: geschlossen, Di: 14-18Uhr, Mi <--- (Bitte benutze die englische Abkürzung "We" für "mi".)
+	*Mo: geschlossen, Di: 14-18Uhr, Mi-Sa: 10-18Uhr <--- (Bitte verzichte auf "uhr".)
+	*Mo: geschlossen, Di: 14-18Uhr <--- (Zeitspanne ohne Minutenangabe angegeben. Das ist nicht sehr eindeutig! Bitte verwende stattdessen folgende Syntax "14:00-18:00".)
+	*Mo: geschlossen, Di: 14-18Uhr, Mi-Sa: 10-18Uhr <--- (Zeitspanne ohne Minutenangabe angegeben. Das ist nicht sehr eindeutig! Bitte verwende stattdessen folgende Syntax "10:00-18:00".)
+	*Mo:  <--- (Du hast das optionale Symbol <separator_for_readability> an der falschen Stelle benutzt. Bitte lies die Syntax-Spezifikation um zu sehen, wo es verwendet werden kann, oder entferne es.)
+	*Mo: geschlossen, Di:  <--- (Du hast das optionale Symbol <separator_for_readability> an der falschen Stelle benutzt. Bitte lies die Syntax-Spezifikation um zu sehen, wo es verwendet werden kann, oder entferne es.)
+	*Mo: geschlossen, Di: 14-18Uhr, Mi-Sa:  <--- (Du hast das optionale Symbol <separator_for_readability> an der falschen Stelle benutzt. Bitte lies die Syntax-Spezifikation um zu sehen, wo es verwendet werden kann, oder entferne es.)
 "Real world example: Was not processed right." for "Mo off; Tu 14:00-18:00; We-Sa 10:00-18:00": [32m[1mPASSED[22m[39m
 "Real world example: Was not processed right (month range/monthday range)" for "Aug,Dec 25-easter": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
@@ -1430,19 +1454,20 @@ With [34m[1mwarnings[22m[39m:
 "Based on real world example: Is processed right." for "Apr-Oct: Sa-Su 08:00-15:00, May-Sep: 00:00-24:00": [32m[1mPASSED[22m[39m
 "Based on real world example: Is processed right." for "Apr-Oct: Sa-Su 08:00-15:00; May-Sep: 00:00-24:00": [32m[1mPASSED[22m[39m
 "Real world example: Was not processed right." for "Mo-Fr 07:00-19:30; Sa-Su 08:00-19:30 open, 19:30-21:00 open "No new laundry loads in"; Nov Th[4] off; Dec 25 off": [32m[1mPASSED[22m[39m
-Bei der Auswertung des Wertes "Jan off; Feb off; Mar off; Apr Tu-Su 10:00-14:30, May Tu-Su 10:00-14:30; Jun Tu-Su 09:00-16:00; Jul Tu-Su 10:00-17:00; Aug Tu-Su 10:00-17:00; Sep Tu-Su 10:00-14:30; Oct Tu-Su 10:00-14:30 Nov off; Dec off" ist ein Fehler aufgetreten. Bitte melde diesen Fehler oder korrigiere diesen mittels eines Pull Requests oder Patches: https://github.com/opening-hours/opening_hours.js. Bug in warning generation code which could not determine the exact position of the warning or error in value.
-tokens_to_use[nrule][2] is undefined. This is ok if nrule is the last rule.
-Bei der Auswertung des Wertes "Jan off; Feb off; Mar off; Apr Tu-Su 10:00-14:30, May Tu-Su 10:00-14:30; Jun Tu-Su 09:00-16:00; Jul Tu-Su 10:00-17:00; Aug Tu-Su 10:00-17:00; Sep Tu-Su 10:00-14:30; Oct Tu-Su 10:00-14:30 Nov off; Dec off" ist ein Fehler aufgetreten. Bitte melde diesen Fehler oder korrigiere diesen mittels eines Pull Requests oder Patches: https://github.com/opening-hours/opening_hours.js. Bug in warning generation code which could not determine the exact position of the warning or error in value.
-tokens_to_use[nrule][2] is undefined. This is ok if nrule is the last rule.
 "Real world example: Was not processed right" for "Jan off; Feb off; Mar off; Apr Tu-Su 10:00-14:30, May Tu-Su 10:00-14:30; Jun Tu-Su 09:00-16:00; Jul Tu-Su 10:00-17:00; Aug Tu-Su 10:00-17:00; Sep Tu-Su 10:00-14:30; Oct Tu-Su 10:00-14:30 Nov off; Dec off": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
-	*Jan off; Feb off; Mar off; Apr Tu-Su 10:00-14:30, May Tu-Su 10:00-14:30; Jun Tu-Su 09:00-16:00; Jul Tu-Su 10:00-17:00; Aug Tu-Su 10:00-17:00; Sep Tu-Su 10:00-14:30; Oct Tu-Su 10:00-14:30 Nov off; Dec off <--- (Du hast 2 nicht verbundene Monate in einer Regel benutzt. Das ist vermutlich ein Fehler. Gleiche Selektoren können (und sollten) immer zusammen und durch Kommas getrennt geschrieben werden. Beispiel für Zeitspannen "12:00-13:00,15:00-18:00". Beispiel für Wochentage "Mo-We,Fr". Einzelne Regeln können mit ";" getrennt werden.)
+	*Jan off; Feb off; Mar off; Apr Tu-Su 10:00-14:30, May Tu-Su 10:00-14:30; Jun Tu-Su 09:00-16:00; Jul Tu-Su 10:00-17:00; Aug Tu-Su 10:00-17:00; Sep Tu-Su 10:00-14:30; Oct Tu-Su 10:00-14:30 Nov  <--- (Du hast 2 nicht verbundene Monate in einer Regel benutzt. Das ist vermutlich ein Fehler. Gleiche Selektoren können (und sollten) immer zusammen und durch Kommas getrennt geschrieben werden. Beispiel für Zeitspannen "12:00-13:00,15:00-18:00". Beispiel für Wochentage "Mo-We,Fr". Einzelne Regeln können mit ";" getrennt werden.)
 "Real world example: Was not processed right" for "Nov-Mar off; Apr,May,Sep,Oct Tu-Su 10:00-14:30; Jun Tu-Su 09:00-16:00; Jul,Aug Tu-Su 10:00-17:00": [32m[1mPASSED[22m[39m
 "Real world example: Was not processed right" for "Nov-Mar off; Apr,May,Sep,Oct 10:00-14:30; Jun 09:00-16:00; Jul,Aug 10:00-17:00; Mo off": [32m[1mPASSED[22m[39m
 "Real world example: Was not processed right (test over a full year)" for "Jan off; Feb off; Mar off; Apr Tu-Su 10:00-14:30, May Tu-Su 10:00-14:30; Jun Tu-Su 09:00-16:00; Jul Tu-Su 10:00-17:00; Aug Tu-Su 10:00-17:00; Sep Tu-Su 10:00-14:30; Oct Tu-Su 10:00-14:30; Nov off; Dec off": [32m[1mPASSED[22m[39m
 "Real world example: Was not processed right (test over a full year)" for "Nov-Mar off; Apr,May,Sep,Oct Tu-Su 10:00-14:30; Jun Tu-Su 09:00-16:00; Jul,Aug Tu-Su 10:00-17:00": [32m[1mPASSED[22m[39m
 "Real world example: Was not processed right (test over a full year)" for "Nov-Mar off; Apr,May,Sep,Oct 10:00-14:30; Jun 09:00-16:00; Jul,Aug 10:00-17:00; Mo off": [32m[1mPASSED[22m[39m
-"Real world example: Was not processed right" for "Tu 10:00-12:00, Fr 16:00-18:00; unknown": [35m[1mCRASHED[22m[39m, reason: TypeError: Cannot read properties of undefined (reading '0')
+"Real world example: Was not processed right" for "Tu 10:00-12:00, Fr 16:00-18:00; unknown": [31m[1mFAILED[22m[39m, bad duration(s): 0,63072000000, expected 0,0, bad intervals: 
+[ '2014-01-01 00:00', '2016-01-01 00:00', true, undefined ],
+expected:
+(none), bad weekstable flag: true, expected false
+With [34m[1mwarnings[22m[39m:
+	*Tu 10:00-12:00, Fr 16:00-18:00; unknown <--- (Diese Regel, welche den Standard-Status (d.h. geschlossen) für alle folgenden Regeln ändert, ist nicht die erste Regel. Diese Regel überschreibt alle vorherigen Regeln. Es kann legitim sein, den Standard-Status z.B. auf geöffnet festzulegen und dann nur die Zeiten, zu denen geschlossen ist, anzugeben.)
 "Real world example: Problem with <additional_rule_separator> in holiday parser" for "PH; Aug-Sep 00:00-24:00": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
 	*PH <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
@@ -2582,7 +2607,7 @@ Der optional_conf_parm["tag_key"] fehlt, ist aber notwendig wegen optional_conf_
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-982/986 tests passed. 4 did not pass.
+984/986 tests passed. 2 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.en.log
+++ b/test/test.en.log
@@ -1389,13 +1389,37 @@ With [34m[1mwarnings[22m[39m:
 "Complex example used in README and benchmark" for "Mo,Tu,Th,Fr 12:00-18:00; Sa,PH 12:00-17:00; Th[3] off; Th[-1] off": [32m[1mPASSED[22m[39m
 "Complex example used in README and benchmark" for "Mo,Tu,Th,Fr 12:00-18:00; Sa,PH 12:00-17:00; Th[3],Th[-1] off": [32m[1mPASSED[22m[39m
 "Warnings corrected to additional rule (real world example)" for "Mo-Fr 09:00-12:00, Mo,Tu,Th 15:00-18:00": [32m[1mPASSED[22m[39m
-"Warnings corrected to additional rule (real world example)" for "Mo – Fr: 9 – 12 Uhr und Mo, Di, Do: 15 – 18 Uhr": [35m[1mCRASHED[22m[39m, reason: TypeError: Cannot read properties of undefined (reading '0')
+"Warnings corrected to additional rule (real world example)" for "Mo – Fr: 9 – 12 Uhr und Mo, Di, Do: 15 – 18 Uhr": [32m[1mPASSED[22m[39m
+With [34m[1mwarnings[22m[39m:
+	*Mo – <--- (Please use notation "-" for "–". Although using "–" is typographical correct, it is not defined in the opening_hours syntax. Correct typography should be done on application level …)
+	*Mo – Fr: 9 – <--- (Please use notation "-" for "–". Although using "–" is typographical correct, it is not defined in the opening_hours syntax. Correct typography should be done on application level …)
+	*Mo – Fr: 9 – 12 Uhr <--- (Please omit "uhr".)
+	*Mo – Fr: 9 – 12 Uhr und <--- (Please use notation "," for "und".)
+	*Mo – Fr: 9 – 12 Uhr und Mo, Di <--- (Please use the English abbreviation "Tu" for "di".)
+	*Mo – Fr: 9 – 12 Uhr und Mo, Di, Do <--- (Please use the English abbreviation "Th" for "do".)
+	*Mo – Fr: 9 – 12 Uhr und Mo, Di, Do: 15 – <--- (Please use notation "-" for "–". Although using "–" is typographical correct, it is not defined in the opening_hours syntax. Correct typography should be done on application level …)
+	*Mo – Fr: 9 – 12 Uhr und Mo, Di, Do: 15 – 18 Uhr <--- (Please omit "uhr".)
+	*Mo – Fr: 9 – 12 Uhr  <--- (Time range without minutes specified. Not very explicit! Please use this syntax instead "09:00-12:00".)
+	*Mo – Fr: 9 – 12 Uhr und Mo, Di, Do: 15 – 18 Uhr <--- (Time range without minutes specified. Not very explicit! Please use this syntax instead "15:00-18:00".)
+	*Mo – Fr:  <--- (You have used the optional symbol <separator_for_readability> in the wrong place. Please check the syntax specification to see where it could be used or remove it.)
+	*Mo – Fr: 9 – 12 Uhr und Mo, Di, Do:  <--- (You have used the optional symbol <separator_for_readability> in the wrong place. Please check the syntax specification to see where it could be used or remove it.)
 "Real world example: Was not processed right." for "Mo off, Tu 14:00-18:00, We-Sa 10:00-18:00": [32m[1mPASSED[22m[39m
 "Real world example: Was not processed right." for "Mo geschl., Tu 14:00-18:00, We-Sa 10:00-18:00": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
 	*Mo geschl <--- (Please use "off" for "geschl". Example: "Mo-Fr 08:00-12:00; Tu off".)
 	*Mo geschl. <--- (Please omit ".".)
-"Real world example: Was not processed right." for "Mo: geschlossen, Di: 14-18Uhr, Mi-Sa: 10-18Uhr": [35m[1mCRASHED[22m[39m, reason: TypeError: Cannot read properties of undefined (reading '0')
+"Real world example: Was not processed right." for "Mo: geschlossen, Di: 14-18Uhr, Mi-Sa: 10-18Uhr": [32m[1mPASSED[22m[39m
+With [34m[1mwarnings[22m[39m:
+	*Mo: geschlossen <--- (Please use "off" for "geschlossen". Example: "Mo-Fr 08:00-12:00; Tu off".)
+	*Mo: geschlossen, Di <--- (Please use the English abbreviation "Tu" for "di".)
+	*Mo: geschlossen, Di: 14-18Uhr <--- (Please omit "uhr".)
+	*Mo: geschlossen, Di: 14-18Uhr, Mi <--- (Please use the English abbreviation "We" for "mi".)
+	*Mo: geschlossen, Di: 14-18Uhr, Mi-Sa: 10-18Uhr <--- (Please omit "uhr".)
+	*Mo: geschlossen, Di: 14-18Uhr <--- (Time range without minutes specified. Not very explicit! Please use this syntax instead "14:00-18:00".)
+	*Mo: geschlossen, Di: 14-18Uhr, Mi-Sa: 10-18Uhr <--- (Time range without minutes specified. Not very explicit! Please use this syntax instead "10:00-18:00".)
+	*Mo:  <--- (You have used the optional symbol <separator_for_readability> in the wrong place. Please check the syntax specification to see where it could be used or remove it.)
+	*Mo: geschlossen, Di:  <--- (You have used the optional symbol <separator_for_readability> in the wrong place. Please check the syntax specification to see where it could be used or remove it.)
+	*Mo: geschlossen, Di: 14-18Uhr, Mi-Sa:  <--- (You have used the optional symbol <separator_for_readability> in the wrong place. Please check the syntax specification to see where it could be used or remove it.)
 "Real world example: Was not processed right." for "Mo off; Tu 14:00-18:00; We-Sa 10:00-18:00": [32m[1mPASSED[22m[39m
 "Real world example: Was not processed right (month range/monthday range)" for "Aug,Dec 25-easter": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
@@ -1430,19 +1454,20 @@ With [34m[1mwarnings[22m[39m:
 "Based on real world example: Is processed right." for "Apr-Oct: Sa-Su 08:00-15:00, May-Sep: 00:00-24:00": [32m[1mPASSED[22m[39m
 "Based on real world example: Is processed right." for "Apr-Oct: Sa-Su 08:00-15:00; May-Sep: 00:00-24:00": [32m[1mPASSED[22m[39m
 "Real world example: Was not processed right." for "Mo-Fr 07:00-19:30; Sa-Su 08:00-19:30 open, 19:30-21:00 open "No new laundry loads in"; Nov Th[4] off; Dec 25 off": [32m[1mPASSED[22m[39m
-An error occurred during evaluation of the value "Jan off; Feb off; Mar off; Apr Tu-Su 10:00-14:30, May Tu-Su 10:00-14:30; Jun Tu-Su 09:00-16:00; Jul Tu-Su 10:00-17:00; Aug Tu-Su 10:00-17:00; Sep Tu-Su 10:00-14:30; Oct Tu-Su 10:00-14:30 Nov off; Dec off". Please file a bug report or pull request: https://github.com/opening-hours/opening_hours.js. Bug in warning generation code which could not determine the exact position of the warning or error in value.
-tokens_to_use[nrule][2] is undefined. This is ok if nrule is the last rule.
-An error occurred during evaluation of the value "Jan off; Feb off; Mar off; Apr Tu-Su 10:00-14:30, May Tu-Su 10:00-14:30; Jun Tu-Su 09:00-16:00; Jul Tu-Su 10:00-17:00; Aug Tu-Su 10:00-17:00; Sep Tu-Su 10:00-14:30; Oct Tu-Su 10:00-14:30 Nov off; Dec off". Please file a bug report or pull request: https://github.com/opening-hours/opening_hours.js. Bug in warning generation code which could not determine the exact position of the warning or error in value.
-tokens_to_use[nrule][2] is undefined. This is ok if nrule is the last rule.
 "Real world example: Was not processed right" for "Jan off; Feb off; Mar off; Apr Tu-Su 10:00-14:30, May Tu-Su 10:00-14:30; Jun Tu-Su 09:00-16:00; Jul Tu-Su 10:00-17:00; Aug Tu-Su 10:00-17:00; Sep Tu-Su 10:00-14:30; Oct Tu-Su 10:00-14:30 Nov off; Dec off": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
-	*Jan off; Feb off; Mar off; Apr Tu-Su 10:00-14:30, May Tu-Su 10:00-14:30; Jun Tu-Su 09:00-16:00; Jul Tu-Su 10:00-17:00; Aug Tu-Su 10:00-17:00; Sep Tu-Su 10:00-14:30; Oct Tu-Su 10:00-14:30 Nov off; Dec off <--- (You have used 2 not connected months in one rule. This is probably an error. Equal selector types can (and should) always be written in conjunction separated by comma. Example for time ranges "12:00-13:00,15:00-18:00". Example for weekdays "Mo-We,Fr". Rules can be separated by ";".)
+	*Jan off; Feb off; Mar off; Apr Tu-Su 10:00-14:30, May Tu-Su 10:00-14:30; Jun Tu-Su 09:00-16:00; Jul Tu-Su 10:00-17:00; Aug Tu-Su 10:00-17:00; Sep Tu-Su 10:00-14:30; Oct Tu-Su 10:00-14:30 Nov  <--- (You have used 2 not connected months in one rule. This is probably an error. Equal selector types can (and should) always be written in conjunction separated by comma. Example for time ranges "12:00-13:00,15:00-18:00". Example for weekdays "Mo-We,Fr". Rules can be separated by ";".)
 "Real world example: Was not processed right" for "Nov-Mar off; Apr,May,Sep,Oct Tu-Su 10:00-14:30; Jun Tu-Su 09:00-16:00; Jul,Aug Tu-Su 10:00-17:00": [32m[1mPASSED[22m[39m
 "Real world example: Was not processed right" for "Nov-Mar off; Apr,May,Sep,Oct 10:00-14:30; Jun 09:00-16:00; Jul,Aug 10:00-17:00; Mo off": [32m[1mPASSED[22m[39m
 "Real world example: Was not processed right (test over a full year)" for "Jan off; Feb off; Mar off; Apr Tu-Su 10:00-14:30, May Tu-Su 10:00-14:30; Jun Tu-Su 09:00-16:00; Jul Tu-Su 10:00-17:00; Aug Tu-Su 10:00-17:00; Sep Tu-Su 10:00-14:30; Oct Tu-Su 10:00-14:30; Nov off; Dec off": [32m[1mPASSED[22m[39m
 "Real world example: Was not processed right (test over a full year)" for "Nov-Mar off; Apr,May,Sep,Oct Tu-Su 10:00-14:30; Jun Tu-Su 09:00-16:00; Jul,Aug Tu-Su 10:00-17:00": [32m[1mPASSED[22m[39m
 "Real world example: Was not processed right (test over a full year)" for "Nov-Mar off; Apr,May,Sep,Oct 10:00-14:30; Jun 09:00-16:00; Jul,Aug 10:00-17:00; Mo off": [32m[1mPASSED[22m[39m
-"Real world example: Was not processed right" for "Tu 10:00-12:00, Fr 16:00-18:00; unknown": [35m[1mCRASHED[22m[39m, reason: TypeError: Cannot read properties of undefined (reading '0')
+"Real world example: Was not processed right" for "Tu 10:00-12:00, Fr 16:00-18:00; unknown": [31m[1mFAILED[22m[39m, bad duration(s): 0,63072000000, expected 0,0, bad intervals: 
+[ '2014-01-01 00:00', '2016-01-01 00:00', true, undefined ],
+expected:
+(none), bad weekstable flag: true, expected false
+With [34m[1mwarnings[22m[39m:
+	*Tu 10:00-12:00, Fr 16:00-18:00; unknown <--- (This rule which changes the default state (which is closed) for all following rules is not the first rule. The rule will overwrite all previous rules. It can be legitimate to change the default state to open for example and then only specify for which times the facility is closed.)
 "Real world example: Problem with <additional_rule_separator> in holiday parser" for "PH; Aug-Sep 00:00-24:00": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
 	*PH <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
@@ -2575,7 +2600,7 @@ The optional_conf_parm["tag_key"] is missing, required by optional_conf_parm["ma
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-975/979 tests passed. 4 did not pass.
+977/979 tests passed. 2 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.en.log
+++ b/test/test.en.log
@@ -1462,10 +1462,7 @@ With [34m[1mwarnings[22m[39m:
 "Real world example: Was not processed right (test over a full year)" for "Jan off; Feb off; Mar off; Apr Tu-Su 10:00-14:30, May Tu-Su 10:00-14:30; Jun Tu-Su 09:00-16:00; Jul Tu-Su 10:00-17:00; Aug Tu-Su 10:00-17:00; Sep Tu-Su 10:00-14:30; Oct Tu-Su 10:00-14:30; Nov off; Dec off": [32m[1mPASSED[22m[39m
 "Real world example: Was not processed right (test over a full year)" for "Nov-Mar off; Apr,May,Sep,Oct Tu-Su 10:00-14:30; Jun Tu-Su 09:00-16:00; Jul,Aug Tu-Su 10:00-17:00": [32m[1mPASSED[22m[39m
 "Real world example: Was not processed right (test over a full year)" for "Nov-Mar off; Apr,May,Sep,Oct 10:00-14:30; Jun 09:00-16:00; Jul,Aug 10:00-17:00; Mo off": [32m[1mPASSED[22m[39m
-"Real world example: Was not processed right" for "Tu 10:00-12:00, Fr 16:00-18:00; unknown": [31m[1mFAILED[22m[39m, bad duration(s): 0,63072000000, expected 0,0, bad intervals: 
-[ '2014-01-01 00:00', '2016-01-01 00:00', true, undefined ],
-expected:
-(none), bad weekstable flag: true, expected false
+"Real world example: Was not processed right" for "Tu 10:00-12:00, Fr 16:00-18:00; unknown": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
 	*Tu 10:00-12:00, Fr 16:00-18:00; unknown <--- (This rule which changes the default state (which is closed) for all following rules is not the first rule. The rule will overwrite all previous rules. It can be legitimate to change the default state to open for example and then only specify for which times the facility is closed.)
 "Real world example: Problem with <additional_rule_separator> in holiday parser" for "PH; Aug-Sep 00:00-24:00": [32m[1mPASSED[22m[39m
@@ -2600,7 +2597,7 @@ The optional_conf_parm["tag_key"] is missing, required by optional_conf_parm["ma
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-977/979 tests passed. 2 did not pass.
+978/979 tests passed. 1 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.js
+++ b/test/test.js
@@ -4454,7 +4454,8 @@ test.addTest('Real world example: Was not processed right (test over a full year
 test.addTest('Real world example: Was not processed right', [
         'Tu 10:00-12:00, Fr 16:00-18:00; unknown',
     ], '2014-01-01 0:00', '2016-01-01 0:00', [
-    ], 0, 0, false, {}, 'not last test');
+        [ '2014-01-01 0:00', '2016-01-01 0:00', true ],
+    ], 0, 1000 * 60 * 60 * 24 * 365 * 2, true, {}, 'not last test');
 
 /* https://github.com/opening-hours/opening_hours.js/issues/75 {{{ */
 test.addTest('Real world example: Problem with <additional_rule_separator> in holiday parser', [


### PR DESCRIPTION
While working on #583 I noticed that values with Additional Rules can crash `getWarnings()` with a `TypeError`.

So I dug into it and found that `formatWarnErrorMessage` defaults to `tokens` when no 4th argument is passed. But `getWarnings()` indexes into `new_tokens`, which can be larger - a rule like `"Mo-Fr 08:00-18:00, Sa 10:00-14:00"` is 1 entry in `tokens` but 2 in `new_tokens`.
All 7 push calls inside `getWarnings()` were missing that argument, so any Additional Rule that triggered a warning would crash.

Fix: pass `new_tokens` explicitly in all 7 push sites, add a guard for the undefined case so it degrades gracefully, and clean up the JSDoc to explain the distinction.

The test suite goes from 972/976 to 975/976 passing - 3 tests that previously crashed now pass. The assertions for `"Tu 10:00-12:00, Fr 16:00-18:00; unknown"` are corrected along the way (they were wrong from the start, hidden by the crash).

---

Note: While digging through this I also noticed that `nrule` serves as three different things (rule index, -1 for tokenizer errors, or a pre-formatted string), which probably made the `tokens`/`new_tokens` confusion easier to miss. Might be worth untangling at some point, but it would be a refactor and is out of scope for this PR,