### PR TITLE
feat: warn on ambiguous single-digit end hours

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -736,7 +736,11 @@ export default function(value, nominatim_object, optional_conf_parm) {
                                 'interpreted_as_year', t('interpreted as year', {number:  Number(tmp[1])})
                         ]);
                 } else {
-                    curr_rule_tokens.push([Number(tmp[1]), 'number', value.length ]);
+                    const num_token = [Number(tmp[1]), 'number', value.length];
+                    // Store whether the original numeric lexeme had a single digit (e.g. "9").
+                    // Only consulted at hour positions, where a single digit (0-9) is ambiguous.
+                    num_token.single_digit_lexeme = tmp[1].length === 1;
+                    curr_rule_tokens.push(num_token);
                 }
 
                 value = value.substr(tmp[1].length + (typeof tmp[2] === 'string' ? tmp[2].length : 0));
@@ -1835,6 +1839,30 @@ export default function(value, nominatim_object, optional_conf_parm) {
                     } else {
                         if (has_normal_time[1]) {
                             minutes_to = getMinutesByHoursMinutes(tokens, nrule, at_end_time);
+                            const from_hour = tokens[at][0];
+                            const to_hour = tokens[at_end_time][0];
+                            // to_hour < 12: am/pm correction can raise the value of a single-digit
+                            // lexeme to >= 12 (e.g. "8pm" -> 20), which is not ambiguous.
+                            const ambiguous_end_hour = tokens[at_end_time].single_digit_lexeme === true && to_hour < 12;
+
+                            // The end hour is ambiguous regardless of the start type
+                            // (e.g. "12:00-6:00" or "sunrise-6:00").
+                            if (!done_with_warnings && ambiguous_end_hour) {
+                                const ambiguous_hours = [];
+                                // The start hour only adds ambiguity when it is a single-digit
+                                // clock time (not a variable time) and the end hour is ambiguous too.
+                                if (tokens[at].single_digit_lexeme === true && from_hour < 12) {
+                                    ambiguous_hours.push([at, from_hour]);
+                                }
+                                ambiguous_hours.push([at_end_time, to_hour]);
+
+                                for (const [token_index, hour] of ambiguous_hours) {
+                                    parsing_warnings.push([nrule, token_index, 'ambiguous_single_digit_hour', t('ambiguous single digit hour', {
+                                        'hour':    hour,
+                                        'hour_pm': hour + 12,
+                                    })]);
+                                }
+                            }
                         } else {
                             timevar_string[1] = tokens[at_end_time+has_time_var_calc[1]][0];
                             minutes_to = word_value_replacement[timevar_string[1]];

--- a/src/locales/translations.yaml
+++ b/src/locales/translations.yaml
@@ -77,6 +77,7 @@ en:
     'outside current day': 'Time range starts outside of the current day'
     'two midnights': 'Time spanning more than two midnights not supported'
     'without minutes': 'Time range without minutes specified. Not very explicit! Please use this syntax instead "{{syntax}}".'
+    'ambiguous single digit hour': 'Single-digit hour "{{hour}}" without leading zero - could mean {{hour}} (in the morning) or {{hour_pm}} (after midday). Add a leading zero like "0{{hour}}" or change it to "{{hour_pm}}" to be explicit.'
     'outside day': 'Time range starts outside of the current day'
     'zero calculation': 'Adding zero in a variable time calculation does not change the variable time. Please omit the calculation (example: "sunrise-(sunset-00:00)").'
     'calculation syntax': 'Calculation with variable time is not in the right syntax'
@@ -217,6 +218,7 @@ de:
     outside current day: "Zeitspanne beginnt außerhalb des aktuellen Tages"
     two midnights: "Zeitspanne welche mehrmals Mitternacht beinhaltet wird nicht unterstützt"
     without minutes: "Zeitspanne ohne Minutenangabe angegeben. Das ist nicht sehr eindeutig! Bitte verwende stattdessen folgende Syntax \"{{syntax}}\"."
+    ambiguous single digit hour: 'Einstellige Stunde "{{hour}}" ohne führende Null - könnte {{hour}} Uhr (morgens) oder {{hour_pm}} Uhr (nachmittags) bedeuten. Führende Null ergänzen, z.B. "0{{hour}}", oder auf "{{hour_pm}}" ändern, um dies eindeutig zu machen.'
     outside day: "Die Zeitspanne beginnt außerhalb des aktuellen Tages"
     zero calculation: "Das Hinzufügen von 0 in einer variablen Zeitberechnung ändert die variable Zeit nicht. Bitte entferne die Zeitberechnung (Beispiel: \"sunrise-(sunset-00:00)\")."
     calculation syntax: "Berechnung mit variabler Zeit hat nicht die korrekte Syntax"
@@ -380,6 +382,7 @@ fr:
     outside current day: "La plage horaire commence en dehors du jour actuel."
     two midnights: "La plage horaire couvrant plusieurs fois minuit n'est pas prise en charge."
     without minutes: "Plage horaire spécifiée sans minutes. Ce n'est pas très précis ! Veuillez utiliser la syntaxe \"{{syntax}}\" à la place."
+    ambiguous single digit hour: 'Heure à un seul chiffre "{{hour}}" sans zéro initial - cela peut signifier {{hour}} h (le matin) ou {{hour_pm}} h (l''après-midi). Ajoutez un zéro initial, par exemple "0{{hour}}", ou remplacez-la par "{{hour_pm}}" pour lever l''ambiguïté.'
     outside day: "La plage horaire commence en dehors du jour actuel."
     zero calculation: "L'ajout de 0 dans un calcul de temps variable ne modifie pas le temps variable. Veuillez supprimer le calcul de temps (exemple : \"sunrise-(sunset-00:00)\")."
     calculation syntax: "Le calcul avec un temps variable n'a pas la syntaxe correcte."

--- a/test/test.de.log
+++ b/test/test.de.log
@@ -2051,6 +2051,19 @@ With [34m[1mwarnings[22m[39m:
 "Value not ideal (probably wrong). Should throw a warning. warnings_severity: 5, "tag_key": "opening_hours"" for "Mo-Fr 08:00-16:00": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
 	*Mo-Fr 08:00-16:00 <--- (Es wurde keine Regel für "PH" (feiertags) angegeben. Dies ist nicht sehr aussagekräftig. Bitte füge die Regel "PH off" an, wenn die Einrichtung an allen Feiertagen geschlossen ist oder schreibe "Sa,Su,PH 12:00-16:00" um auszudrücken, dass Samstags, Sonntags und feiertags von 12:00-16:00 geöffnet ist. Bei einer Öffnungszeit wie "Fr-Sa 18:00-06:00" ist Vorsicht geboten, da "PH off" auf 00:00-24:00 zutrifft. Hier kann "Fr-Sa 18:00-06:00; PH 18:00-06:00 off" verwendet werden. Falls die Einrichtung täglich und an Feiertagen geöffnet ist, kann dies explizit mittels "Mo-Su,PH" ausgedrückt werden. Wenn du dir im Unklaren bist, versuche die Öffnungszeit zu klären. Falls das nicht möglich ist, lass die Angabe weg und ignoriere diese Warnung.)
+"Structured warning: ambiguous single-digit start and end hour" for "9:00-6:00": [32m[1mPASSED[22m[39m
+"Structured warning: ambiguous single-digit end hour only" for "11:00-6:00": [32m[1mPASSED[22m[39m
+"Structured warning: ambiguous single-digit end hour with leading-zero start" for "09:00-6:00": [32m[1mPASSED[22m[39m
+"Structured warning: no warning for unambiguous single-digit hours" for "Mo 8:00-22:00": [32m[1mPASSED[22m[39m
+"Structured warning: no warning for afternoon single-digit end hour" for "9:00-15:00": [32m[1mPASSED[22m[39m
+"Structured warning: no warning for unambiguous end hour >= 12" for "7:00-13:00": [32m[1mPASSED[22m[39m
+"Structured warning: ambiguous single-digit end hour with afternoon start" for "12:00-6:00": [32m[1mPASSED[22m[39m
+"Structured warning: ambiguous single-digit end hour with evening start" for "20:00-6:00": [32m[1mPASSED[22m[39m
+"Structured warning: ambiguous single-digit end hour with variable-time start" for "sunrise-9:00": [32m[1mPASSED[22m[39m
+"Structured warning: no warning for variable-time start with unambiguous end hour" for "sunrise-15:00": [32m[1mPASSED[22m[39m
+"Structured warning: no warning for variable-time start with leading-zero end" for "sunrise-09:00": [32m[1mPASSED[22m[39m
+"Structured warning: no warning when leading zeros are used" for "09:00-06:00": [32m[1mPASSED[22m[39m
+"Structured warning: no warning with leading zeros and weekdays" for "Tu-Sa 09:00-06:00": [32m[1mPASSED[22m[39m
 "Structured warning: time range without minutes" for "Mo 10-12": [32m[1mPASSED[22m[39m
 "Structured warning: word error correction has stable type" for "Mon": [32m[1mPASSED[22m[39m
 "Structured warning: no warnings yields empty list" for "Mo 10:00-12:00": [32m[1mPASSED[22m[39m
@@ -2651,7 +2664,7 @@ Der optional_conf_parm["tag_key"] fehlt, ist aber notwendig wegen optional_conf_
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-1016/1016 tests passed. 0 did not pass.
+1029/1029 tests passed. 0 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.en.log
+++ b/test/test.en.log
@@ -2051,6 +2051,19 @@ With [34m[1mwarnings[22m[39m:
 "Value not ideal (probably wrong). Should throw a warning. warnings_severity: 5, "tag_key": "opening_hours"" for "Mo-Fr 08:00-16:00": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
 	*Mo-Fr 08:00-16:00 <--- (There was no PH (public holiday) specified. This is not very explicit. Please either append a "PH off" rule if the amenity is closed on all public holidays or use something like "Sa,Su,PH 12:00-16:00" to say that on Saturdays, Sundays and on public holidays the amenity is open 12:00-16:00. Be careful with opening hours like "Fr-Sa 18:00-06:00" because "PH off" applies to 00:00-24:00. So "Fr-Sa 18:00-06:00; PH 18:00-06:00 off" is probably what you want. If the amenity is open everyday including public holidays then you can make this explicit by writing "Mo-Su,PH". If you are not certain try to find it out. If you can’t then do not add PH to the value and ignore this warning.)
+"Structured warning: ambiguous single-digit start and end hour" for "9:00-6:00": [32m[1mPASSED[22m[39m
+"Structured warning: ambiguous single-digit end hour only" for "11:00-6:00": [32m[1mPASSED[22m[39m
+"Structured warning: ambiguous single-digit end hour with leading-zero start" for "09:00-6:00": [32m[1mPASSED[22m[39m
+"Structured warning: no warning for unambiguous single-digit hours" for "Mo 8:00-22:00": [32m[1mPASSED[22m[39m
+"Structured warning: no warning for afternoon single-digit end hour" for "9:00-15:00": [32m[1mPASSED[22m[39m
+"Structured warning: no warning for unambiguous end hour >= 12" for "7:00-13:00": [32m[1mPASSED[22m[39m
+"Structured warning: ambiguous single-digit end hour with afternoon start" for "12:00-6:00": [32m[1mPASSED[22m[39m
+"Structured warning: ambiguous single-digit end hour with evening start" for "20:00-6:00": [32m[1mPASSED[22m[39m
+"Structured warning: ambiguous single-digit end hour with variable-time start" for "sunrise-9:00": [32m[1mPASSED[22m[39m
+"Structured warning: no warning for variable-time start with unambiguous end hour" for "sunrise-15:00": [32m[1mPASSED[22m[39m
+"Structured warning: no warning for variable-time start with leading-zero end" for "sunrise-09:00": [32m[1mPASSED[22m[39m
+"Structured warning: no warning when leading zeros are used" for "09:00-06:00": [32m[1mPASSED[22m[39m
+"Structured warning: no warning with leading zeros and weekdays" for "Tu-Sa 09:00-06:00": [32m[1mPASSED[22m[39m
 "Structured warning: time range without minutes" for "Mo 10-12": [32m[1mPASSED[22m[39m
 "Structured warning: word error correction has stable type" for "Mon": [32m[1mPASSED[22m[39m
 "Structured warning: no warnings yields empty list" for "Mo 10:00-12:00": [32m[1mPASSED[22m[39m
@@ -2641,7 +2654,7 @@ The optional_conf_parm["tag_key"] is missing, required by optional_conf_parm["ma
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-1006/1006 tests passed. 0 did not pass.
+1019/1019 tests passed. 0 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.js
+++ b/test/test.js
@@ -5351,6 +5351,71 @@ test.addShouldWarn('Value not ideal (probably wrong). Should throw a warning. wa
 test.addShouldWarn('Value not ideal (probably wrong). Should throw a warning. warnings_severity: 5, "tag_key": "opening_hours"', [
         'Mo-Fr 08:00-16:00',
     ], nominatim_default, 'not only test', { 'warnings_severity': 5, 'tag_key': 'opening_hours' });
+
+test.addStructuredWarnings('Structured warning: ambiguous single-digit start and end hour',
+    '9:00-6:00',
+    [ 'ambiguous_single_digit_hour', 'ambiguous_single_digit_hour' ],
+    nominatim_default, 'not only test', { 'tag_key': 'opening_hours' });
+
+test.addStructuredWarnings('Structured warning: ambiguous single-digit end hour only',
+    '11:00-6:00',
+    [ 'ambiguous_single_digit_hour' ],
+    nominatim_default, 'not only test', { 'tag_key': 'opening_hours' });
+
+test.addStructuredWarnings('Structured warning: ambiguous single-digit end hour with leading-zero start',
+    '09:00-6:00',
+    [ 'ambiguous_single_digit_hour' ],
+    nominatim_default, 'not only test', { 'tag_key': 'opening_hours' });
+
+test.addStructuredWarnings('Structured warning: no warning for unambiguous single-digit hours',
+    'Mo 8:00-22:00',
+    [],
+    nominatim_default, 'not only test', { 'tag_key': 'opening_hours' });
+
+test.addStructuredWarnings('Structured warning: no warning for afternoon single-digit end hour',
+    '9:00-15:00',
+    [],
+    nominatim_default, 'not only test', { 'tag_key': 'opening_hours' });
+
+test.addStructuredWarnings('Structured warning: no warning for unambiguous end hour >= 12',
+    '7:00-13:00',
+    [],
+    nominatim_default, 'not only test', { 'tag_key': 'opening_hours' });
+
+test.addStructuredWarnings('Structured warning: ambiguous single-digit end hour with afternoon start',
+    '12:00-6:00',
+    [ 'ambiguous_single_digit_hour' ],
+    nominatim_default, 'not only test', { 'tag_key': 'opening_hours' });
+
+test.addStructuredWarnings('Structured warning: ambiguous single-digit end hour with evening start',
+    '20:00-6:00',
+    [ 'ambiguous_single_digit_hour' ],
+    nominatim_default, 'not only test', { 'tag_key': 'opening_hours' });
+
+test.addStructuredWarnings('Structured warning: ambiguous single-digit end hour with variable-time start',
+    'sunrise-9:00',
+    [ 'ambiguous_single_digit_hour' ],
+    nominatim_default, 'not only test', { 'tag_key': 'opening_hours' });
+
+test.addStructuredWarnings('Structured warning: no warning for variable-time start with unambiguous end hour',
+    'sunrise-15:00',
+    [],
+    nominatim_default, 'not only test', { 'tag_key': 'opening_hours' });
+
+test.addStructuredWarnings('Structured warning: no warning for variable-time start with leading-zero end',
+    'sunrise-09:00',
+    [],
+    nominatim_default, 'not only test', { 'tag_key': 'opening_hours' });
+
+test.addStructuredWarnings('Structured warning: no warning when leading zeros are used',
+    '09:00-06:00',
+    [],
+    nominatim_default, 'not only test', { 'tag_key': 'opening_hours' });
+
+test.addStructuredWarnings('Structured warning: no warning with leading zeros and weekdays',
+    'Tu-Sa 09:00-06:00',
+    [],
+    nominatim_default, 'not only test', { 'tag_key': 'opening_hours' });
 // }}}
 
 // getStructuredWarnings: machine-readable warning objects {{{


### PR DESCRIPTION
Fixes #581.

This adds a warning for ranges like `9:00-6:00`, where the single-digit hours are easy to misread. In the reported case this was parsed as `09:00-06:00`, but the shop actually meant `09:00-18:00`.

The warning stays deliberately narrow: `09:00-06:00` is still fine, `9:00-15:00` stays quiet, and am/pm times are ignored. So the warning should mostly catch the cases where adding a leading zero or changing the hour to its afternoon form would make the mapper's intent clear.

This change also covers variable-time starts such as `sunrise-9:00`, because the end hour is ambiguous in the same way.

I added quite a few tests (maybe too many) to cover the edge cases here: padded vs. unpadded hours, overnight ranges, am/pm input, and variable-time starts.

**Example warning message:**

```
Single-digit hour "6" without leading zero - could mean 6 (in the morning) or 18 (after midday). Add a leading zero like "06" or change it to "18" to be explicit.
```