### PR TITLE
refactor(i18n): simplify translations

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,10 +32,9 @@
  */
 import * as holiday_definitions from './holidays/index';
 import word_error_correction from './locales/word_error_correction.yaml';
-import lang from './locales/lang.yaml';
 
 import SunCalc from 'suncalc';
-import i18n, { normalizeLocale } from './locales/i18n';
+import { translate } from './locales/i18n';
 
 export default function(value, nominatim_object, optional_conf_parm) {
     // Short constants {{{
@@ -131,35 +130,13 @@ export default function(value, nominatim_object, optional_conf_parm) {
     /* }}} */
 
     /* Translation function {{{ */
-    // Initialize from i18n.language; optional_conf_parm.locale overrides it.
-    let locale = normalizeLocale(i18n.language);
+    // Parser messages use the `texts` translations. Pretty output translates separately.
+    const parser_locale = optional_conf_parm && typeof optional_conf_parm['locale'] === 'string'
+        ? optional_conf_parm['locale']
+        : 'en';
 
-    const t = function(str, variables) {
-        // Use i18n for German and French translations, fallback to built-in lang for others
-        if (typeof locale === 'string' && ['de', 'fr'].indexOf(locale) !== -1) {
-            let translatorFunction;
-            if (i18n.language !== locale) {
-                translatorFunction = i18n.getFixedT(locale);
-            } else {
-                translatorFunction = i18n.t;
-            }
-            const text = translatorFunction('opening_hours:texts.' + str, variables);
-            return text;
-        }
-
-        // Fallback for non-German locales
-        let text = lang[str];
-        if (typeof text === 'undefined') {
-            text = str;
-        }
-        return text.replace(/{{([^{}]*)}}/g, function (match, c) {
-            return typeof variables[c] !== 'undefined'
-                ? variables[c]
-                : match
-                ;
-            }
-        );
-    };
+    // Parser errors and warnings only need message translations.
+    const t = (key, variables) => translate(parser_locale, 'texts', key, variables);
     /* }}} */
 
     /* Optional constructor parameters {{{ */
@@ -220,9 +197,6 @@ export default function(value, nominatim_object, optional_conf_parm) {
     if (typeof optional_conf_parm === 'number') {
         oh_mode = optional_conf_parm;
     } else if (typeof optional_conf_parm === 'object') {
-        if (typeof optional_conf_parm['locale'] === 'string') {
-            locale = normalizeLocale(optional_conf_parm['locale']);
-        }
         if (checkOptionalConfParm('mode', 'number')) {
             oh_mode = optional_conf_parm['mode'];
         }
@@ -1371,15 +1345,9 @@ export default function(value, nominatim_object, optional_conf_parm) {
                     }
                 );
             }
-            const old_prettified_value_length = prettified_value.length;
+            const shouldTranslatePrettyOutput = typeof user_conf['locale'] === 'string' && user_conf['locale'] !== 'en';
 
-            if (typeof user_conf['locale'] === 'string' && user_conf['locale'] !== 'en') {
-                let translatorFunction;
-                if (i18n.language !== user_conf['locale']) {
-                    translatorFunction = i18n.getFixedT(user_conf['locale']);
-                } else {
-                    translatorFunction = i18n.t.bind(i18n);
-                }
+            if (shouldTranslatePrettyOutput) {
                 for (let i = 0; i < prettified_group_value.length; i++) {
                     const type = prettified_group_value[i][0][2];
                     if (type === 'weekday') {
@@ -1393,11 +1361,13 @@ export default function(value, nominatim_object, optional_conf_parm) {
                     } else {
                         const prettifiedValueIsProbablyTranslatable = prettified_group_value[i][1].indexOf(':') === -1;
                         if (prettifiedValueIsProbablyTranslatable) {
-                            prettified_group_value[i][1] = translatorFunction(['opening_hours:pretty.' + prettified_group_value[i][1], prettified_group_value[i][1]]);
+                            prettified_group_value[i][1] = translate(user_conf['locale'], 'pretty', prettified_group_value[i][1]);
                         }
                     }
                 }
             }
+
+            const old_prettified_value_length = prettified_value.length;
 
             prettified_value += prettified_group_value.map(function (array) {
                 return array[1];

--- a/src/locales/i18n.js
+++ b/src/locales/i18n.js
@@ -3,78 +3,106 @@
  *
  * SPDX-License-Identifier: LGPL-3.0-only
  */
-import opening_hours_resources from './opening_hours_resources.yaml';
+import resources from './opening_hours_resources.yaml';
+import lang from './lang.yaml';
 
-const resources = opening_hours_resources;
+// Merge English texts into the shared resource tree.
+// Other locales live in opening_hours_resources.yaml; English texts are in lang.yaml.
+resources.en.opening_hours.texts = lang;
 
 /**
- * Normalize a locale string to the base language used for translation lookup.
+ * Replace `{{varName}}` (or `{{-varName}}`) placeholders in a translation string.
+ * The `-` prefix is a legacy i18next no-HTML-escape marker; it has no effect here.
  *
- * Accepts BCP 47 locale tags (e.g. de-DE) and POSIX locale identifiers per ISO 15897 (e.g. de_DE).
- * Returns the base language subtag (usually ISO 639).
- *
- * @param {string} localeString - Locale string like 'de', 'de-DE' or 'de_DE'.
- * @returns {string} Base language, e.g. 'de'.
+ * @param {string} str  - Translation string containing `{{…}}` placeholders.
+ * @param {Object} vars - Map of placeholder names to replacement values.
+ * @returns {string}
  */
-export function normalizeLocale(localeString) {
-    return localeString.split(/[-_]/)[0];
+function interpolate(str, vars) {
+    return str.replace(/{{-?([^{}]*)}}/g, function(match, varName) {
+        const name = varName.trim();
+        if (name in vars) {
+            return vars[name];
+        }
+        return match;
+    });
 }
 
-// Simple i18n object compatible with the minimal features used in src/index.js
-const i18n = {
-    language: 'en',
-    isInitialized: true,
-
-    t: function(key, variables) {
-        return this._translate(this.language, key, variables);
-    },
-
-    getFixedT: function(locale) {
-        const self = this;
-        return function(key, variables) {
-            return self._translate(locale, key, variables);
-        };
-    },
-
-    _translate: function(locale, key, variables) {
-        // Handle array of keys (fallback mechanism)
-        const keys = Array.isArray(key) ? key : [key];
-
-        for (const k of keys) {
-            // Parse namespace:path notation (e.g., "opening_hours:pretty.off")
-            const parts = k.split(':');
-            const namespace = parts.length > 1 ? parts[0] : 'opening_hours';
-            const path = parts.length > 1 ? parts[1] : parts[0];
-
-            // Try to get translation
-            const translation = this._getNestedValue(resources, [locale, namespace, ...path.split('.')]);
-
-            if (translation !== undefined) {
-                // Replace variables like {{variable}} or {{-variable}}
-                // The minus prefix means "don't escape HTML" (compatibility feature)
-                if (typeof translation === 'string' && variables) {
-                    return translation.replace(/{{-?([^{}]*)}}/g, function (match, varName) {
-                        const trimmed = varName.trim();
-                        return typeof variables[trimmed] !== 'undefined' ? variables[trimmed] : match;
-                    });
-                }
-                return translation;
-            }
-        }
-
-        // Fallback: return the last key if no translation found
-        const lastKey = keys[keys.length - 1];
-        return lastKey.includes(':') ? lastKey.split(':')[1] : lastKey;
-    },
-
-    _getNestedValue: function(obj, path) {
-        let current = obj;
-        for (const key of path) {
-            if (current === undefined || current === null) return undefined;
-            current = current[key];
-        }
-        return current;
+/**
+ * Extract the base language subtag from a locale tag (e.g. 'de-DE' → 'de').
+ *
+ * Accepts BCP 47 tags (e.g. 'de-DE') and POSIX identifiers per ISO 15897 (e.g. 'de_DE').
+ * For non-strings, returns 'en' (the default fallback locale).
+ *
+ * @param {string|null|undefined} locale - Locale tag.
+ * @returns {string} Base language, e.g. 'de'.
+ */
+function baseLanguage(locale) {
+    if (locale && typeof locale === 'string') {
+        return locale.split(/[-_]/)[0];
     }
-};
+    return 'en';
+}
 
-export default i18n;
+/**
+ * Build the locale fallback chain for a given locale tag.
+ *
+ * 'de-DE' → ['de-DE', 'de', 'en']
+ * 'de'    → ['de', 'en']
+ * null    → ['en']
+ *
+ * @param {string|null|undefined} locale - BCP 47 locale tag.
+ * @returns {string[]}
+ */
+function localeChain(locale) {
+    const base = baseLanguage(locale);
+    // Deduplicate entries like ['de', 'de', 'en'] or ['en', 'en'].
+    return [...new Set([locale, base, 'en'].filter(Boolean))];
+}
+
+/**
+ * Walk the resource tree for the first locale in the fallback chain that has
+ * a translation for the given key.
+ *
+ * Tree shape: resources[locale].opening_hours[section][key]
+ *
+ * @param {string|null|undefined} locale  - BCP 47 locale tag.
+ * @param {string}                section - 'texts' or 'pretty'.
+ * @param {string}                key     - Translation key (dot-separated for nesting).
+ * @returns {*} Matched value, or `undefined` if not found anywhere in the chain.
+ */
+function lookup(locale, section, key) {
+    const keyPath = key.split('.');
+    for (const loc of localeChain(locale)) {
+        // Navigate to resources[locale].opening_hours[section], then drill down by key path.
+        let value = resources[loc]?.opening_hours?.[section];
+        for (const segment of keyPath) value = value?.[segment];
+        // Return as soon as we find a value defined by the resource tree.
+        if (value !== undefined) return value;
+    }
+    return undefined;
+}
+
+/**
+ * Translate a key into the requested locale, falling back through the locale
+ * chain to English. Returns the key itself when no translation is found.
+ *
+ * @param {string|null|undefined} locale  - BCP 47 locale tag (e.g. 'de', 'de-DE').
+ * @param {string}                section - 'texts' (error/warning messages) or
+ *                                          'pretty' (prettified output tokens).
+ * @param {string}                key     - Translation key (dot-separated for nesting).
+ * @param {Object}               [vars]   - Variables to interpolate via `{{varName}}`.
+ * @returns {string}
+ */
+export function translate(locale, section, key, vars) {
+    const result = lookup(locale, section, key);
+
+    if (typeof result === 'string') {
+        if (vars) {
+            return interpolate(result, vars);
+        }
+        return result;
+    }
+
+    return key;
+}


### PR DESCRIPTION
This PR simplifies how translations are resolved.

Instead of keeping a small i18next-like wrapper around the translation files, the parser now uses a direct `translate()` helper. Locale fallback is handled in one place, which makes the translation flow easier to read and removes some special-case code from the parser.

I still see more refactor potential on i18n, but this is already a big change to review.
