### PR TITLE
fix(prettify): translate grouped PH/SH tokens

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1287,17 +1287,6 @@ export default function(value, nominatim_object, optional_conf_parm) {
             }
         });
 
-        // use months, weekdays for locales 'en' and 'all'
-        // otherwise use Date.toLocaleString, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString
-        const _is_en_or_all = (user_conf['locale'] === 'en' || user_conf['locale'] === 'all') && user_conf['date_format'] === 'short';
-        const months_local = _is_en_or_all ? months : [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].map(function(month) {
-            return new Date(2018, month - 1, 1).toLocaleString(user_conf['locale'], {month: user_conf['date_format']});
-        });
-        const weekdays_local = _is_en_or_all ? weekdays : [1, 2, 3, 4, 5, 6, 7].map(function(weekday) {
-            // 2017-01-01 is Sunday
-            return new Date(2017, 0, weekday).toLocaleString(user_conf['locale'], {weekday: user_conf['date_format']});
-        });
-
         for (let nrule = 0; nrule < new_tokens.length; nrule++) {
             if (new_tokens[nrule][0].length === 0) continue;
             // Rule does contain nothing useful e.g. second rule of '10:00-12:00;' (empty) which needs to be handled.
@@ -1366,27 +1355,6 @@ export default function(value, nominatim_object, optional_conf_parm) {
                         return selector_order.indexOf(a[0][2]) - selector_order.indexOf(b[0][2]);
                     }
                 );
-            }
-            const shouldTranslatePrettyOutput = typeof user_conf['locale'] === 'string' && user_conf['locale'] !== 'en';
-
-            if (shouldTranslatePrettyOutput) {
-                for (let i = 0; i < prettified_group_value.length; i++) {
-                    const type = prettified_group_value[i][0][2];
-                    if (type === 'weekday') {
-                        weekdays.forEach(function (weekday, key) {
-                            prettified_group_value[i][1] = prettified_group_value[i][1].replace(new RegExp(weekday, 'g'), weekdays_local[key]);
-                        });
-                    } else if (type === 'month') {
-                        months.forEach(function (month, key) {
-                            prettified_group_value[i][1] = prettified_group_value[i][1].replace(new RegExp(month, 'g'), months_local[key]);
-                        });
-                    } else {
-                        const prettifiedValueIsProbablyTranslatable = prettified_group_value[i][1].indexOf(':') === -1;
-                        if (prettifiedValueIsProbablyTranslatable) {
-                            prettified_group_value[i][1] = translate(user_conf['locale'], 'pretty', prettified_group_value[i][1]);
-                        }
-                    }
-                }
             }
 
             const old_prettified_value_length = prettified_value.length;
@@ -4067,6 +4035,59 @@ export default function(value, nominatim_object, optional_conf_parm) {
     };
     /* }}} */
 
