### PR TITLE
fix(i18n): accept underscore in locale separator

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ import word_error_correction from './locales/word_error_correction.yaml';
 import lang from './locales/lang.yaml';
 
 import SunCalc from 'suncalc';
-import i18n from './locales/i18n';
+import i18n, { normalizeLocale } from './locales/i18n';
 
 export default function(value, nominatim_object, optional_conf_parm) {
     // Short constants {{{
@@ -131,8 +131,8 @@ export default function(value, nominatim_object, optional_conf_parm) {
     /* }}} */
 
     /* Translation function {{{ */
-    let locale = 'en'; // Default locale
-    locale = i18n.language;
+    // Initialize from i18n.language; optional_conf_parm.locale overrides it.
+    let locale = normalizeLocale(i18n.language);
 
     const t = function(str, variables) {
         // Use i18n for German and French translations, fallback to built-in lang for others
@@ -221,8 +221,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
         oh_mode = optional_conf_parm;
     } else if (typeof optional_conf_parm === 'object') {
         if (typeof optional_conf_parm['locale'] === 'string') {
-            /* TODO: The split thing is obviously a workaround. */
-            locale = optional_conf_parm['locale'].split('-')[0];
+            locale = normalizeLocale(optional_conf_parm['locale']);
         }
         if (checkOptionalConfParm('mode', 'number')) {
             oh_mode = optional_conf_parm['mode'];

--- a/src/locales/i18n.js
+++ b/src/locales/i18n.js
@@ -7,6 +7,19 @@ import opening_hours_resources from './opening_hours_resources.yaml';
 
 const resources = opening_hours_resources;
 
+/**
+ * Normalize a locale string to the base language used for translation lookup.
+ *
+ * Accepts BCP 47 locale tags (e.g. de-DE) and POSIX locale identifiers per ISO 15897 (e.g. de_DE).
+ * Returns the base language subtag (usually ISO 639).
+ *
+ * @param {string} localeString - Locale string like 'de', 'de-DE' or 'de_DE'.
+ * @returns {string} Base language, e.g. 'de'.
+ */
+export function normalizeLocale(localeString) {
+    return localeString.split(/[-_]/)[0];
+}
+
 // Simple i18n object compatible with the minimal features used in src/index.js
 const i18n = {
     language: 'en',


### PR DESCRIPTION
Locale tags like 'de_DE' were ignored because the lookup only handled the hyphen form 'de-DE', so German fell back to English.

I've build a small `normalizeLocale()` helper in `i18n.js` that accepts both forms and reduces to the base language, and use it for both the default locale and the one from `optional_conf_parm`.

I still see some potential for refactoring when it comes to i18n, but I don't want to mix refactoring too much with fixes in one PR.

Ref #480