### PR TITLE
fix(parser): reject mixed monthday/week comma rules

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3757,6 +3757,8 @@ export default function(value, nominatim_object, optional_conf_parm) {
                 at = parseMonthRange(tokens, at);
             } else if (matchTokens(tokens, at, 'month')) {
                 return parseMonthRange(tokens, at, true, true);
+            } else if (matchTokens(tokens, at - 1, ',')) { // additional rule
+                throw formatWarnErrorMessage(nrule, at - 1, t('additional rule no sense'));
             } else {
                 // throw 'Unexpected token in monthday range: "' + tokens[at] + '"';
                 return at;

--- a/test/test.de.log
+++ b/test/test.de.log
@@ -2351,7 +2351,9 @@ We,  <--- (Eine weitere Regel an dieser Stelle ergibt keinen Sinn. Benutze einfa
 "Incorrect syntax which should throw an error" for "week 05, Aug Mo; 00:23-00:42 unknown "warning at correct position?"": [32m[1mPASSED[22m[39m
 week 05,  <--- (Eine weitere Regel an dieser Stelle ergibt keinen Sinn. Benutze einfach ";" als Trenner für Regeln. Siehe https://wiki.openstreetmap.org/wiki/Key:opening_hours/specification#explain:additional_rule_separator)
 
-"Incorrect syntax which should throw an error" for "Jun 02-5, week 05 00:00-24:00; 00:23-00:42 unknown "warning at correct position?"": [31m[1mFAILED[22m[39m
+"Incorrect syntax which should throw an error" for "Jun 02-5, week 05 00:00-24:00; 00:23-00:42 unknown "warning at correct position?"": [32m[1mPASSED[22m[39m
+Jun 02-5,  <--- (Eine weitere Regel an dieser Stelle ergibt keinen Sinn. Benutze einfach ";" als Trenner für Regeln. Siehe https://wiki.openstreetmap.org/wiki/Key:opening_hours/specification#explain:additional_rule_separator)
+
 "Incorrect syntax which should throw an error" for "Jan 00; 00:23-00:42 unknown "warning at correct position?"": [32m[1mPASSED[22m[39m
 Jan 00 <--- (Die Tagesangabe für Jan muss zwischen 1 und 31 liegen.)
 
@@ -2604,7 +2606,7 @@ Der optional_conf_parm["tag_key"] fehlt, ist aber notwendig wegen optional_conf_
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-985/986 tests passed. 1 did not pass.
+986/986 tests passed. 0 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.en.log
+++ b/test/test.en.log
@@ -2351,7 +2351,9 @@ We,  <--- (An additional rule does not make sense here. Just use a ";" as rule s
 "Incorrect syntax which should throw an error" for "week 05, Aug Mo; 00:23-00:42 unknown "warning at correct position?"": [32m[1mPASSED[22m[39m
 week 05,  <--- (An additional rule does not make sense here. Just use a ";" as rule separator. See https://wiki.openstreetmap.org/wiki/Key:opening_hours/specification#explain:additional_rule_separator)
 
-"Incorrect syntax which should throw an error" for "Jun 02-5, week 05 00:00-24:00; 00:23-00:42 unknown "warning at correct position?"": [31m[1mFAILED[22m[39m
+"Incorrect syntax which should throw an error" for "Jun 02-5, week 05 00:00-24:00; 00:23-00:42 unknown "warning at correct position?"": [32m[1mPASSED[22m[39m
+Jun 02-5,  <--- (An additional rule does not make sense here. Just use a ";" as rule separator. See https://wiki.openstreetmap.org/wiki/Key:opening_hours/specification#explain:additional_rule_separator)
+
 "Incorrect syntax which should throw an error" for "Jan 00; 00:23-00:42 unknown "warning at correct position?"": [32m[1mPASSED[22m[39m
 Jan 00 <--- (The day for Jan must be between 1 and 31.)
 
@@ -2597,7 +2599,7 @@ The optional_conf_parm["tag_key"] is missing, required by optional_conf_parm["ma
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-978/979 tests passed. 1 did not pass.
+979/979 tests passed. 0 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet


### PR DESCRIPTION
The last failing parser test had been bugging me, so I went digging for the cause.

The issue was in parseMonthdayRange: after a comma, it sometimes accepted an incompatible selector (for example week) instead of failing with additional rule no sense like the other parsers.

So I aligned it with the rest. That was the last failing parser test :smiley: 