### PR TITLE
refactor(evaluation-tool): restructure result layout

### DIFF
--- a/site/css/main.css
+++ b/site/css/main.css
@@ -437,6 +437,10 @@ section {
     width: 98%;
 }
 
+#show_prettified_value:empty {
+    display: none;
+}
+
 /* Ensure diff_value input has black text when colored background is applied */
 #diff_value {
     color: #000 !important;

--- a/site/index.html
+++ b/site/index.html
@@ -33,7 +33,6 @@
         <main id="user">
             <form id="check" action="#">
                 <!-- User input -->
-                <section id="date-time-inputs"></section>
                 <section id="position-inputs"></section>
                 <section id="mode-selector"></section>
 
@@ -53,8 +52,8 @@
                     </div>
                 </section>
 
-                <section id="actions-section">
-                    <h2 id="actions-heading"></h2>
+                <section id="compare-section">
+                    <h2 id="compare-heading"></h2>
 
                     <div id="action-compare" class="action-item">
                         <div class="action-description" id="compare-label"></div>
@@ -67,6 +66,26 @@
                         </div>
                         <div id="compare-result"></div>
                     </div>
+                </section>
+
+                <section id="results-section">
+                    <h2 id="results-heading"></h2>
+                    <div id="show_prettified_value"></div>
+
+                    <div id="show_warnings_or_errors">
+                    </div>
+
+                    <div id="date-time-inputs"></div>
+
+                    <div id="show_time_table">
+                    </div>
+
+                    <div id="show_results">
+                    </div>
+                </section>
+
+                <section id="actions-section">
+                    <h2 id="actions-heading"></h2>
 
                     <div id="action-links">
                         <div id="action-permalink" class="action-item">
@@ -92,18 +111,6 @@
                         <div id="action-josm" class="action-item"></div>
 
                         <div id="action-yohours" class="action-item"></div>
-                    </div>
-                </section>
-
-                <section id="results-section">
-                    <h2 id="results-heading"></h2>
-                    <div id="show_warnings_or_errors">
-                    </div>
-
-                    <div id="show_time_table">
-                    </div>
-
-                    <div id="show_results">
                     </div>
                 </section>
 

--- a/site/js/helpers.js
+++ b/site/js/helpers.js
@@ -539,6 +539,7 @@ export async function Evaluate (offset = 0, reset) {
     // Cache DOM elements
     const showTimeTable = document.getElementById('show_time_table');
     const showWarningsOrErrors = document.getElementById('show_warnings_or_errors');
+    const showPrettifiedValue = document.getElementById('show_prettified_value');
     const showResults = document.getElementById('show_results');
     const actionJosm = document.getElementById('action-josm');
     const actionYoHours = document.getElementById('action-yohours');
@@ -561,6 +562,7 @@ export async function Evaluate (offset = 0, reset) {
     } catch (err) {
         crashed = err;
         showWarningsOrErrors.replaceChildren(createMessageBox('error', crashed));
+        showPrettifiedValue.innerHTML = '';
         showTimeTable.innerHTML = '';
         showResults.innerHTML = '';
     }
@@ -580,6 +582,7 @@ export async function Evaluate (offset = 0, reset) {
 
         // Display value explanation
         showWarningsOrErrors.replaceChildren(generateValueExplanationFragment(prettifiedValueArray));
+        showPrettifiedValue.innerHTML = '';
 
         // Display matching rule
         const ruleIndex = it.getMatchingRule();
@@ -590,7 +593,7 @@ export async function Evaluate (offset = 0, reset) {
 
         // Show prettified value if different from input
         if (prettified !== value) {
-            showWarningsOrErrors.append(generatePrettifiedValueFragment(prettified));
+            showPrettifiedValue.append(generatePrettifiedValueFragment(prettified));
         }
 
         // Append warnings if any

--- a/site/js/main.js
+++ b/site/js/main.js
@@ -132,6 +132,7 @@ function initializeUI() {
 
     // Actions section
     document.getElementById('actions-heading').textContent = i18next.t('words.actions');
+    document.getElementById('compare-heading').textContent = i18next.t('words.compare');
     document.getElementById('compare-label').textContent = i18next.t('texts.value to compare');
     document.getElementById('action-permalink-label').textContent = i18next.t('texts.share config');
     document.getElementById('permalink-with-timestamp-label').textContent = i18next.t('texts.with timestamp');


### PR DESCRIPTION
Keep comparison and prettified output close to the original value. Move date and time controls next to the schedule they affect. Move less frequently used external actions below the main results to reduce scrolling during evaluation.

Refs #610