### PR TITLE
fix(parser): handle numeric day offsets without special cases

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -688,6 +688,25 @@ export default function(value, nominatim_object, optional_conf_parm) {
         };
 
         let last_rule_fallback_terminated = false;
+        const NUMERIC_DAY_OFFSET_PATTERN = String.raw`\d+\s*days?(?!\s*(?:a|\/)\s*week)\b`;
+        const ERROR_TOLERANCE_ALTERNATIVES = [
+            String.raw`&|_|→|‐|‑|‒|–|−|—|ー|=|·`,
+            String.raw`öffnungszeit(?:en)?:?|opening_hours\s*=|\?|~|～|：`,
+            String.raw`always (?:open|closed)|24x7|24 hours 7 days a week|24 hours`,
+            String.raw`7 ?days(?:(?: a |\/)week)?|7j?\/7|all days?|every day`,
+            String.raw`(?:bis|till?|-|–)? ?(?:open ?end|late)`,
+            String.raw`(?:(?:one )?day (?:before|after) )?(?:school|public) holidays?`,
+            String.raw`days(?=\s|$|[^\p{L}_])|до|рм|ам|jours fériés|on work days?|sonntags?`,
+            String.raw`(?:nur |an )?sonn-?(?:(?: und |\/)feiertag(?:s|en?)?)?`,
+            String.raw`(?:an )?feiertag(?:s|en?)?|(?:nach|on|by) (?:appointments?|vereinbarung|absprache)`,
+            String.raw`p\.m\.|a\.m\.`,
+            String.raw`(?:[^\s\d\p{P}\p{S}\p{C}]|_)+(?=\s|$|[\s\d\p{Po}\p{Ps}\p{Pe}\p{Pd}\p{Pf}\p{Pi}\p{S}\p{C}])`,
+            String.raw`à|á|mo|tu|we|th|fr|sa|su|jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec`,
+        ].join('|');
+        const ERROR_TOLERANCE_REGEX = new RegExp(
+            String.raw`^(?!${NUMERIC_DAY_OFFSET_PATTERN})(${ERROR_TOLERANCE_ALTERNATIVES})(\.?)`,
+            'iu'
+        );
 
         while (value !== '') {
             /* Ordered after likelihood of input for performance reasons.
@@ -767,7 +786,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
                             'please_use_ok_for_ko', t('please use ok for ko', {'ko': tmp[0], 'ok': ok})]);
                 }
                 value = ok + value.substr(tmp[0].length);
-            } else if ((tmp = value.match(/^(&|_|→|‐|‑|‒|–|−|—|ー|=|·|öffnungszeit(?:en)?:?|opening_hours\s*=|\?|~|～|：|always (?:open|closed)|24x7|24 hours 7 days a week|24 hours|7 ?days(?:(?: a |\/)week)?|7j?\/7|all days?|every day|(?:bis|till?|-|–)? ?(?:open ?end|late)|(?:(?:one )?day (?:before|after) )?(?:school|public) holidays?|days(?=\s|$|[^\p{L}_])|до|рм|ам|jours fériés|on work days?|sonntags?|(?:nur |an )?sonn-?(?:(?: und |\/)feiertag(?:s|en?)?)?|(?:an )?feiertag(?:s|en?)?|(?:nach|on|by) (?:appointments?|vereinbarung|absprache)|p\.m\.|a\.m\.|(?:[^\s\d\p{P}\p{S}\p{C}]|_)+(?=\s|$|[\s\d\p{Po}\p{Ps}\p{Pe}\p{Pd}\p{Pf}\p{Pi}\p{S}\p{C}])|à|á|mo|tu|we|th|fr|sa|su|jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)(\.?)/iu))) {
+            } else if ((tmp = value.match(ERROR_TOLERANCE_REGEX))) {
                 /* Handle all remaining words and specific other characters with error tolerance.
                  *
                  * à|á: Word boundary does not work with Unicode chars: 'test à test'.match(/\bà\b/i)
@@ -882,11 +901,11 @@ export default function(value, nominatim_object, optional_conf_parm) {
                                 'interpreted_as_year', t('interpreted as year', {number:  Number(tmp[1])})
                         ]);
                 } else {
-                    const num_token = [Number(tmp[1]), 'number', value.length];
+                    const number_token = [ Number(tmp[1]), 'number', value.length ];
                     // Store whether the original numeric lexeme had a single digit (e.g. "9").
                     // Only consulted at hour positions, where a single digit (0-9) is ambiguous.
-                    num_token.single_digit_lexeme = tmp[1].length === 1;
-                    curr_rule_tokens.push(num_token);
+                    number_token.single_digit_lexeme = tmp[1].length === 1;
+                    curr_rule_tokens.push(number_token);
                 }
 
                 value = value.substr(tmp[1].length + (typeof tmp[2] === 'string' ? tmp[2].length : 0));
@@ -2381,7 +2400,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
                     );
                 }
 
-                const add_days = getMoveDays(tokens, endat+1, 6, 'constrained weekdays');
+                const add_days = getMoveDays(tokens, endat+1, 6, 'max differ name constrained weekdays');
                 week_stable = false;
 
                 // Create selector for each list element.
@@ -2547,14 +2566,14 @@ export default function(value, nominatim_object, optional_conf_parm) {
      *            0. Days to add.
      *            1. How many tokens.
      */
-    function getMoveDays(tokens, at, max_differ, name) {
+    function getMoveDays(tokens, at, max_differ, name_key) {
         const add_days = [ 0, 0 ]; // [ 'days to add', 'how many tokens' ]
         add_days[0] = matchTokens(tokens, at, '+') || (matchTokens(tokens, at, '-') ? -1 : 0);
         if (add_days[0] !== 0 && matchTokens(tokens, at+1, 'number', 'calcday')) {
             // continues with '+ 5 days' or something like that
             if (tokens[at+1][0] > max_differ)
                 throw formatWarnErrorMessage(nrule, at+2,
-                    t('max differ',{'maxdiffer': max_differ, 'name': name}));
+                    t('max differ', {'maxdiffer': max_differ, 'name': t(name_key)}));
             add_days[0] *= tokens[at+1][0];
             if (add_days[0] === 0 && !done_with_warnings)
                 parsing_warnings.push([ nrule, at+2, 'adding_0', t('adding 0') ]);
@@ -2579,7 +2598,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
         const applying_holidays = getMatchingHoliday(holiday_type);
 
         if (holiday_type === 'PH') {
-            const add_days = getMoveDays(tokens, at + 1, 1, 'public holiday');
+            const add_days = getMoveDays(tokens, at + 1, 1, 'max differ name public holiday');
             const selector = createPublicHolidaySelector(applying_holidays, add_days);
             target_array.push(selector);
             return at + 1 + add_days[1];
@@ -3737,12 +3756,12 @@ export default function(value, nominatim_object, optional_conf_parm) {
             has_event[0] = matchTokens(tokens, at+has_year[0], 'event');
 
             if (has_event[0])
-                has_calc[0] = getMoveDays(tokens, at+has_year[0]+1, 200, 'event like easter');
+                has_calc[0] = getMoveDays(tokens, at+has_year[0]+1, 200, 'max differ name event like easter');
 
             let at_range_sep;
             if (matchTokens(tokens, at+has_year[0], 'month', 'weekday', '[')) {
                 has_constrained_weekday[0] = getConstrainedWeekday(tokens, at+has_year[0]+3);
-                has_calc[0] = getMoveDays(tokens, has_constrained_weekday[0][1], 6, 'constrained weekdays');
+                has_calc[0] = getMoveDays(tokens, has_constrained_weekday[0][1], 6, 'max differ name constrained weekdays');
                 at_range_sep = has_constrained_weekday[0][1] + (typeof has_calc[0] === 'object' && has_calc[0][1] ? 3 : 0);
             } else {
                 at_range_sep = at+has_year[0]
@@ -3759,10 +3778,10 @@ export default function(value, nominatim_object, optional_conf_parm) {
                 if (!has_month[1]) {
                     has_event[1] = matchTokens(tokens, at_sec_event_or_month, 'event');
                     if (has_event[1]) {
-                        has_calc[1] = getMoveDays(tokens, at_sec_event_or_month+1, 366, 'event like easter');
+                        has_calc[1] = getMoveDays(tokens, at_sec_event_or_month+1, 366, 'max differ name event like easter');
                     } else if (matchTokens(tokens, at_sec_event_or_month, 'month', 'weekday', '[')) {
                         has_constrained_weekday[1] = getConstrainedWeekday(tokens, at_sec_event_or_month+3);
-                        has_calc[1] = getMoveDays(tokens, has_constrained_weekday[1][1], 6, 'constrained weekdays');
+                        has_calc[1] = getMoveDays(tokens, has_constrained_weekday[1][1], 6, 'max differ name constrained weekdays');
                     }
                 }
             }

--- a/src/locales/translations.yaml
+++ b/src/locales/translations.yaml
@@ -89,6 +89,9 @@ en:
     'additional rule no sense': 'An additional rule does not make sense here. Just use a ";" as rule separator. See https://wiki.openstreetmap.org/wiki/Key:opening_hours/specification#explain:additional_rule_separator'
     'unexpected token weekday range': 'Unexpected token in weekday range: {{token}}'
     'max differ': 'There should be no reason to differ more than {{maxdiffer}} days from a {{name}}. If so tell us …'
+    'max differ name constrained weekdays': 'constrained weekdays'
+    'max differ name event like easter': 'event like Easter'
+    'max differ name public holiday': 'public holiday'
     'adding 0': 'Adding 0 does not change the date. Please omit this.'
     'unexpected token holiday': 'Unexpected token (holiday parser): {{token}}'
     'no holiday definition': 'There are no holidays ({{name}}) defined for country {{cc}}.'
@@ -233,6 +236,9 @@ de:
       Siehe https://wiki.openstreetmap.org/wiki/Key:opening_hours/specification#explain:additional_rule_separator
     unexpected token weekday range: "Unerwartes Token in Tages-Spanne: {{token}}"
     max differ: "Es sollte keinen Grund geben, mehr als {{maxdiffer}} Tage von einem {{name}} abzuweichen. Wenn nötig, teile uns dies bitte mit …"
+    max differ name constrained weekdays: "Wochentag mit Monatsbeschränkung"
+    max differ name event like easter: "beweglichen Feiertag"
+    max differ name public holiday: "Feiertag"
     adding 0: "Addition von 0 verändert das Datum nicht. Bitte weglassen."
     unexpected token holiday: "Unerwarteter Token (in Feiertags-Auswertung): {{token}}"
     no holiday definition: "{{name}} ist für das Land {{cc}} nicht definiert."
@@ -397,6 +403,9 @@ fr:
       Voir https://wiki.openstreetmap.org/wiki/Key:opening_hours/specification#explain:additional_rule_separator
     unexpected token weekday range: "Token inattendu dans la plage de jours : {{token}}"
     max differ: "Il ne devrait pas y avoir de raison de s'écarter de plus de {{maxdiffer}} jours d'un {{name}}. Si nécessaire, veuillez nous en informer…"
+    max differ name constrained weekdays: "jour de semaine contraint"
+    max differ name event like easter: "événement comme Pâques"
+    max differ name public holiday: "jour férié"
     adding 0: "L'addition de 0 ne modifie pas la date. Veuillez l'omettre."
     unexpected token holiday: "Token inattendu (dans l'évaluation des jours fériés) : {{token}}"
     no holiday definition: "{{name}} n'est pas défini pour le pays {{cc}}."

--- a/src/locales/word_error_correction.yaml
+++ b/src/locales/word_error_correction.yaml
@@ -93,8 +93,6 @@
   "all days": "Mo-Su"
   "7j/7": "Mo-Su"
   "7/7": "Mo-Su"
-  "7days": "Mo-Su"
-  "7 days": "Mo-Su"
   "7 days a week": "Mo-Su"
   "7 days/week": "Mo-Su"
   "24 hours 7 days a week": "24/7"

--- a/src/locales/word_error_correction_manual.yaml
+++ b/src/locales/word_error_correction_manual.yaml
@@ -98,8 +98,6 @@
   'all days': Mo-Su
   '7j/7': Mo-Su
   '7/7': Mo-Su
-  '7days': Mo-Su
-  '7 days': Mo-Su
   '7 days a week': Mo-Su
   '7 days/week': Mo-Su
   '24 hours 7 days a week': 24/7

--- a/test/test.de.log
+++ b/test/test.de.log
@@ -408,6 +408,10 @@ With [34m[1mwarnings[22m[39m:
 With [34m[1mwarnings[22m[39m:
 	*public holiday <--- (Bitte verwende "PH" anstelle von "public holiday".)
 	*public holiday <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
+"#622: seven-day variable date offset" for "easter -7 days-Nov 01: Tu-Sa 10:00-12:00,13:30-17:00; Su,PH 11:00-17:00": [32m[1mPASSED[22m[39m
+"#622: seven-day variable date offset" for "Easter - 7days - Nov 01: Tu-Sa 10:00-12:00, 13:30-17:00; Su, PH 11:00-17:00": [32m[1mPASSED[22m[39m
+"#622: seven-day variable date offset" for "Easter -7 day-Nov 01: Tu-Sa 10:00-12:00,13:30-17:00; Su,PH 11:00-17:00": [32m[1mPASSED[22m[39m
+"#622: seven-day variable date offset" for "Easter - 07 days - Nov 01: Tu-Sa 10:00-12:00, 13:30-17:00; Su, PH 11:00-17:00": [32m[1mPASSED[22m[39m
 "Variable days: school holidays" for "SH": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
 	*SH <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
@@ -1670,10 +1674,6 @@ With [34m[1mwarnings[22m[39m:
 With [34m[1mwarnings[22m[39m:
 	*every day <--- (Bitte verwende "Mo-Su" anstelle von "every day".)
 	*every day <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
-"Error tolerance: Full range" for "7days": [32m[1mPASSED[22m[39m
-With [34m[1mwarnings[22m[39m:
-	*7days <--- (Bitte verwende "Mo-Su" anstelle von "7days".)
-	*7days <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
 "Error tolerance: Full range" for "7j/7": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
 	*7j/7 <--- (Bitte verwende "Mo-Su" anstelle von "7j/7".)
@@ -1682,10 +1682,6 @@ With [34m[1mwarnings[22m[39m:
 With [34m[1mwarnings[22m[39m:
 	*7/7 <--- (Bitte verwende "Mo-Su" anstelle von "7/7".)
 	*7/7 <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
-"Error tolerance: Full range" for "7 days": [32m[1mPASSED[22m[39m
-With [34m[1mwarnings[22m[39m:
-	*7 days <--- (Bitte verwende "Mo-Su" anstelle von "7 days".)
-	*7 days <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
 "Error tolerance: Full range" for "7 days a week": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
 	*7 days a week <--- (Bitte verwende "Mo-Su" anstelle von "7 days a week".)
@@ -2114,9 +2110,6 @@ Der Wert enthält nichts, was ausgewertet werden könnte.
 "Incorrect syntax which should throw an error" for "||": [32m[1mPASSED[22m[39m
 || <--- (Die Regel vor der Fallback-Regel enthält nichts nützliches)
 
-"Incorrect syntax which should throw an error" for "Mo[2] - 7 days; 00:23-00:42 unknown "warning at correct position?"": [32m[1mPASSED[22m[39m
-Mo[2] -  <--- (Unerwartetes Zeichen: "-" Das bedeutet, dass die Syntax an dieser Stelle nicht erkannt werden konnte.) Mo[2] - 7 days <--- (Bitte verwende "Mo-Su" anstelle von "7 days".)
-
 "Incorrect syntax which should throw an error" for ":week 02-54 00:00-24:00; 00:23-00:42 unknown "warning at correct position?"": [32m[1mPASSED[22m[39m
 : <--- (Unerwartetes Zeichen: "timesep" Das bedeutet, dass die Syntax an dieser Stelle nicht erkannt werden konnte.) 
 
@@ -2250,7 +2243,7 @@ Sa[1,3- <--- ("]" oder weitere Zahlen erwartet.)
 Sa[1,3,. <--- (Unexpected token in number range: timesep)
 
 "Incorrect syntax which should throw an error" for "PH + 2 day; 00:23-00:42 unknown "warning at correct position?"": [32m[1mPASSED[22m[39m
-PH + 2 day <--- (Es sollte keinen Grund geben, mehr als 1 Tage von einem public holiday abzuweichen. Wenn nötig, teile uns dies bitte mit …)
+PH + 2 day <--- (Es sollte keinen Grund geben, mehr als 1 Tage von einem Feiertag abzuweichen. Wenn nötig, teile uns dies bitte mit …)
 
 "Incorrect syntax which should throw an error" for "Su-PH; 00:23-00:42 unknown "warning at correct position?"": [32m[1mPASSED[22m[39m
 Su- <--- (Unerwartetes Zeichen: "-" Das bedeutet, dass die Syntax an dieser Stelle nicht erkannt werden konnte.) 
@@ -2259,7 +2252,7 @@ Su- <--- (Unerwartetes Zeichen: "-" Das bedeutet, dass die Syntax an dieser Stel
 2012,  <--- (Eine weitere Regel an dieser Stelle ergibt keinen Sinn. Benutze einfach ";" als Trenner für Regeln. Siehe https://wiki.openstreetmap.org/wiki/Key:opening_hours/specification#explain:additional_rule_separator)
 
 "Incorrect syntax which should throw an error" for "easter + 370 days; 00:23-00:42 unknown "warning at correct position?"": [32m[1mPASSED[22m[39m
-easter + 370 days <--- (Es sollte keinen Grund geben, mehr als 200 Tage von einem event like easter abzuweichen. Wenn nötig, teile uns dies bitte mit …)
+easter + 370 days <--- (Es sollte keinen Grund geben, mehr als 200 Tage von einem beweglichen Feiertag abzuweichen. Wenn nötig, teile uns dies bitte mit …)
 
 "Incorrect syntax which should throw an error" for "easter - 2 days - 2012 easter + 2 days: open "Easter Monday"; 00:23-00:42 unknown "warning at correct position?"": [32m[1mPASSED[22m[39m
 easter - 2 days -  <--- (Unerwartetes Zeichen: "-" Das bedeutet, dass die Syntax an dieser Stelle nicht erkannt werden konnte.) 
@@ -2449,6 +2442,9 @@ Dec 32 <--- (Die Tagesangabe für Dec muss zwischen 1 und 31 liegen.)
 
 "Incorrect syntax which should throw an error" for "We 12:00-18:00,,,,,,; 00:23-00:42 unknown "warning at correct position?"": [32m[1mPASSED[22m[39m
 We 12:00-18:00,, <--- (Unerwartetes Zeichen: "," Das bedeutet, dass die Syntax an dieser Stelle nicht erkannt werden konnte.) 
+
+"Constrained weekday offsets beyond six days should be rejected" for "Mo[2] - 7 days; 00:23-00:42 unknown "warning at correct position?"": [32m[1mPASSED[22m[39m
+Mo[2] - 7 days <--- (Es sollte keinen Grund geben, mehr als 6 Tage von einem Wochentag mit Monatsbeschränkung abzuweichen. Wenn nötig, teile uns dies bitte mit …)
 
 "Missing information (e.g. country or holidays not known to opening_hours.js)" for "PH": [32m[1mPASSED[22m[39m
 Der Ländercode fehlt. Dieser wird benötigt um die korrekten Feiertage zu bestimmen (siehe in der README wie dieser anzugeben ist)
@@ -2669,7 +2665,7 @@ Der optional_conf_parm["tag_key"] fehlt, ist aber notwendig wegen optional_conf_
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-1032/1032 tests passed. 0 did not pass.
+1034/1034 tests passed. 0 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.en.log
+++ b/test/test.en.log
@@ -408,6 +408,10 @@ With [34m[1mwarnings[22m[39m:
 With [34m[1mwarnings[22m[39m:
 	*public holiday <--- (Please use notation "PH" for "public holiday".)
 	*public holiday <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
+"#622: seven-day variable date offset" for "easter -7 days-Nov 01: Tu-Sa 10:00-12:00,13:30-17:00; Su,PH 11:00-17:00": [32m[1mPASSED[22m[39m
+"#622: seven-day variable date offset" for "Easter - 7days - Nov 01: Tu-Sa 10:00-12:00, 13:30-17:00; Su, PH 11:00-17:00": [32m[1mPASSED[22m[39m
+"#622: seven-day variable date offset" for "Easter -7 day-Nov 01: Tu-Sa 10:00-12:00,13:30-17:00; Su,PH 11:00-17:00": [32m[1mPASSED[22m[39m
+"#622: seven-day variable date offset" for "Easter - 07 days - Nov 01: Tu-Sa 10:00-12:00, 13:30-17:00; Su, PH 11:00-17:00": [32m[1mPASSED[22m[39m
 "Variable days: school holidays" for "SH": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
 	*SH <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
@@ -1670,10 +1674,6 @@ With [34m[1mwarnings[22m[39m:
 With [34m[1mwarnings[22m[39m:
 	*every day <--- (Please use notation "Mo-Su" for "every day".)
 	*every day <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
-"Error tolerance: Full range" for "7days": [32m[1mPASSED[22m[39m
-With [34m[1mwarnings[22m[39m:
-	*7days <--- (Please use notation "Mo-Su" for "7days".)
-	*7days <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
 "Error tolerance: Full range" for "7j/7": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
 	*7j/7 <--- (Please use notation "Mo-Su" for "7j/7".)
@@ -1682,10 +1682,6 @@ With [34m[1mwarnings[22m[39m:
 With [34m[1mwarnings[22m[39m:
 	*7/7 <--- (Please use notation "Mo-Su" for "7/7".)
 	*7/7 <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
-"Error tolerance: Full range" for "7 days": [32m[1mPASSED[22m[39m
-With [34m[1mwarnings[22m[39m:
-	*7 days <--- (Please use notation "Mo-Su" for "7 days".)
-	*7 days <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
 "Error tolerance: Full range" for "7 days a week": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
 	*7 days a week <--- (Please use notation "Mo-Su" for "7 days a week".)
@@ -2114,9 +2110,6 @@ The value contains nothing meaningful which can be parsed.
 "Incorrect syntax which should throw an error" for "||": [32m[1mPASSED[22m[39m
 || <--- (Rule before fallback rule does not contain anything useful)
 
-"Incorrect syntax which should throw an error" for "Mo[2] - 7 days; 00:23-00:42 unknown "warning at correct position?"": [32m[1mPASSED[22m[39m
-Mo[2] -  <--- (Unexpected token: "-" This means that the syntax is not valid at that point or it is currently not supported.) Mo[2] - 7 days <--- (Please use notation "Mo-Su" for "7 days".)
-
 "Incorrect syntax which should throw an error" for ":week 02-54 00:00-24:00; 00:23-00:42 unknown "warning at correct position?"": [32m[1mPASSED[22m[39m
 : <--- (Unexpected token: "timesep" This means that the syntax is not valid at that point or it is currently not supported.) 
 
@@ -2259,7 +2252,7 @@ Su- <--- (Unexpected token: "-" This means that the syntax is not valid at that 
 2012,  <--- (An additional rule does not make sense here. Just use a ";" as rule separator. See https://wiki.openstreetmap.org/wiki/Key:opening_hours/specification#explain:additional_rule_separator)
 
 "Incorrect syntax which should throw an error" for "easter + 370 days; 00:23-00:42 unknown "warning at correct position?"": [32m[1mPASSED[22m[39m
-easter + 370 days <--- (There should be no reason to differ more than 200 days from a event like easter. If so tell us …)
+easter + 370 days <--- (There should be no reason to differ more than 200 days from a event like Easter. If so tell us …)
 
 "Incorrect syntax which should throw an error" for "easter - 2 days - 2012 easter + 2 days: open "Easter Monday"; 00:23-00:42 unknown "warning at correct position?"": [32m[1mPASSED[22m[39m
 easter - 2 days -  <--- (Unexpected token: "-" This means that the syntax is not valid at that point or it is currently not supported.) 
@@ -2449,6 +2442,9 @@ Dec 32 <--- (The day for Dec must be between 1 and 31.)
 
 "Incorrect syntax which should throw an error" for "We 12:00-18:00,,,,,,; 00:23-00:42 unknown "warning at correct position?"": [32m[1mPASSED[22m[39m
 We 12:00-18:00,, <--- (Unexpected token: "," This means that the syntax is not valid at that point or it is currently not supported.) 
+
+"Constrained weekday offsets beyond six days should be rejected" for "Mo[2] - 7 days; 00:23-00:42 unknown "warning at correct position?"": [32m[1mPASSED[22m[39m
+Mo[2] - 7 days <--- (There should be no reason to differ more than 6 days from a constrained weekdays. If so tell us …)
 
 "Missing information (e.g. country or holidays not known to opening_hours.js)" for "PH": [32m[1mPASSED[22m[39m
 Country code missing which is needed to select the correct holidays (see README how to provide it)
@@ -2659,7 +2655,7 @@ The optional_conf_parm["tag_key"] is missing, required by optional_conf_parm["ma
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-1022/1022 tests passed. 0 did not pass.
+1024/1024 tests passed. 0 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.js
+++ b/test/test.js
@@ -821,6 +821,17 @@ test.addTest('Variable days: public holidays', [
         [ '2014-12-26 00:00', '2014-12-27 00:00', false, '2. Weihnachtstag' ],
     ], 1000 * 60 * 60 * 24 * (20 + 2 * 2), 0, false, nominatim_default, 'not only test');
 
+test.addTest('#622: seven-day variable date offset', [
+        'easter -7 days-Nov 01: Tu-Sa 10:00-12:00,13:30-17:00; Su,PH 11:00-17:00',
+        'Easter - 7days - Nov 01: Tu-Sa 10:00-12:00, 13:30-17:00; Su, PH 11:00-17:00',
+        'Easter -7 day-Nov 01: Tu-Sa 10:00-12:00,13:30-17:00; Su,PH 11:00-17:00',
+        'Easter - 07 days - Nov 01: Tu-Sa 10:00-12:00, 13:30-17:00; Su, PH 11:00-17:00',
+    ], '2026-03-29 0:00', '2026-04-01 0:00', [
+        [ '2026-03-29 11:00', '2026-03-29 17:00' ],
+        [ '2026-03-31 10:00', '2026-03-31 12:00' ],
+        [ '2026-03-31 13:30', '2026-03-31 17:00' ],
+    ], 1000 * 60 * 60 * (6 + 2 + 3.5), 0, false, nominatim_default, 'not only test');
+
 // Updated from 2014 to 2024 for OpenHolidays data (2020-2027)
 // Data source: OpenHolidays Git Submodule Baden-Württemberg
 test.addTest('Variable days: school holidays', [
@@ -5206,10 +5217,8 @@ test.addTest('Error tolerance: Full range', [
         'every day',
         'all days',
         'every day',
-        '7days',
         '7j/7',
         '7/7',
-        '7 days',
         '7 days a week',
         '7 days/week',
         'täglich',
@@ -5485,7 +5494,6 @@ test.addShouldFail('Incorrect syntax which should throw an error', [
         '||', // only rule delimiter
         // '12:00-14:00 ||',
         // }}}
-        'Mo[2] - 7 days' + value_suffix,
         ':week 02-54 00:00-24:00' + value_suffix,
         ':::week 02-54 00:00-24:00' + value_suffix,
         'week :2-54 00:00-24:00' + value_suffix,
@@ -5599,6 +5607,10 @@ test.addShouldFail('Incorrect syntax which should throw an error', [
         'Nov 31' + value_suffix,
         'Dec 32' + value_suffix,
         'We 12:00-18:00,,,,,,' + value_suffix,
+    ], nominatim_default, 'not last test');
+
+test.addShouldFail('Constrained weekday offsets beyond six days should be rejected', [
+        'Mo[2] - 7 days' + value_suffix,
     ], nominatim_default, 'not last test');
 
 test.addShouldFail('Missing information (e.g. country or holidays not known to opening_hours.js)', [


### PR DESCRIPTION
This fixes #622. I cross-checked the current usage in the OSM Planet data and found that `7days` and `7 days` are mostly used as part of date offsets, for example `Easter - 7days`. I therefore changed the parser so these expressions are handled as regular date offsets instead of being mistaken for the `7days` correction.

While working on this, I removed the special-case parser logic and the standalone `7days` / `7 days` corrections. I also cleaned up the long error-tolerance regular expression, made the affected warning names translatable, and simplified some variable naming in the tokenizer. The unambiguous forms such as `7 days a week` and `7/7` remain supported, with regression tests covering the different offset spellings.