### PR TITLE
fix: preserve prettifyValue semantics in #596 cases

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4079,6 +4079,16 @@ export default function(value, nominatim_object, optional_conf_parm) {
 
         let prettified_value = '';
         let at = selector_start;
+        // Preserve a leading malformed ':' before a time selector so the
+        // prettified form keeps the same meaning as the tolerated input.
+        if (selector_type === 'time'
+                && selector_start > 1
+                && matchTokens(tokens, selector_start - 1, 'timesep')
+                && matchTokens(tokens, selector_start, 'number')
+                && (matchTokens(tokens, selector_start - 2, 'rule separator')
+                    || matchTokens(tokens, selector_start - 2, ','))) {
+            prettified_value += ':';
+        }
         // console.log(selector_type);
         while (at <= selector_end) {
             // console.log('At: ' + at + ', token: ' + tokens[at]);

--- a/src/index.js
+++ b/src/index.js
@@ -265,6 +265,9 @@ export default function(value, nominatim_object, optional_conf_parm) {
     let done_with_warnings = false; // The functions which returns warnings can be called multiple times.
     let done_with_selector_reordering = false;
     let done_with_selector_reordering_warnings = false;
+    // Rule indices for which prettify must keep the original selector order,
+    // because reordering time/state would change the meaning (#596).
+    const rules_without_selector_reordering = new Set();
     // eslint-disable-next-line no-var
     var tokens = tokenize(value); // TODO: Figure out why tests fail if this is const or let.
     // console.log(JSON.stringify(tokens, null, '    '));
@@ -1084,6 +1087,9 @@ export default function(value, nominatim_object, optional_conf_parm) {
                         t('additional rule which evaluates to closed'),
                         new_tokens
                     ]);
+                    // Reordering would move time before state (e.g. "off") and
+                    // can change semantics for additional rules (#596).
+                    rules_without_selector_reordering.add(nrule);
                 }
                 /* }}} */
 
@@ -1350,7 +1356,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
             // console.log('Prettified value: ' + JSON.stringify(prettified_group_value, null, '    '));
             const not_sorted_prettified_group_value = prettified_group_value.slice();
 
-            if (!done_with_selector_reordering) {
+            if (!done_with_selector_reordering && !rules_without_selector_reordering.has(nrule)) {
                 prettified_group_value.sort(
                     function (a, b) {
                         const selector_order = [ 'year', 'month', 'week', 'holiday', 'weekday', 'time', '24/7', 'state', 'comment'];

--- a/src/index.js
+++ b/src/index.js
@@ -4106,7 +4106,8 @@ export default function(value, nominatim_object, optional_conf_parm) {
                     && at + 2 <= selector_end
                     && matchTokens(tokens, at, 'number')
                     && matchTokens(tokens, at+1, '-')
-                    && matchTokens(tokens, at+2, 'number')) {
+                    && matchTokens(tokens, at+2, 'number')
+                    && tokens[at][0] !== tokens[at+2][0]) {
                 prettified_value += (tokens[at][0] < 10 ?
                         (tokens[at][0] === 0 && conf.one_zero_if_hour_zero ? '' : '0')
                         : '') + tokens[at][0].toString();

--- a/src/index.js
+++ b/src/index.js
@@ -1355,8 +1355,11 @@ export default function(value, nominatim_object, optional_conf_parm) {
             } while (selector_start_end_type[1] < new_tokens[nrule][0].length);
             // console.log('Prettified value: ' + JSON.stringify(prettified_group_value, null, '    '));
             const not_sorted_prettified_group_value = prettified_group_value.slice();
+            const contains_comment_selector = prettified_group_value.some(function (array) {
+                return array[0][2] === 'comment';
+            });
 
-            if (!done_with_selector_reordering && !rules_without_selector_reordering.has(nrule)) {
+            if (!done_with_selector_reordering && !rules_without_selector_reordering.has(nrule) && !contains_comment_selector) {
                 prettified_group_value.sort(
                     function (a, b) {
                         const selector_order = [ 'year', 'month', 'week', 'holiday', 'weekday', 'time', '24/7', 'state', 'comment'];

--- a/test/test.de.log
+++ b/test/test.de.log
@@ -2614,6 +2614,9 @@ Der optional_conf_parm["tag_key"] fehlt, ist aber notwendig wegen optional_conf_
 "Compare prettifyValue" for "Jan 01,3,9,21,31": [32m[1mPASSED[22m[39m
 "Compare prettifyValue" for "week 01-05/2,9": [32m[1mPASSED[22m[39m
 "Regression: prettifyValue should not reorder additional off rule (#596)" for "Nov-Feb Mo-Sa 10:00-16:00, Su 13:00-16:00; Mar-Oct Mo-Sa 10:00-17:00, off 12:00-13:00, Su 14:00-17:00": [32m[1mPASSED[22m[39m
+"Regression: prettifyValue should keep bare time ranges unchanged (#596)" for "Monday-Saturday 8-9, Sunday 8-8": [32m[1mPASSED[22m[39m
+"Regression: prettifyValue should keep bare time ranges unchanged (#596)" for "Mo-Fr 10:00-19:00; Sa 16-16": [32m[1mPASSED[22m[39m
+"Regression: prettifyValue should keep bare time ranges unchanged (#596)" for "Su 8-8, Mo Closed, Tu-Th 12-8, F-Sa 12-9": [32m[1mPASSED[22m[39m
 "Test isEqualTo function: Full range" for "open": [32m[1mPASSED[22m[39m
 "Test isEqualTo function: Full range" for "24/7": [32m[1mPASSED[22m[39m
 "Test isEqualTo function: Full range" for "2000-2100": [32m[1mPASSED[22m[39m
@@ -2632,7 +2635,7 @@ Der optional_conf_parm["tag_key"] fehlt, ist aber notwendig wegen optional_conf_
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-1000/1000 tests passed. 0 did not pass.
+1003/1003 tests passed. 0 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.de.log
+++ b/test/test.de.log
@@ -2613,6 +2613,7 @@ Der optional_conf_parm["tag_key"] fehlt, ist aber notwendig wegen optional_conf_
 "Compare prettifyValue" for "Mo: 7-18; ": [32m[1mPASSED[22m[39m
 "Compare prettifyValue" for "Jan 01,3,9,21,31": [32m[1mPASSED[22m[39m
 "Compare prettifyValue" for "week 01-05/2,9": [32m[1mPASSED[22m[39m
+"Regression: prettifyValue should not reorder additional off rule (#596)" for "Nov-Feb Mo-Sa 10:00-16:00, Su 13:00-16:00; Mar-Oct Mo-Sa 10:00-17:00, off 12:00-13:00, Su 14:00-17:00": [32m[1mPASSED[22m[39m
 "Test isEqualTo function: Full range" for "open": [32m[1mPASSED[22m[39m
 "Test isEqualTo function: Full range" for "24/7": [32m[1mPASSED[22m[39m
 "Test isEqualTo function: Full range" for "2000-2100": [32m[1mPASSED[22m[39m
@@ -2631,7 +2632,7 @@ Der optional_conf_parm["tag_key"] fehlt, ist aber notwendig wegen optional_conf_
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-999/999 tests passed. 0 did not pass.
+1000/1000 tests passed. 0 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.de.log
+++ b/test/test.de.log
@@ -1367,14 +1367,7 @@ With [34m[1mwarnings[22m[39m:
 "Additional comments for unknown" for "Sa 10:00-12:00 unknown "Maybe open. Call us. (testing special tokens in comment: ; ;; ' || | test end)"": [32m[1mPASSED[22m[39m
 "Date overwriting with additional comments for unknown " for "Mo-Fr 10:00-20:00 unknown "Maybe"; We 10:00-16:00 "Maybe open. Call us."": [32m[1mPASSED[22m[39m
 "Date overwriting with additional comments for unknown " for "Mo-Fr 10:00-20:00 unknown "Maybe"; We "Maybe open. Call us." 10:00-16:00": [32m[1mPASSED[22m[39m
-With [34m[1mwarnings[22m[39m:
-	*Mo-Fr 10:00-20:00 unknown "Maybe"; We 10:00-16:00 <--- (Der Selektor "time" wurde für eine bessere Lesbarkeit und der Vollständigkeit halber mit "comment" getauscht.)
-	*Mo-Fr 10:00-20:00 unknown "Maybe"; We 10:00-16:00 "Maybe open. Call us." <--- (Der Selektor "comment" wurde für eine bessere Lesbarkeit und der Vollständigkeit halber mit "time" getauscht.)
 "Date overwriting with additional comments for unknown " for "Mo-Fr 10:00-20:00 unknown "Maybe"; "Maybe open. Call us." We 10:00-16:00": [32m[1mPASSED[22m[39m
-With [34m[1mwarnings[22m[39m:
-	*Mo-Fr 10:00-20:00 unknown "Maybe"; We <--- (Der Selektor "weekday" wurde für eine bessere Lesbarkeit und der Vollständigkeit halber mit "comment" getauscht.)
-	*Mo-Fr 10:00-20:00 unknown "Maybe"; We 10:00-16:00 <--- (Der Selektor "time" wurde für eine bessere Lesbarkeit und der Vollständigkeit halber mit "weekday" getauscht.)
-	*Mo-Fr 10:00-20:00 unknown "Maybe"; We 10:00-16:00 "Maybe open. Call us." <--- (Der Selektor "comment" wurde für eine bessere Lesbarkeit und der Vollständigkeit halber mit "time" getauscht.)
 "Additional comments with time ranges spanning midnight" for "22:00-26:00; We 12:00-14:00 unknown "Maybe open. Call us."": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
 	*22:00-26:00; We 12:00-14:00 unknown "Maybe open. Call us." <--- (Diese Regel überschreibt Teile der vorherigen Regel. Der Grund dafür ist, dass normale Regeln auf den ganzen Tag zutreffen und alle Definitionen von vorhergehenden Regeln für diesen Tag überschreiben. Du kannst diese Regel als additive Regel deklarieren indem du ein "," anstelle des üblichen ";" für diese Regel verwendest. Beachte das die Überschreibung auch gewünscht sein kann und in so einem Fall diese Warnung ignoriert werden kann.)

--- a/test/test.de.log
+++ b/test/test.de.log
@@ -1368,6 +1368,7 @@ With [34m[1mwarnings[22m[39m:
 "Date overwriting with additional comments for unknown " for "Mo-Fr 10:00-20:00 unknown "Maybe"; We 10:00-16:00 "Maybe open. Call us."": [32m[1mPASSED[22m[39m
 "Date overwriting with additional comments for unknown " for "Mo-Fr 10:00-20:00 unknown "Maybe"; We "Maybe open. Call us." 10:00-16:00": [32m[1mPASSED[22m[39m
 "Date overwriting with additional comments for unknown " for "Mo-Fr 10:00-20:00 unknown "Maybe"; "Maybe open. Call us." We 10:00-16:00": [32m[1mPASSED[22m[39m
+"Date overwriting with reordered selectors (overwrite semantics)" for "Mo-Fr 10:00-20:00 open; We 10:00-16:00 open": [32m[1mPASSED[22m[39m
 "Additional comments with time ranges spanning midnight" for "22:00-26:00; We 12:00-14:00 unknown "Maybe open. Call us."": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
 	*22:00-26:00; We 12:00-14:00 unknown "Maybe open. Call us." <--- (Diese Regel überschreibt Teile der vorherigen Regel. Der Grund dafür ist, dass normale Regeln auf den ganzen Tag zutreffen und alle Definitionen von vorhergehenden Regeln für diesen Tag überschreiben. Du kannst diese Regel als additive Regel deklarieren indem du ein "," anstelle des üblichen ";" für diese Regel verwendest. Beachte das die Überschreibung auch gewünscht sein kann und in so einem Fall diese Warnung ignoriert werden kann.)
@@ -1771,6 +1772,19 @@ With [34m[1mwarnings[22m[39m:
 "Time intervals (not specified/documented use of colon, please avoid this)" for "00:00-24:00; Mo: 15:00-16:00 off": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
 	*00:00-24:00; Mo:  <--- (Du hast das optionale Symbol <separator_for_readability> an der falschen Stelle benutzt. Bitte lies die Syntax-Spezifikation um zu sehen, wo es verwendet werden kann, oder entferne es.)
+"Reordered selectors without comments still emit switched warnings" for "Mo-Fr 10:00-20:00 open; open We 10:00-16:00": [32m[1mPASSED[22m[39m
+With [34m[1mwarnings[22m[39m:
+	*Mo-Fr 10:00-20:00 open; We <--- (Der Selektor "weekday" wurde für eine bessere Lesbarkeit und der Vollständigkeit halber mit "state" getauscht.)
+	*Mo-Fr 10:00-20:00 open; We 10:00-16:00 <--- (Der Selektor "time" wurde für eine bessere Lesbarkeit und der Vollständigkeit halber mit "weekday" getauscht.)
+	*Mo-Fr 10:00-20:00 open; We 10:00-16:00 open <--- (Der Selektor "state" wurde für eine bessere Lesbarkeit und der Vollständigkeit halber mit "time" getauscht.)
+"Reordered selectors without comments still emit switched warnings" for "Mo-Fr 10:00-20:00 open; We open 10:00-16:00": [32m[1mPASSED[22m[39m
+With [34m[1mwarnings[22m[39m:
+	*Mo-Fr 10:00-20:00 open; We 10:00-16:00 <--- (Der Selektor "time" wurde für eine bessere Lesbarkeit und der Vollständigkeit halber mit "state" getauscht.)
+	*Mo-Fr 10:00-20:00 open; We 10:00-16:00 open <--- (Der Selektor "state" wurde für eine bessere Lesbarkeit und der Vollständigkeit halber mit "time" getauscht.)
+"Reordered selectors without comments still emit switched warnings" for "Mo-Fr 10:00-20:00 open; 10:00-16:00 We open": [32m[1mPASSED[22m[39m
+With [34m[1mwarnings[22m[39m:
+	*Mo-Fr 10:00-20:00 open; We <--- (Der Selektor "weekday" wurde für eine bessere Lesbarkeit und der Vollständigkeit halber mit "time" getauscht.)
+	*Mo-Fr 10:00-20:00 open; We 10:00-16:00 <--- (Der Selektor "time" wurde für eine bessere Lesbarkeit und der Vollständigkeit halber mit "weekday" getauscht.)
 "Error tolerance: ambiguous words (listopad)" for "listopad 12:00-18:00": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
 	*listopad <--- (Word "listopad" is ambiguous: Nov (Czech) or Oct (Croatian) or Nov (Polish). Please specify language context or use English month name.)
@@ -2039,6 +2053,8 @@ With [34m[1mwarnings[22m[39m:
 "Structured warning: word error correction has stable type" for "Mon": [32m[1mPASSED[22m[39m
 "Structured warning: no warnings yields empty list" for "Mo 10:00-12:00": [32m[1mPASSED[22m[39m
 "Structured warning: multiple warnings keep distinct positions" for "Mo 10-12; Tu 14-16": [32m[1mPASSED[22m[39m
+"Structured warning: switched remains for reorder without comments" for "Mo-Fr 10:00-20:00 open; open We 10:00-16:00": [32m[1mPASSED[22m[39m
+"Structured warning: no switched for reordered comment selector" for "Mo-Fr 10:00-20:00 unknown "Maybe"; We "Maybe open. Call us." 10:00-16:00": [32m[1mPASSED[22m[39m
 "Season words should fail with explicit date-range guidance" for "We off; Mo,Tu,Th-Su,PH; spring We 11:00-14:00,17:00+": [32m[1mPASSED[22m[39m
 We off; Mo,Tu,Th-Su,PH; spring <--- (Saisonwörter sind mehrdeutig. Bitte verwende stattdessen explizite Datumsbereiche, z. B. Jun-Aug, Dec-Feb oder Jun 21-Sep 22.)
 
@@ -2630,7 +2646,7 @@ Der optional_conf_parm["tag_key"] fehlt, ist aber notwendig wegen optional_conf_
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-1005/1005 tests passed. 0 did not pass.
+1011/1011 tests passed. 0 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.de.log
+++ b/test/test.de.log
@@ -2610,6 +2610,8 @@ Der optional_conf_parm["tag_key"] fehlt, ist aber notwendig wegen optional_conf_
 "Regression: prettifyValue should keep bare time ranges unchanged (#596)" for "Monday-Saturday 8-9, Sunday 8-8": [32m[1mPASSED[22m[39m
 "Regression: prettifyValue should keep bare time ranges unchanged (#596)" for "Mo-Fr 10:00-19:00; Sa 16-16": [32m[1mPASSED[22m[39m
 "Regression: prettifyValue should keep bare time ranges unchanged (#596)" for "Su 8-8, Mo Closed, Tu-Th 12-8, F-Sa 12-9": [32m[1mPASSED[22m[39m
+"Regression: prettifyValue should not reorder comments across state (#596)" for "Mo-Fr 11:00-14:00 "Mittagessen" open": [32m[1mPASSED[22m[39m
+"Regression: prettifyValue should preserve malformed time selectors (#596)" for "Tu-We 09:00-12:30,14:00-18:00; Th 09:00-12:30,:15:00-18:00, Fr 09:00-12:30, 14:00-18:00; Sa 09:00-12:30,13:30-16:30": [32m[1mPASSED[22m[39m
 "Test isEqualTo function: Full range" for "open": [32m[1mPASSED[22m[39m
 "Test isEqualTo function: Full range" for "24/7": [32m[1mPASSED[22m[39m
 "Test isEqualTo function: Full range" for "2000-2100": [32m[1mPASSED[22m[39m
@@ -2628,7 +2630,7 @@ Der optional_conf_parm["tag_key"] fehlt, ist aber notwendig wegen optional_conf_
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-1003/1003 tests passed. 0 did not pass.
+1005/1005 tests passed. 0 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.en.log
+++ b/test/test.en.log
@@ -1367,14 +1367,7 @@ With [34m[1mwarnings[22m[39m:
 "Additional comments for unknown" for "Sa 10:00-12:00 unknown "Maybe open. Call us. (testing special tokens in comment: ; ;; ' || | test end)"": [32m[1mPASSED[22m[39m
 "Date overwriting with additional comments for unknown " for "Mo-Fr 10:00-20:00 unknown "Maybe"; We 10:00-16:00 "Maybe open. Call us."": [32m[1mPASSED[22m[39m
 "Date overwriting with additional comments for unknown " for "Mo-Fr 10:00-20:00 unknown "Maybe"; We "Maybe open. Call us." 10:00-16:00": [32m[1mPASSED[22m[39m
-With [34m[1mwarnings[22m[39m:
-	*Mo-Fr 10:00-20:00 unknown "Maybe"; We 10:00-16:00 <--- (The selector "time" was switched with the selector "comment" for readability and compatibility reasons.)
-	*Mo-Fr 10:00-20:00 unknown "Maybe"; We 10:00-16:00 "Maybe open. Call us." <--- (The selector "comment" was switched with the selector "time" for readability and compatibility reasons.)
 "Date overwriting with additional comments for unknown " for "Mo-Fr 10:00-20:00 unknown "Maybe"; "Maybe open. Call us." We 10:00-16:00": [32m[1mPASSED[22m[39m
-With [34m[1mwarnings[22m[39m:
-	*Mo-Fr 10:00-20:00 unknown "Maybe"; We <--- (The selector "weekday" was switched with the selector "comment" for readability and compatibility reasons.)
-	*Mo-Fr 10:00-20:00 unknown "Maybe"; We 10:00-16:00 <--- (The selector "time" was switched with the selector "weekday" for readability and compatibility reasons.)
-	*Mo-Fr 10:00-20:00 unknown "Maybe"; We 10:00-16:00 "Maybe open. Call us." <--- (The selector "comment" was switched with the selector "time" for readability and compatibility reasons.)
 "Additional comments with time ranges spanning midnight" for "22:00-26:00; We 12:00-14:00 unknown "Maybe open. Call us."": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
 	*22:00-26:00; We 12:00-14:00 unknown "Maybe open. Call us." <--- (This rule overwrites parts of the previous rule. This happens because normal rules apply to the whole day and overwrite any definition made by previous rules. You can make this rule an additional rule by using a "," instead of the normal ";" to separate the rules. Note that the overwriting can also be desirable in which case you can ignore this warning.)
@@ -2610,6 +2603,7 @@ The optional_conf_parm["tag_key"] is missing, required by optional_conf_parm["ma
 "Regression: prettifyValue should keep bare time ranges unchanged (#596)" for "Monday-Saturday 8-9, Sunday 8-8": [32m[1mPASSED[22m[39m
 "Regression: prettifyValue should keep bare time ranges unchanged (#596)" for "Mo-Fr 10:00-19:00; Sa 16-16": [32m[1mPASSED[22m[39m
 "Regression: prettifyValue should keep bare time ranges unchanged (#596)" for "Su 8-8, Mo Closed, Tu-Th 12-8, F-Sa 12-9": [32m[1mPASSED[22m[39m
+"Regression: prettifyValue should not reorder comments across state (#596)" for "Mo-Fr 11:00-14:00 "Mittagessen" open, PH off": [32m[1mPASSED[22m[39m
 "Test isEqualTo function: Full range" for "open": [32m[1mPASSED[22m[39m
 "Test isEqualTo function: Full range" for "24/7": [32m[1mPASSED[22m[39m
 "Test isEqualTo function: Full range" for "2000-2100": [32m[1mPASSED[22m[39m
@@ -2628,7 +2622,7 @@ The optional_conf_parm["tag_key"] is missing, required by optional_conf_parm["ma
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-996/996 tests passed. 0 did not pass.
+997/997 tests passed. 0 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.en.log
+++ b/test/test.en.log
@@ -1368,6 +1368,7 @@ With [34m[1mwarnings[22m[39m:
 "Date overwriting with additional comments for unknown " for "Mo-Fr 10:00-20:00 unknown "Maybe"; We 10:00-16:00 "Maybe open. Call us."": [32m[1mPASSED[22m[39m
 "Date overwriting with additional comments for unknown " for "Mo-Fr 10:00-20:00 unknown "Maybe"; We "Maybe open. Call us." 10:00-16:00": [32m[1mPASSED[22m[39m
 "Date overwriting with additional comments for unknown " for "Mo-Fr 10:00-20:00 unknown "Maybe"; "Maybe open. Call us." We 10:00-16:00": [32m[1mPASSED[22m[39m
+"Date overwriting with reordered selectors (overwrite semantics)" for "Mo-Fr 10:00-20:00 open; We 10:00-16:00 open": [32m[1mPASSED[22m[39m
 "Additional comments with time ranges spanning midnight" for "22:00-26:00; We 12:00-14:00 unknown "Maybe open. Call us."": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
 	*22:00-26:00; We 12:00-14:00 unknown "Maybe open. Call us." <--- (This rule overwrites parts of the previous rule. This happens because normal rules apply to the whole day and overwrite any definition made by previous rules. You can make this rule an additional rule by using a "," instead of the normal ";" to separate the rules. Note that the overwriting can also be desirable in which case you can ignore this warning.)
@@ -1771,6 +1772,19 @@ With [34m[1mwarnings[22m[39m:
 "Time intervals (not specified/documented use of colon, please avoid this)" for "00:00-24:00; Mo: 15:00-16:00 off": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
 	*00:00-24:00; Mo:  <--- (You have used the optional symbol <separator_for_readability> in the wrong place. Please check the syntax specification to see where it could be used or remove it.)
+"Reordered selectors without comments still emit switched warnings" for "Mo-Fr 10:00-20:00 open; open We 10:00-16:00": [32m[1mPASSED[22m[39m
+With [34m[1mwarnings[22m[39m:
+	*Mo-Fr 10:00-20:00 open; We <--- (The selector "weekday" was switched with the selector "state" for readability and compatibility reasons.)
+	*Mo-Fr 10:00-20:00 open; We 10:00-16:00 <--- (The selector "time" was switched with the selector "weekday" for readability and compatibility reasons.)
+	*Mo-Fr 10:00-20:00 open; We 10:00-16:00 open <--- (The selector "state" was switched with the selector "time" for readability and compatibility reasons.)
+"Reordered selectors without comments still emit switched warnings" for "Mo-Fr 10:00-20:00 open; We open 10:00-16:00": [32m[1mPASSED[22m[39m
+With [34m[1mwarnings[22m[39m:
+	*Mo-Fr 10:00-20:00 open; We 10:00-16:00 <--- (The selector "time" was switched with the selector "state" for readability and compatibility reasons.)
+	*Mo-Fr 10:00-20:00 open; We 10:00-16:00 open <--- (The selector "state" was switched with the selector "time" for readability and compatibility reasons.)
+"Reordered selectors without comments still emit switched warnings" for "Mo-Fr 10:00-20:00 open; 10:00-16:00 We open": [32m[1mPASSED[22m[39m
+With [34m[1mwarnings[22m[39m:
+	*Mo-Fr 10:00-20:00 open; We <--- (The selector "weekday" was switched with the selector "time" for readability and compatibility reasons.)
+	*Mo-Fr 10:00-20:00 open; We 10:00-16:00 <--- (The selector "time" was switched with the selector "weekday" for readability and compatibility reasons.)
 "Error tolerance: ambiguous words (listopad)" for "listopad 12:00-18:00": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
 	*listopad <--- (Word "listopad" is ambiguous: Nov (Czech) or Oct (Croatian) or Nov (Polish). Please specify language context or use English month name.)
@@ -2039,6 +2053,8 @@ With [34m[1mwarnings[22m[39m:
 "Structured warning: word error correction has stable type" for "Mon": [32m[1mPASSED[22m[39m
 "Structured warning: no warnings yields empty list" for "Mo 10:00-12:00": [32m[1mPASSED[22m[39m
 "Structured warning: multiple warnings keep distinct positions" for "Mo 10-12; Tu 14-16": [32m[1mPASSED[22m[39m
+"Structured warning: switched remains for reorder without comments" for "Mo-Fr 10:00-20:00 open; open We 10:00-16:00": [32m[1mPASSED[22m[39m
+"Structured warning: no switched for reordered comment selector" for "Mo-Fr 10:00-20:00 unknown "Maybe"; We "Maybe open. Call us." 10:00-16:00": [32m[1mPASSED[22m[39m
 "Season words should fail with explicit date-range guidance" for "We off; Mo,Tu,Th-Su,PH; spring We 11:00-14:00,17:00+": [32m[1mPASSED[22m[39m
 We off; Mo,Tu,Th-Su,PH; spring <--- (Season words are ambiguous. Please use explicit date ranges instead, e.g. Jun-Aug, Dec-Feb, or Jun 21-Sep 22.)
 
@@ -2623,7 +2639,7 @@ The optional_conf_parm["tag_key"] is missing, required by optional_conf_parm["ma
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-998/998 tests passed. 0 did not pass.
+1004/1004 tests passed. 0 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.en.log
+++ b/test/test.en.log
@@ -2607,6 +2607,9 @@ The optional_conf_parm["tag_key"] is missing, required by optional_conf_parm["ma
 "Compare prettifyValue" for "Jan 01,3,9,21,31": [32m[1mPASSED[22m[39m
 "Compare prettifyValue" for "week 01-05/2,9": [32m[1mPASSED[22m[39m
 "Regression: prettifyValue should not reorder additional off rule (#596)" for "Nov-Feb Mo-Sa 10:00-16:00, Su 13:00-16:00; Mar-Oct Mo-Sa 10:00-17:00, off 12:00-13:00, Su 14:00-17:00": [32m[1mPASSED[22m[39m
+"Regression: prettifyValue should keep bare time ranges unchanged (#596)" for "Monday-Saturday 8-9, Sunday 8-8": [32m[1mPASSED[22m[39m
+"Regression: prettifyValue should keep bare time ranges unchanged (#596)" for "Mo-Fr 10:00-19:00; Sa 16-16": [32m[1mPASSED[22m[39m
+"Regression: prettifyValue should keep bare time ranges unchanged (#596)" for "Su 8-8, Mo Closed, Tu-Th 12-8, F-Sa 12-9": [32m[1mPASSED[22m[39m
 "Test isEqualTo function: Full range" for "open": [32m[1mPASSED[22m[39m
 "Test isEqualTo function: Full range" for "24/7": [32m[1mPASSED[22m[39m
 "Test isEqualTo function: Full range" for "2000-2100": [32m[1mPASSED[22m[39m
@@ -2625,7 +2628,7 @@ The optional_conf_parm["tag_key"] is missing, required by optional_conf_parm["ma
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-993/993 tests passed. 0 did not pass.
+996/996 tests passed. 0 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.en.log
+++ b/test/test.en.log
@@ -2606,6 +2606,7 @@ The optional_conf_parm["tag_key"] is missing, required by optional_conf_parm["ma
 "Compare prettifyValue" for "Mo: 7-18; ": [32m[1mPASSED[22m[39m
 "Compare prettifyValue" for "Jan 01,3,9,21,31": [32m[1mPASSED[22m[39m
 "Compare prettifyValue" for "week 01-05/2,9": [32m[1mPASSED[22m[39m
+"Regression: prettifyValue should not reorder additional off rule (#596)" for "Nov-Feb Mo-Sa 10:00-16:00, Su 13:00-16:00; Mar-Oct Mo-Sa 10:00-17:00, off 12:00-13:00, Su 14:00-17:00": [32m[1mPASSED[22m[39m
 "Test isEqualTo function: Full range" for "open": [32m[1mPASSED[22m[39m
 "Test isEqualTo function: Full range" for "24/7": [32m[1mPASSED[22m[39m
 "Test isEqualTo function: Full range" for "2000-2100": [32m[1mPASSED[22m[39m
@@ -2624,7 +2625,7 @@ The optional_conf_parm["tag_key"] is missing, required by optional_conf_parm["ma
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-992/992 tests passed. 0 did not pass.
+993/993 tests passed. 0 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.en.log
+++ b/test/test.en.log
@@ -2603,7 +2603,8 @@ The optional_conf_parm["tag_key"] is missing, required by optional_conf_parm["ma
 "Regression: prettifyValue should keep bare time ranges unchanged (#596)" for "Monday-Saturday 8-9, Sunday 8-8": [32m[1mPASSED[22m[39m
 "Regression: prettifyValue should keep bare time ranges unchanged (#596)" for "Mo-Fr 10:00-19:00; Sa 16-16": [32m[1mPASSED[22m[39m
 "Regression: prettifyValue should keep bare time ranges unchanged (#596)" for "Su 8-8, Mo Closed, Tu-Th 12-8, F-Sa 12-9": [32m[1mPASSED[22m[39m
-"Regression: prettifyValue should not reorder comments across state (#596)" for "Mo-Fr 11:00-14:00 "Mittagessen" open, PH off": [32m[1mPASSED[22m[39m
+"Regression: prettifyValue should not reorder comments across state (#596)" for "Mo-Fr 11:00-14:00 "Mittagessen" open": [32m[1mPASSED[22m[39m
+"Regression: prettifyValue should preserve malformed time selectors (#596)" for "Tu-We 09:00-12:30,14:00-18:00; Th 09:00-12:30,:15:00-18:00, Fr 09:00-12:30, 14:00-18:00; Sa 09:00-12:30,13:30-16:30": [32m[1mPASSED[22m[39m
 "Test isEqualTo function: Full range" for "open": [32m[1mPASSED[22m[39m
 "Test isEqualTo function: Full range" for "24/7": [32m[1mPASSED[22m[39m
 "Test isEqualTo function: Full range" for "2000-2100": [32m[1mPASSED[22m[39m
@@ -2622,7 +2623,7 @@ The optional_conf_parm["tag_key"] is missing, required by optional_conf_parm["ma
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-997/997 tests passed. 0 did not pass.
+998/998 tests passed. 0 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.js
+++ b/test/test.js
@@ -5667,6 +5667,10 @@ test.addPrettifyValue('Compare prettifyValue', [
         'week 01-05/2,9',
     ], 'all', 'week 01-05/2,09', 'not only test');
 
+test.addPrettifyValue('Regression: prettifyValue should not reorder additional off rule (#596)', [
+        'Nov-Feb Mo-Sa 10:00-16:00, Su 13:00-16:00; Mar-Oct Mo-Sa 10:00-17:00, off 12:00-13:00, Su 14:00-17:00',
+    ], 'all', 'Nov-Feb Mo-Sa 10:00-16:00, Su 13:00-16:00; Mar-Oct Mo-Sa 10:00-17:00, closed 12:00-13:00, Su 14:00-17:00');
+
 /* }}} */
 
 /* isEqualTo {{{ */

--- a/test/test.js
+++ b/test/test.js
@@ -5671,6 +5671,18 @@ test.addPrettifyValue('Regression: prettifyValue should not reorder additional o
         'Nov-Feb Mo-Sa 10:00-16:00, Su 13:00-16:00; Mar-Oct Mo-Sa 10:00-17:00, off 12:00-13:00, Su 14:00-17:00',
     ], 'all', 'Nov-Feb Mo-Sa 10:00-16:00, Su 13:00-16:00; Mar-Oct Mo-Sa 10:00-17:00, closed 12:00-13:00, Su 14:00-17:00');
 
+test.addPrettifyValue('Regression: prettifyValue should keep bare time ranges unchanged (#596)', [
+        'Monday-Saturday 8-9, Sunday 8-8',
+    ], 'all', 'Mo-Sa 08:00-09:00, Su 8-8');
+
+test.addPrettifyValue('Regression: prettifyValue should keep bare time ranges unchanged (#596)', [
+        'Mo-Fr 10:00-19:00; Sa 16-16',
+    ], 'all', 'Mo-Fr 10:00-19:00; Sa 16-16');
+
+test.addPrettifyValue('Regression: prettifyValue should keep bare time ranges unchanged (#596)', [
+        'Su 8-8, Mo Closed, Tu-Th 12-8, F-Sa 12-9',
+    ], 'all', 'Su 8-8, Mo closed, Tu-Th 12:00-08:00, Fr-Sa 12:00-09:00');
+
 /* }}} */
 
 /* isEqualTo {{{ */

--- a/test/test.js
+++ b/test/test.js
@@ -5684,8 +5684,12 @@ test.addPrettifyValue('Regression: prettifyValue should keep bare time ranges un
     ], 'all', 'Su 8-8, Mo closed, Tu-Th 12:00-08:00, Fr-Sa 12:00-09:00');
 
 test.addPrettifyValue('Regression: prettifyValue should not reorder comments across state (#596)', [
-        'Mo-Fr 11:00-14:00 "Mittagessen" open, PH off',
-    ], 'en', 'Mo-Fr 11:00-14:00 "Mittagessen" open, PH off');
+        'Mo-Fr 11:00-14:00 "Mittagessen" open',
+    ], 'all', 'Mo-Fr 11:00-14:00 "Mittagessen" open');
+
+test.addPrettifyValue('Regression: prettifyValue should preserve malformed time selectors (#596)', [
+        'Tu-We 09:00-12:30,14:00-18:00; Th 09:00-12:30,:15:00-18:00, Fr 09:00-12:30, 14:00-18:00; Sa 09:00-12:30,13:30-16:30',
+    ], 'all', 'Tu-We 09:00-12:30,14:00-18:00; Th 09:00-12:30, :15:00-18:00, Fr 09:00-12:30,14:00-18:00; Sa 09:00-12:30,13:30-16:30');
 
 /* }}} */
 

--- a/test/test.js
+++ b/test/test.js
@@ -5683,6 +5683,10 @@ test.addPrettifyValue('Regression: prettifyValue should keep bare time ranges un
         'Su 8-8, Mo Closed, Tu-Th 12-8, F-Sa 12-9',
     ], 'all', 'Su 8-8, Mo closed, Tu-Th 12:00-08:00, Fr-Sa 12:00-09:00');
 
+test.addPrettifyValue('Regression: prettifyValue should not reorder comments across state (#596)', [
+        'Mo-Fr 11:00-14:00 "Mittagessen" open, PH off',
+    ], 'en', 'Mo-Fr 11:00-14:00 "Mittagessen" open, PH off');
+
 /* }}} */
 
 /* isEqualTo {{{ */

--- a/test/test.js
+++ b/test/test.js
@@ -3850,6 +3850,24 @@ test.addTest('Date overwriting with additional comments for unknown ', [
         [ '2012-10-05 10:00', '2012-10-05 20:00', true, 'Maybe' ],
     ], 0, 1000 * 60 * 60 * (4 * 10 + 6), true, {}, 'not only test');
 
+test.addTest('Date overwriting with reordered selectors (overwrite semantics)', [
+        'Mo-Fr 10:00-20:00 open; We 10:00-16:00 open',
+    ], '2012-10-01 0:00', '2012-10-08 0:00', [
+        [ '2012-10-01 10:00', '2012-10-01 20:00' ],
+        [ '2012-10-02 10:00', '2012-10-02 20:00' ],
+        [ '2012-10-03 10:00', '2012-10-03 16:00' ],
+        [ '2012-10-04 10:00', '2012-10-04 20:00' ],
+        [ '2012-10-05 10:00', '2012-10-05 20:00' ],
+    ], 1000 * 60 * 60 * 46, 0, true, {}, 'not only test');
+
+// Reordered (non-canonical) variants still emit switched warnings. The
+// canonical form above is unaffected because no reordering occurs there.
+test.addShouldWarn('Reordered selectors without comments still emit switched warnings', [
+        'Mo-Fr 10:00-20:00 open; open We 10:00-16:00',
+        'Mo-Fr 10:00-20:00 open; We open 10:00-16:00',
+        'Mo-Fr 10:00-20:00 open; 10:00-16:00 We open',
+    ], {}, 'not only test');
+
 test.addTest('Additional comments with time ranges spanning midnight', [
         '22:00-26:00; We 12:00-14:00 unknown "Maybe open. Call us."',
     ], '2012-10-01 0:00', '2012-10-08 0:00', [
@@ -5331,6 +5349,16 @@ test.addStructuredWarnings('Structured warning: multiple warnings keep distinct 
         'Mo 10-12; Tu 14-16',
         [ 'without_minutes', 'without_minutes' ],
         nominatim_default, 'not only test', { 'tag_key': 'opening_hours' });
+
+test.addStructuredWarnings('Structured warning: switched remains for reorder without comments',
+    'Mo-Fr 10:00-20:00 open; open We 10:00-16:00',
+    [ 'switched', 'switched', 'switched' ],
+    nominatim_default, 'not only test', { 'tag_key': 'opening_hours' });
+
+test.addStructuredWarnings('Structured warning: no switched for reordered comment selector',
+    'Mo-Fr 10:00-20:00 unknown "Maybe"; We "Maybe open. Call us." 10:00-16:00',
+    [],
+    nominatim_default, 'not only test', { 'tag_key': 'opening_hours' });
 // }}}
 
 // values which should fail during parsing {{{


### PR DESCRIPTION
This fixes the `prettifyValue()` problems reported in #596.

The underlying issue was always the same: prettifying must not change the meaning of the value. In a few cases it still did, mainly by reordering selectors too aggressively or by normalizing tolerated input into something semantically different.

This PR fixes the affected cases:

- additional `off`/`closed` rules
- bare-hour ranges like `8-8` or `12-8`
- comment/state/time combinations
- tolerated malformed time selectors like `:15:00-18:00`

I adjusted the tests accordingly.

I also looked at whether the prettify logic should be split out of `index.js`. That would likely make the code easier to test in isolation, but it would also make this PR much broader. I kept that work out of this change and focused this PR on the fixes.
