### PR TITLE
fix(parser): reject ambiguous season words

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -79,6 +79,11 @@ export default function(value, nominatim_object, optional_conf_parm) {
         'off': [ 'off', 'state' ],
         'unknown': [ 'unknown', 'state' ],
     }
+    const ambiguous_season_words = new Set([
+        'spring', 'summer', 'autumn', 'winter', // en
+        'frühling', 'fruehling', 'frühjahr', 'sommer', 'herbst', // de
+        'primavera', 'estate', 'autunno', 'inverno', // it
+    ]);
 
     const default_prettify_conf = {
         // Update README.md if changed.
@@ -652,7 +657,8 @@ export default function(value, nominatim_object, optional_conf_parm) {
                  * mo|tu|we|th|fr|sa|su|jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec: Prefer defended keywords
                  * if used in cases like 'mo12:00-14:00' (when keyword is followed by number).
                  */
-                let correct_val = returnCorrectWordOrToken(tmp[1].toLowerCase(), value.length);
+                const lower_word = tmp[1].toLowerCase();
+                let correct_val = returnCorrectWordOrToken(lower_word, value.length);
                 // console.log('Error tolerance for string "' + tmp[1] + '" returned "' + correct_val + '".');
                 if (typeof correct_val === 'object') {
                     curr_rule_tokens.push([ correct_val[0], correct_val[1], value.length ]);
@@ -699,6 +705,13 @@ export default function(value, nominatim_object, optional_conf_parm) {
                     // value = correct_val + value.substr(tmp[0].length);
                     // Does not work because it would generate the wrong length for formatWarnErrorMessage.
                 } else {
+                    if (ambiguous_season_words.has(lower_word)) {
+                        throw formatWarnErrorMessage(
+                            -1,
+                            value.length - tmp[0].length,
+                            t('season words ambiguous')
+                        );
+                    }
                     // No correction available. Insert as single character token and let the parser handle the error.
                     curr_rule_tokens.push([value[0].toLowerCase(), value[0].toLowerCase(), value.length - 1 ]);
                     value = value.substr(1);

--- a/src/locales/translations.yaml
+++ b/src/locales/translations.yaml
@@ -5,6 +5,7 @@
 en:
   texts:
     'unexpected token': 'Unexpected token: "{{token}}" This means that the syntax is not valid at that point or it is currently not supported.'
+    'season words ambiguous': 'Season words are ambiguous. Please use explicit date ranges instead, e.g. Jun-Aug, Dec-Feb, or Jun 21-Sep 22.'
     'no string': 'The value (first parameter) is not a string.'
     'nothing': 'The value contains nothing meaningful which can be parsed.'
     'nothing useful': 'This rule does not contain anything useful. Please remove this empty rule.'
@@ -136,6 +137,7 @@ en:
 de:
   texts:
     unexpected token: "Unerwartetes Zeichen: \"{{token}}\" Das bedeutet, dass die Syntax an dieser Stelle nicht erkannt werden konnte."
+    'season words ambiguous': 'Saisonwörter sind mehrdeutig. Bitte verwende stattdessen explizite Datumsbereiche, z. B. Jun-Aug, Dec-Feb oder Jun 21-Sep 22.'
     no string: "Der Wert (erster Parameter) ist kein String"
     nothing: "Der Wert enthält nichts, was ausgewertet werden könnte."
     nothing useful: "Diese Regel enthält nichts nützliches. Bitte entferne diese leere Regel."
@@ -296,6 +298,7 @@ fi:
 fr:
   texts:
     unexpected token: "Caractère inattendu : \"{{token}}\" — la syntaxe à cet endroit n'a pas pu être reconnue."
+    'season words ambiguous': 'Les mots de saison sont ambigus. Veuillez utiliser des plages de dates explicites, par exemple Jun-Aug, Dec-Feb ou Jun 21-Sep 22.'
     no string: "La valeur (premier paramètre) n'est pas une chaîne de caractères."
     nothing: "La valeur ne contient rien qui puisse être évalué."
     nothing useful: "Cette règle ne contient rien d'utile. Veuillez supprimer cette règle vide."

--- a/src/locales/word_error_correction.yaml
+++ b/src/locales/word_error_correction.yaml
@@ -8,26 +8,14 @@
 
 "assuming ok for ko":
   "daytime": "sunrise-sunset"
-  "spring": "Mar-May"
-  "summer": "Jun-Aug"
-  "autumn": "Sep-Nov"
-  "winter": "Dec-Feb"
   "_": "-"
   "=": "-"
-  "frühling": "Mar-May"
-  "frühjahr": "Mar-May"
-  "sommer": "Jun-Aug"
-  "herbst": "Sep-Nov"
   "gesloten": "off"
   "feestdag": "PH"
   "feestdagen": "PH"
   "m": "Mo"
   "w": "We"
   "f": "Fr"
-  "primavera": "Mar-May"
-  "estate": "Jun-Aug"
-  "autunno": "Sep-Nov"
-  "inverno": "Dec-Feb"
 "please use English written ok for ko":
   "(?:an )?feiertag(?:s|en?)?": "PH"
 "please use off for ko":

--- a/src/locales/word_error_correction_manual.yaml
+++ b/src/locales/word_error_correction_manual.yaml
@@ -8,17 +8,8 @@
 
 'assuming ok for ko':
   daytime: sunrise-sunset
-  spring: Mar-May
-  summer: Jun-Aug
-  autumn: Sep-Nov
-  winter: Dec-Feb
   _: '-'
   '=': '-'
-  frühling: Mar-May
-  frühjahr: Mar-May
-  sommer: Jun-Aug
-  herbst: Sep-Nov
-  # winter: Dec-Feb # Same as in English.
   gesloten: 'off'
   feestdag: PH
   feestdagen: PH
@@ -28,11 +19,6 @@
   # TODO: Needs code refactor to support this.
   # außer: '; off'
 
-  # Italian
-  primavera: Mar-May
-  estate: Jun-Aug
-  autunno: Sep-Nov
-  inverno: Dec-Feb
 'please use English written ok for ko':
   '(?:an )?feiertag(?:s|en?)?': PH
 'please use off for ko':

--- a/test/test.de.log
+++ b/test/test.de.log
@@ -1471,14 +1471,6 @@ With [34m[1mwarnings[22m[39m:
 "Real world example: Problem with <additional_rule_separator> in holiday parser" for "We off; Mo,Tu,Th-Su,PH; Jun-Aug We 11:00-14:00,17:00+": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
 	*We off; Mo,Tu,Th-Su,PH <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
-"Real world example: Problem with <additional_rule_separator> in holiday parser" for "We off; Mo,Tu,Th-Su,PH; Sommer We 11:00-14:00,17:00+": [32m[1mPASSED[22m[39m
-With [34m[1mwarnings[22m[39m:
-	*We off; Mo,Tu,Th-Su,PH; Sommer <--- ("sommer" wird als "Jun-Aug" interpretiert.)
-	*We off; Mo,Tu,Th-Su,PH <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
-"Real world example: Problem with <additional_rule_separator> in holiday parser" for "We off; Mo,Tu,Th-Su,PH; sommer We 11:00-14:00,17:00+": [32m[1mPASSED[22m[39m
-With [34m[1mwarnings[22m[39m:
-	*We off; Mo,Tu,Th-Su,PH; sommer <--- ("sommer" wird als "Jun-Aug" interpretiert.)
-	*We off; Mo,Tu,Th-Su,PH <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
 "Real world example: Problem with <additional_rule_separator> in holiday parser" for "Mo,Tu,Th-Su,PH 00:00-24:00; Jun-Aug We 11:00-14:00,17:00+": [32m[1mPASSED[22m[39m
 "Real world example: Problem with daylight saving?" for "Mo-Su,PH 15:00-03:00; easter -2 days 15:00-24:00": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
@@ -2043,6 +2035,24 @@ With [34m[1mwarnings[22m[39m:
 "Structured warning: word error correction has stable type" for "Mon": [32m[1mPASSED[22m[39m
 "Structured warning: no warnings yields empty list" for "Mo 10:00-12:00": [32m[1mPASSED[22m[39m
 "Structured warning: multiple warnings keep distinct positions" for "Mo 10-12; Tu 14-16": [32m[1mPASSED[22m[39m
+"Season words should fail with explicit date-range guidance" for "We off; Mo,Tu,Th-Su,PH; spring We 11:00-14:00,17:00+": [32m[1mPASSED[22m[39m
+We off; Mo,Tu,Th-Su,PH; spring <--- (Saisonwörter sind mehrdeutig. Bitte verwende stattdessen explizite Datumsbereiche, z. B. Jun-Aug, Dec-Feb oder Jun 21-Sep 22.)
+
+"Season words should fail with explicit date-range guidance" for "We off; Mo,Tu,Th-Su,PH; winter We 11:00-14:00,17:00+": [32m[1mPASSED[22m[39m
+We off; Mo,Tu,Th-Su,PH; winter <--- (Saisonwörter sind mehrdeutig. Bitte verwende stattdessen explizite Datumsbereiche, z. B. Jun-Aug, Dec-Feb oder Jun 21-Sep 22.)
+
+"Season words should fail with explicit date-range guidance" for "We off; Mo,Tu,Th-Su,PH; Frühling We 11:00-14:00,17:00+": [32m[1mPASSED[22m[39m
+We off; Mo,Tu,Th-Su,PH; Frühling <--- (Saisonwörter sind mehrdeutig. Bitte verwende stattdessen explizite Datumsbereiche, z. B. Jun-Aug, Dec-Feb oder Jun 21-Sep 22.)
+
+"Season words should fail with explicit date-range guidance" for "We off; Mo,Tu,Th-Su,PH; Fruehling We 11:00-14:00,17:00+": [32m[1mPASSED[22m[39m
+We off; Mo,Tu,Th-Su,PH; Fruehling <--- (Saisonwörter sind mehrdeutig. Bitte verwende stattdessen explizite Datumsbereiche, z. B. Jun-Aug, Dec-Feb oder Jun 21-Sep 22.)
+
+"Season words should fail with explicit date-range guidance" for "We off; Mo,Tu,Th-Su,PH; FRÜHLING We 11:00-14:00,17:00+": [32m[1mPASSED[22m[39m
+We off; Mo,Tu,Th-Su,PH; FRÜHLING <--- (Saisonwörter sind mehrdeutig. Bitte verwende stattdessen explizite Datumsbereiche, z. B. Jun-Aug, Dec-Feb oder Jun 21-Sep 22.)
+
+"Season words should fail with explicit date-range guidance" for "We off; Mo,Tu,Th-Su,PH; primavera We 11:00-14:00,17:00+": [32m[1mPASSED[22m[39m
+We off; Mo,Tu,Th-Su,PH; primavera <--- (Saisonwörter sind mehrdeutig. Bitte verwende stattdessen explizite Datumsbereiche, z. B. Jun-Aug, Dec-Feb oder Jun 21-Sep 22.)
+
 "Incorrect syntax which should throw an error" for "Mo-Fr 17:00-12:00; Sa-Su 24:00-12:00": [32m[1mPASSED[22m[39m
 Mo-Fr 17:00-12:00; Sa-Su 24:00 <--- (Zeitspanne beginnt außerhalb des aktuellen Tages)
 
@@ -2610,7 +2620,7 @@ Der optional_conf_parm["tag_key"] fehlt, ist aber notwendig wegen optional_conf_
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-990/990 tests passed. 0 did not pass.
+994/994 tests passed. 0 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.en.log
+++ b/test/test.en.log
@@ -1471,14 +1471,6 @@ With [34m[1mwarnings[22m[39m:
 "Real world example: Problem with <additional_rule_separator> in holiday parser" for "We off; Mo,Tu,Th-Su,PH; Jun-Aug We 11:00-14:00,17:00+": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
 	*We off; Mo,Tu,Th-Su,PH <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
-"Real world example: Problem with <additional_rule_separator> in holiday parser" for "We off; Mo,Tu,Th-Su,PH; Sommer We 11:00-14:00,17:00+": [32m[1mPASSED[22m[39m
-With [34m[1mwarnings[22m[39m:
-	*We off; Mo,Tu,Th-Su,PH; Sommer <--- (Assuming "Jun-Aug" for "sommer".)
-	*We off; Mo,Tu,Th-Su,PH <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
-"Real world example: Problem with <additional_rule_separator> in holiday parser" for "We off; Mo,Tu,Th-Su,PH; sommer We 11:00-14:00,17:00+": [32m[1mPASSED[22m[39m
-With [34m[1mwarnings[22m[39m:
-	*We off; Mo,Tu,Th-Su,PH; sommer <--- (Assuming "Jun-Aug" for "sommer".)
-	*We off; Mo,Tu,Th-Su,PH <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
 "Real world example: Problem with <additional_rule_separator> in holiday parser" for "Mo,Tu,Th-Su,PH 00:00-24:00; Jun-Aug We 11:00-14:00,17:00+": [32m[1mPASSED[22m[39m
 "Real world example: Problem with daylight saving?" for "Mo-Su,PH 15:00-03:00; easter -2 days 15:00-24:00": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
@@ -2043,6 +2035,24 @@ With [34m[1mwarnings[22m[39m:
 "Structured warning: word error correction has stable type" for "Mon": [32m[1mPASSED[22m[39m
 "Structured warning: no warnings yields empty list" for "Mo 10:00-12:00": [32m[1mPASSED[22m[39m
 "Structured warning: multiple warnings keep distinct positions" for "Mo 10-12; Tu 14-16": [32m[1mPASSED[22m[39m
+"Season words should fail with explicit date-range guidance" for "We off; Mo,Tu,Th-Su,PH; spring We 11:00-14:00,17:00+": [32m[1mPASSED[22m[39m
+We off; Mo,Tu,Th-Su,PH; spring <--- (Season words are ambiguous. Please use explicit date ranges instead, e.g. Jun-Aug, Dec-Feb, or Jun 21-Sep 22.)
+
+"Season words should fail with explicit date-range guidance" for "We off; Mo,Tu,Th-Su,PH; winter We 11:00-14:00,17:00+": [32m[1mPASSED[22m[39m
+We off; Mo,Tu,Th-Su,PH; winter <--- (Season words are ambiguous. Please use explicit date ranges instead, e.g. Jun-Aug, Dec-Feb, or Jun 21-Sep 22.)
+
+"Season words should fail with explicit date-range guidance" for "We off; Mo,Tu,Th-Su,PH; Frühling We 11:00-14:00,17:00+": [32m[1mPASSED[22m[39m
+We off; Mo,Tu,Th-Su,PH; Frühling <--- (Season words are ambiguous. Please use explicit date ranges instead, e.g. Jun-Aug, Dec-Feb, or Jun 21-Sep 22.)
+
+"Season words should fail with explicit date-range guidance" for "We off; Mo,Tu,Th-Su,PH; Fruehling We 11:00-14:00,17:00+": [32m[1mPASSED[22m[39m
+We off; Mo,Tu,Th-Su,PH; Fruehling <--- (Season words are ambiguous. Please use explicit date ranges instead, e.g. Jun-Aug, Dec-Feb, or Jun 21-Sep 22.)
+
+"Season words should fail with explicit date-range guidance" for "We off; Mo,Tu,Th-Su,PH; FRÜHLING We 11:00-14:00,17:00+": [32m[1mPASSED[22m[39m
+We off; Mo,Tu,Th-Su,PH; FRÜHLING <--- (Season words are ambiguous. Please use explicit date ranges instead, e.g. Jun-Aug, Dec-Feb, or Jun 21-Sep 22.)
+
+"Season words should fail with explicit date-range guidance" for "We off; Mo,Tu,Th-Su,PH; primavera We 11:00-14:00,17:00+": [32m[1mPASSED[22m[39m
+We off; Mo,Tu,Th-Su,PH; primavera <--- (Season words are ambiguous. Please use explicit date ranges instead, e.g. Jun-Aug, Dec-Feb, or Jun 21-Sep 22.)
+
 "Incorrect syntax which should throw an error" for "Mo-Fr 17:00-12:00; Sa-Su 24:00-12:00": [32m[1mPASSED[22m[39m
 Mo-Fr 17:00-12:00; Sa-Su 24:00 <--- (Time range starts outside of the current day)
 
@@ -2603,7 +2613,7 @@ The optional_conf_parm["tag_key"] is missing, required by optional_conf_parm["ma
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-983/983 tests passed. 0 did not pass.
+987/987 tests passed. 0 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.js
+++ b/test/test.js
@@ -4468,8 +4468,6 @@ test.addTest('Real world example: Problem with <additional_rule_separator> in ho
 test.addTest('Real world example: Problem with <additional_rule_separator> in holiday parser', [
         // 'We off, Mo,Tu,Th-Su,PH, Jun-Aug We 11:00-14:00,17:00+', // Should fail.
         'We off; Mo,Tu,Th-Su,PH; Jun-Aug We 11:00-14:00,17:00+',
-        'We off; Mo,Tu,Th-Su,PH; Sommer We 11:00-14:00,17:00+',
-        'We off; Mo,Tu,Th-Su,PH; sommer We 11:00-14:00,17:00+',
         'Mo,Tu,Th-Su,PH 00:00-24:00; Jun-Aug We 11:00-14:00,17:00+'
     ], '2015-05-25 0:00', '2015-06-10 0:00', [
         [ '2015-05-25 00:00', '2015-05-26 00:00', false, 'Pfingstmontag' ], // Mo: 1
@@ -4480,6 +4478,15 @@ test.addTest('Real world example: Problem with <additional_rule_separator> in ho
         [ '2015-06-04 03:00', '2015-06-05 00:00', false, 'Fronleichnam' ], // Th
         [ '2015-06-05 00:00', '2015-06-10 00:00' ], // Fr-Tu: 5
     ], 1000 * 60 * 60 * (24 * (1 + 1 + 6 + 5) + 3 + (24 - 3)), 1000 * 60 * 60 * (24 - 17 + 3), false, nominatim_default, 'not last test');
+
+test.addShouldFail('Season words should fail with explicit date-range guidance', [
+    'We off; Mo,Tu,Th-Su,PH; spring We 11:00-14:00,17:00+',
+    'We off; Mo,Tu,Th-Su,PH; winter We 11:00-14:00,17:00+',
+    'We off; Mo,Tu,Th-Su,PH; Frühling We 11:00-14:00,17:00+',
+    'We off; Mo,Tu,Th-Su,PH; Fruehling We 11:00-14:00,17:00+',
+    'We off; Mo,Tu,Th-Su,PH; FRÜHLING We 11:00-14:00,17:00+',
+    'We off; Mo,Tu,Th-Su,PH; primavera We 11:00-14:00,17:00+',
+    ], nominatim_default, 'not only test');
 /* }}} */
 
 /* https://github.com/opening-hours/opening_hours.js/issues/87 {{{ */


### PR DESCRIPTION
Season auto-mapping was discussed in issue #21 and implemented in [e04464a](https://github.com/opening-hours/opening_hours.js/commit/e04464a3e6df7abea9a762e22d7efebfd59bca26)/[2f21067](https://github.com/opening-hours/opening_hours.js/commit/2f210672d6eb504d41a41df82f0157427ae42b77) for convenience.

This PR reverts that behavior: season names like `summer` or `winter` no longer map silently to fixed month ranges.

Reason: season terms are ambiguous (hemisphere, local convention, astronomical vs meteorological), so implicit mapping can produce wrong results.

Instead, the parser now raises a clear error and asks for explicit date ranges:

> *Season words are ambiguous. Please use explicit date ranges, e.g. Jun-Aug, Dec-Feb, or Jun 21-Sep 22.*

I considered a warning but rejected it, because it would still allow silently wrong interpretations.

@ypid, since you introduced this behavior back then, your opinion on this change would be very valuable :slightly_smiling_face: 

Solves #600.