+    /* Memoized localized month/weekday names for prettified output.
+     * :param conf: Prettify configuration (locale/date_format).
+     * :param kind: Either 'weekday' or 'month'.
+     * :returns: Localized name array with stable index mapping.
+     */
+    const localized_name_cache = {};
+
+    function getLocalizedNames(conf, kind) {
+        const useEnglishShortNames =
+            (conf['locale'] === 'en' || conf['locale'] === 'all') && conf['date_format'] === 'short';
+        if (useEnglishShortNames) {
+            return kind === 'weekday' ? weekdays : months;
+        }
+
+        const cache_key = kind + '|' + conf['locale'] + '|' + conf['date_format'];
+        if (!localized_name_cache[cache_key]) {
+            localized_name_cache[cache_key] = kind === 'weekday'
+                // 2026-02-01 is a Sunday, so day 1..7 maps to Su..Sa.
+                ? [1, 2, 3, 4, 5, 6, 7].map(function (weekday) {
+                    return new Date(2026, 1, weekday).toLocaleString(conf['locale'], {weekday: conf['date_format']});
+                })
+                // The year is arbitrary; only the month index affects the name.
+                : [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].map(function (month) {
+                    return new Date(2026, month - 1, 1).toLocaleString(conf['locale'], {month: conf['date_format']});
+                });
+        }
+        return localized_name_cache[cache_key];
+    }
+
+    /* Translate prettify output token-wise (fixes PH/SH inside grouped selectors, #319).
+     * :param value: Token value (index for month/weekday, string otherwise).
+     * :param token_type: Token type, e.g. 'weekday', 'month', 'state'.
+     * :param conf: Prettify configuration (locale/date_format).
+     * :returns: Translated token string or unchanged value.
+     */
+    function translatePrettyToken(value, token_type, conf) {
+        if (token_type === 'weekday') {
+            return getLocalizedNames(conf, 'weekday')[value];
+        }
+
+        if (token_type === 'month') {
+            return getLocalizedNames(conf, 'month')[value];
+        }
+
+        // Other tokens (e.g. holidays 'PH'/'SH' or the 'off'/'closed' state)
+        // only need translation for non-English locales.
+        if (typeof conf['locale'] !== 'string' || conf['locale'] === 'en') {
+            return value;
+        }
+
+        return translate(conf['locale'], 'pretty', value);
+    }
+
     /* Generate prettified value for selector based on tokens. {{{
      *
      * :param tokens: List of token objects.
@@ -4091,6 +4112,8 @@ export default function(value, nominatim_object, optional_conf_parm) {
         }
         // console.log(selector_type);
         while (at <= selector_end) {
+            const token_value = tokens[at][0];
+            const token_type = tokens[at][1];
             // console.log('At: ' + at + ', token: ' + tokens[at]);
             if (matchTokens(tokens, at, 'weekday')) {
                 if (!conf.leave_weekday_sep_one_day_betw
@@ -4099,7 +4122,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
                     && tokens[at][0] === (tokens[at-2][0] + 1) % 7) {
                         prettified_value = prettified_value.substring(0, prettified_value.length - 1) + conf.sep_one_day_between;
                 }
-                prettified_value += weekdays[tokens[at][0]];
+                prettified_value += translatePrettyToken(token_value, 'weekday', conf);
             } else if (at - selector_start > 0 // e.g. '09:0' -> '09:00'
                     && selector_type === 'time'
                     && matchTokens(tokens, at-1, 'timesep')
@@ -4131,7 +4154,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
             } else if (matchTokens(tokens, at, 'comment')) {
                 prettified_value += '"' + tokens[at][0].toString() + '"';
             } else if (matchTokens(tokens, at, 'closed')) {
-                prettified_value += (conf.leave_off_closed ? tokens[at][0] : conf.keyword_for_off_closed);
+                prettified_value += translatePrettyToken(conf.leave_off_closed ? token_value : conf.keyword_for_off_closed, 'state', conf);
             } else if (at - selector_start > 0 && matchTokens(tokens, at, 'number')
                     && (selector_type === 'month' || selector_type === 'week')) {
                 prettified_value +=
@@ -4140,12 +4163,12 @@ export default function(value, nominatim_object, optional_conf_parm) {
                     + tokens[at][0];
             } else if (at - selector_start > 0 && matchTokens(tokens, at, 'month')
                     && matchTokens(tokens, at-1, 'year')) {
-                prettified_value += ' ' + months[[tokens[at][0]]];
+                prettified_value += ' ' + translatePrettyToken(token_value, 'month', conf);
             } else if (at - selector_start > 0 && matchTokens(tokens, at, 'event')
                     && matchTokens(tokens, at-1, 'year')) {
                 prettified_value += ' ' + tokens[at][0];
             } else if (matchTokens(tokens, at, 'month')) {
-                prettified_value += months[[tokens[at][0]]];
+                prettified_value += translatePrettyToken(token_value, 'month', conf);
                 if (at + 1 <= selector_end && matchTokens(tokens, at+1, 'weekday'))
                     prettified_value += ' ';
             } else if (at + 2 <= selector_end
@@ -4162,7 +4185,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
                     && tokens[at][0] === ',') {
                 /* Remove trailing , which is ignored in parseTimeRange. */
             } else {
-                prettified_value += tokens[at][0].toString();
+                prettified_value += translatePrettyToken(token_value.toString(), token_type, conf);
             }
             at++;
         }

--- a/test/test.de.log
+++ b/test/test.de.log
@@ -2613,6 +2613,9 @@ Der optional_conf_parm["tag_key"] fehlt, ist aber notwendig wegen optional_conf_
 "Compare prettifyValue" for "Tue": [32m[1mPASSED[22m[39m
 "Compare prettifyValue" for "Dienstag": [32m[1mPASSED[22m[39m
 "Compare prettifyValue" for "PH": [32m[1mPASSED[22m[39m
+"Regression: prettifyValue should translate holiday tokens inside weekday groups (#319)" for "Mo,PH off": [32m[1mPASSED[22m[39m
+"Regression: prettifyValue should translate school holiday tokens inside weekday groups (#319)" for "Mo,SH off": [32m[1mPASSED[22m[39m
+"prettifyValue should translate weekday and month tokens in a mixed selector" for "Jan Mo off": [32m[1mPASSED[22m[39m
 "Compare prettifyValue" for "märz": [32m[1mPASSED[22m[39m
 "Compare prettifyValue" for "mär": [32m[1mPASSED[22m[39m
 "Compare prettifyValue" for "SH": [32m[1mPASSED[22m[39m
@@ -2646,7 +2649,7 @@ Der optional_conf_parm["tag_key"] fehlt, ist aber notwendig wegen optional_conf_
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-1011/1011 tests passed. 0 did not pass.
+1014/1014 tests passed. 0 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.js
+++ b/test/test.js
@@ -5665,6 +5665,18 @@ test.addPrettifyValue('Compare prettifyValue', [
         'PH',
     ], 'de', 'Feiertags');
 
+test.addPrettifyValue('Regression: prettifyValue should translate holiday tokens inside weekday groups (#319)', [
+        'Mo,PH off',
+    ], 'de', 'Mo,Feiertags geschlossen');
+
+test.addPrettifyValue('Regression: prettifyValue should translate school holiday tokens inside weekday groups (#319)', [
+        'Mo,SH off',
+    ], 'de', 'Mo,Schulferien geschlossen');
+
+test.addPrettifyValue('prettifyValue should translate weekday and month tokens in a mixed selector', [
+        'Jan Mo off',
+    ], 'de', 'Jan Mo geschlossen');
+
 test.addPrettifyValue('Compare prettifyValue', [
         'märz',
         'mär',


### PR DESCRIPTION
This fixes the `Mo,PH off` case in `prettifyValue` (see #320).

As ypid pointed out in the discussion, translating after assembling the full selector string is fragile for mixed groups like `Mo,PH`.

This change moves translation to token level while building the output, so `PH`/`SH` are translated correctly in grouped selectors as well.