### PR TITLE
chore: add eslint-plugin-jsdoc for better documentation

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,6 +3,7 @@
 import { defineConfig, globalIgnores } from 'eslint/config'
 import globals from 'globals'
 import js from '@eslint/js'
+import jsdoc from 'eslint-plugin-jsdoc';
 import markdown from '@eslint/markdown'
 import stylistic from '@stylistic/eslint-plugin'
 import tseslint from 'typescript-eslint'
@@ -11,7 +12,7 @@ export default defineConfig([
   globalIgnores(['build/*', 'submodules/*', '**/yohours_model.js', 'src/holidays/generated-openholidays.js']),
   {
     files: ['**/*.js', '**/*.mjs'],
-    extends: [js.configs.recommended],
+    extends: [js.configs.recommended, jsdoc.configs['flat/recommended'],],
     plugins: { '@stylistic': stylistic },
     languageOptions: {
       ecmaVersion: 'latest',
@@ -25,7 +26,11 @@ export default defineConfig([
       '@stylistic/quotes': [ 'error', 'single' ],
       '@stylistic/no-trailing-spaces': 'error',
       'prefer-const': 'error',
-      'no-var': 'error'
+      'no-var': 'error',
+      'jsdoc/require-jsdoc': ['warn', { publicOnly: true }],
+      // TODO: Re-enable this rule after the affected comments have been migrated safely.
+      // Disabled for now because its autofix does not preserve Vim fold markers or legacy JSDoc descriptions.
+      'jsdoc/convert-to-jsdoc-comments': ['off', { lineOrBlockStyle: 'block' }],
     },
   },
   { files: ['**/*.md'], plugins: { markdown }, language: 'markdown/gfm', extends: ['markdown/recommended'] },

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "cz-conventional-changelog": "^3.3.0",
         "doctoc": "^2.5.0",
         "eslint": "^10.7.0",
+        "eslint-plugin-jsdoc": "^63.3.1",
         "glob": "^13.0.6",
         "globals": "^17.7.0",
         "husky": "^9.1.7",
@@ -359,6 +360,33 @@
       "license": "MIT",
       "engines": {
         "node": ">=22"
+      }
+    },
+    "node_modules/@es-joy/jsdoccomment": {
+      "version": "0.90.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.90.0.tgz",
+      "integrity": "sha512-51x9KxyTAN6guZOCd+lmcDdkhgdMdP/6iMMtg9dyhCWDc3+iSUyoB7f/9WAM/yGHmGFq25Vd6bXRR7CZcB+tog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.9",
+        "@typescript-eslint/types": "^8.65.0",
+        "comment-parser": "1.4.7",
+        "esquery": "^1.7.0",
+        "jsdoc-type-pratt-parser": "~7.3.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@es-joy/resolve.exports": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/resolve.exports/-/resolve.exports-1.2.0.tgz",
+      "integrity": "sha512-Q9hjxWI5xBM+qW2enxfe8wDKdFWMfd0Z29k5ZJnuBqD/CasY5Zryj09aCA6owbGATWz+39p5uIdaHXpopOcG8g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1275,6 +1303,19 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
+    "node_modules/@sindresorhus/base62": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/base62/-/base62-1.0.0.tgz",
+      "integrity": "sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@stylistic/eslint-plugin": {
       "version": "5.10.0",
       "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.10.0.tgz",
@@ -1818,6 +1859,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/are-docs-informative": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
+      "integrity": "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -2346,6 +2397,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/comment-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.7.tgz",
+      "integrity": "sha512-0h+uSNtQGW3D98eQt3jJ8L06Fves8hncB4V/PKdw/Qb8Hnk19VaKuTr55UNRYiSoVa7WwrFls+rh3ux9agmkeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/commit-and-tag-version": {
@@ -3526,6 +3587,90 @@
         }
       }
     },
+    "node_modules/eslint-plugin-jsdoc": {
+      "version": "63.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.3.1.tgz",
+      "integrity": "sha512-yVyTPtOY2tA8EjTwUtaM3pFxj9i/3m4/FSPMv5gMnDHSSleCpzIYQLyV8KnVmEIkkPpNhDlkDQ99mTfjxgqLxA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@es-joy/jsdoccomment": "~0.90.0",
+        "@es-joy/resolve.exports": "1.2.0",
+        "are-docs-informative": "^0.0.2",
+        "comment-parser": "1.4.7",
+        "debug": "^4.4.3",
+        "escape-string-regexp": "^4.0.0",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "html-entities": "^2.6.0",
+        "object-deep-merge": "^2.0.1",
+        "parse-imports-exports": "^0.2.4",
+        "semver": "^7.8.5",
+        "spdx-expression-parse": "^5.0.0",
+        "to-valid-identifier": "^1.0.0"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/spdx-expression-parse": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-5.0.0.tgz",
+      "integrity": "sha512-vngmw3Rgn+o2arXNbnZaj5UtOEBuWBfvaI+Wc8GFfykIhA5/vdK9/Sp/XkLv63dykz2rxKDvKEHupF5P0FORcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "9.1.2",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
@@ -4482,6 +4627,23 @@
         "node": ">=10"
       }
     },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/htmlparser2": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
@@ -5072,6 +5234,16 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdoc-type-pratt-parser": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.3.0.tgz",
+      "integrity": "sha512-DoyJXo7x/n48M3NsGOs9QnEws0ft0tV3YsSgvWMNxz2hZtz+Q6fpqUD96lVYX4a+jcEkzHeFNDJOn68TzXfbdA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/json-buffer": {
@@ -7314,6 +7486,13 @@
         "npm": ">=10.0.0"
       }
     },
+    "node_modules/object-deep-merge": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object-deep-merge/-/object-deep-merge-2.0.1.tgz",
+      "integrity": "sha512-aKttDKcU3pyZqKcCkDhsMn70WmZFG2JGDQLP9EcLyTSIFQRCPWLAmBZRLJnrVUrhPG1jETEEbfdgbNtJf1LyMg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -7579,6 +7758,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/parse-imports-exports": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/parse-imports-exports/-/parse-imports-exports-0.2.4.tgz",
+      "integrity": "sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-statements": "1.0.11"
+      }
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -7607,6 +7796,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/parse-statements": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/parse-statements/-/parse-statements-1.0.11.tgz",
+      "integrity": "sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -8399,6 +8595,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/reserved-identifiers": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/reserved-identifiers/-/reserved-identifiers-1.2.0.tgz",
+      "integrity": "sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.12",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
@@ -9022,6 +9231,23 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/to-valid-identifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-valid-identifier/-/to-valid-identifier-1.0.0.tgz",
+      "integrity": "sha512-41wJyvKep3yT2tyPqX/4blcfybknGB4D+oETKLs7Q76UiPqRpUJK3hr1nxelyYO0PHKVzJwlu0aCeEAsGI6rpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/base62": "^1.0.0",
+        "reserved-identifiers": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tosource": {

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "cz-conventional-changelog": "^3.3.0",
     "doctoc": "^2.5.0",
     "eslint": "^10.7.0",
+    "eslint-plugin-jsdoc": "^63.3.1",
     "glob": "^13.0.6",
     "globals": "^17.7.0",
     "husky": "^9.1.7",

--- a/scripts/check_for_new_taginfo_data.js
+++ b/scripts/check_for_new_taginfo_data.js
@@ -41,7 +41,11 @@ const https = require('node:https');
 const fs   = require('node:fs');
 /* }}} */
 
-/* Helper functions {{{ */
+/**
+ * Read the database creation time from a taginfo dump file. {{{
+ * @param {string} file Path to the taginfo dump file.
+ * @returns {Date|undefined} Database creation time, or `undefined` if it cannot be read.
+ */
 function get_dump_creation_time_from_file(file) {
     try {
         const data = JSON.parse(fs.readFileSync(file, 'utf8'));

--- a/scripts/check_holiday_state_codes.mjs
+++ b/scripts/check_holiday_state_codes.mjs
@@ -17,6 +17,9 @@ const GENERATED_FILE = path.join(HOLIDAYS_DIR, 'generated-openholidays.js');
 /**
  * Country-wide PH/SH definitions and metadata are not regions.
  * A region is a named mapping with its own PH or SH list.
+ * @param {string} key - Country or region key to inspect.
+ * @param {object} value - Holiday definition associated with the key.
+ * @returns {boolean} Whether the value represents a holiday region.
  */
 function isHolidayRegion(key, value) {
     return typeof value === 'object'

--- a/scripts/fetch-school-holidays.mjs
+++ b/scripts/fetch-school-holidays.mjs
@@ -34,6 +34,8 @@ const stats = {
 /**
  * Parse CSV file (semicolon-separated)
  * Handles quoted fields containing semicolons and commas
+ * @param {string} content - Semicolon-separated CSV content.
+ * @returns {object[]} Parsed CSV rows.
  */
 function parseCSV(content) {
   const lines = content.trim().split('\n');
@@ -87,6 +89,8 @@ function parseCSV(content) {
 /**
  * Load subdivision names from subdivisions.csv
  * Returns: { "BW": "Baden-Württemberg", ... }
+ * @param {string} country - Country code to load subdivision names for.
+ * @returns {Promise<object>} Subdivision codes mapped to localized names.
  */
 async function loadSubdivisionNames(country) {
   try {
@@ -124,6 +128,7 @@ async function loadSubdivisionNames(country) {
 
 /**
  * Discover all countries with school holidays in submodule
+ * @returns {Promise<string[]>} Country codes with school holiday data.
  */
 async function discoverCountriesInSubmodule() {
   const countries = new Set();
@@ -159,6 +164,8 @@ async function discoverCountriesInSubmodule() {
 
 /**
  * Load complete YAML data (PH, SH, meta) for merging
+ * @param {string} country - Country code to load holiday data for.
+ * @returns {Promise<object>} Parsed country holiday data.
  */
 async function loadCompleteYaml(country) {
   try {
@@ -172,6 +179,8 @@ async function loadCompleteYaml(country) {
 
 /**
  * Check if a YAML file has school holidays data
+ * @param {string} country - Country code to check for school holidays.
+ * @returns {Promise<boolean>} Whether school holiday data exists.
  */
 async function yamlHasSchoolHolidays(country) {
   try {
@@ -198,6 +207,8 @@ async function yamlHasSchoolHolidays(country) {
 
 /**
  * Load school holidays from CSV files in submodule
+ * @param {string} country - Country code to load school holidays for.
+ * @returns {Promise<object[]|null>} Parsed holiday rows, or null if unavailable.
  */
 async function loadSchoolHolidaysFromSubmodule(country) {
   const holidaysDir = path.join(SUBMODULE_DIR, country, 'holidays');
@@ -228,6 +239,10 @@ async function loadSchoolHolidaysFromSubmodule(country) {
 
 /**
  * Convert CSV data to opening_hours.js format
+ * @param {object[]} csvData - Parsed school holiday rows.
+ * @param {string} country - Country code the rows belong to.
+ * @param {number[]} yearRange - Inclusive range of years to include.
+ * @returns {object} School holidays grouped by subdivision.
  */
 function convertCSVToInternalFormat(csvData, country, yearRange) {
   // Group by subdivision -> holiday name -> years
@@ -346,6 +361,7 @@ function convertCSVToInternalFormat(csvData, country, yearRange) {
 
 /**
  * Get submodule commit info for reproducible builds
+ * @returns {Promise<object>} Submodule hash and commit timestamp.
  */
 async function getSubmoduleInfo() {
   const { execSync } = await import('child_process');
@@ -370,6 +386,10 @@ async function getSubmoduleInfo() {
 
 /**
  * Generate JavaScript file with holiday definitions
+ * @param {object} countriesData - Generated holiday data grouped by country.
+ * @param {number[]} yearRange - Inclusive range of years included in the output.
+ * @param {object} submodule - Metadata for the source data submodule.
+ * @returns {Promise<string>} Generated JavaScript source.
  */
 async function generateJavaScriptFile(countriesData, yearRange, submodule) {
   const commitDate = new Date(submodule.commitUnixTimestamp * 1000).toISOString().split('T')[0];
@@ -457,6 +477,9 @@ async function generateJavaScriptFile(countriesData, yearRange, submodule) {
 
 /**
  * Format object in compact style
+ * @param {object} obj - Object to format.
+ * @param {number} indent - Current indentation level.
+ * @returns {string} Formatted JavaScript object literal.
  */
 function formatCompactObject(obj, indent) {
   const ind = '  '.repeat(indent);
@@ -503,6 +526,7 @@ function formatCompactObject(obj, indent) {
 
 /**
  * Discover all YAML files
+ * @returns {Promise<string[]>} Country codes with YAML data.
  */
 async function discoverYamlCountries() {
   const countries = new Set();
@@ -523,6 +547,8 @@ async function discoverYamlCountries() {
 
 /**
  * Validate that all generated countries are exported in index.js
+ * @param {string[]} generatedCountries - Country codes found in generated data.
+ * @returns {Promise<void>} Resolves after export validation completes.
  */
 async function validateExports(generatedCountries) {
   const INDEX_FILE = path.join(HOLIDAYS_DIR, 'index.js');
@@ -597,6 +623,7 @@ async function validateExports(generatedCountries) {
 
 /**
  * Build school holidays for all countries
+ * @returns {Promise<object>} Generated holiday data grouped by country.
  */
 async function buildSchoolHolidays() {
   console.log('═'.repeat(60));

--- a/site/js/countryToLanguageMapping.js
+++ b/site/js/countryToLanguageMapping.js
@@ -232,6 +232,12 @@ export const countryToLanguageMapping = {
     'zm': 'en',
     'zw': 'en,sn,nd ',
 };
+
+/**
+ * Get the preferred languages for a country code.
+ * @param {string} country_code - ISO 3166-1 alpha-2 country code.
+ * @returns {string} Comma-separated preferred language codes, or the country code when unknown.
+ */
 export function mapCountryToLanguage(country_code) {
     if (typeof countryToLanguageMapping[country_code] !== 'undefined') {
         return countryToLanguageMapping[country_code];

--- a/site/js/helpers.js
+++ b/site/js/helpers.js
@@ -35,9 +35,11 @@ const evaluation_tool_colors = {
 const OSM_MAX_VALUE_LENGTH = 255;
 /* }}} */
 
-// load nominatim_data in JOSM {{{
-// Using a different way to load stuff in JOSM than https://github.com/vibrog/OpenLinkMap/
-// prevent josm remote plugin of showing message
+/**
+ * Load nominatim_data in JOSM using the JOSM remote control API. {{{
+ * @param {string} url_param - Query parameter sent to the JOSM remote control API.
+ * @returns {void}
+ */
 export function josm(url_param) {
     fetch(`http://localhost:8111/${url_param}`)
         .then(response => {
@@ -51,7 +53,11 @@ export function josm(url_param) {
 }
 // }}}
 
-// ISO 8601 calendar week number {{{
+/**
+ * ISO 8601 calendar week number. {{{
+ * @param {Date} date - Date for which to calculate the week number.
+ * @returns {number} ISO calendar week number.
+ */
 export function getISOWeekNumber(date) {
     const millisecondsPerDay = 24 * 60 * 60 * 1000;
     const utcDate = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
@@ -71,11 +77,10 @@ export function getISOWeekNumber(date) {
  *
  * The names of countries and states are localized in OSM and opening_hours.js
  * (holidays) so we need to get the localized names from Nominatim as well.
- *
  * @param {number} lat - Latitude
  * @param {number} lon - Longitude
  * @param {string} preferredLanguage - Preferred language code (e.g., 'de', 'en')
- * @returns {Promise<Object>} Nominatim response with address data
+ * @returns {Promise<object>} Nominatim response with address data
  */
 async function reverseGeocodeLocation(lat, lon, preferredLanguage) {
     // Cached response for default coordinates to avoid queries on initial load
@@ -113,7 +118,11 @@ async function reverseGeocodeLocation(lat, lon, preferredLanguage) {
     return data;
 }
 
-/* JS for toggling examples on and off {{{ */
+/**
+ * Toggle examples on and off. {{{
+ * @param {string} control - ID of the element to toggle.
+ * @returns {void}
+ */
 export function toggle(control){
     const elem = document.getElementById(control);
 
@@ -125,6 +134,11 @@ export function toggle(control){
 }
 /* }}} */
 
+/**
+ * Open the browser prompt used to copy text to the clipboard.
+ * @param {string} text - Text to display for copying.
+ * @returns {void}
+ */
 export function copyToClipboard(text) {
     window.prompt('Copy to clipboard: Ctrl+C, Enter', text);
 }
@@ -178,7 +192,6 @@ function generateSelectorElement(selectorType, selectorValue) {
  *
  * Converts the internal rule structure into human-readable HTML with links
  * to the specification for each selector type and rule separator.
- *
  * @param {Array} prettifiedValueArray - Array containing [rules, ruleSeparators]
  * @returns {DocumentFragment} DOM fragment with formatted value explanation
  */
@@ -231,10 +244,9 @@ function generateResultsElement(matchingRule) {
 
 /**
  * Generate HTML display for deviation information between two opening hours values.
- *
- * @param {Object} oh1 - The first opening_hours instance
- * @param {Object} oh2 - The second opening_hours instance
- * @param {Object} deviationInfo - Deviation data from isEqualTo comparison
+ * @param {object} oh1 - The first opening_hours instance
+ * @param {object} oh2 - The second opening_hours instance
+ * @param {object} deviationInfo - Deviation data from isEqualTo comparison
  * @returns {string} HTML string with formatted deviation information
  */
 function generateDeviationHTML(oh1, oh2, deviationInfo) {
@@ -319,8 +331,7 @@ function generateDeviationHTML(oh1, oh2, deviationInfo) {
  * - Green (ok): Values are equivalent
  * - Orange (warn): Values differ, shows deviation details in #compare-result
  * - Brown (error): Diff value failed to parse
- *
- * @param {Object} oh - The opening_hours instance to compare
+ * @param {object} oh - The opening_hours instance to compare
  * @param {string} diffValue - The opening hours value to compare against
  * @param {number} mode - The parsing mode for opening hours
  * @param {Date} startDate - The date to start comparison from
@@ -476,6 +487,12 @@ function generateValueTooLongFragment(prettified, value) {
 
 /* }}} */
 
+/**
+ * Evaluate the current opening-hours expression and update the page.
+ * @param {number} [offset] - Offset used when evaluating the expression; defaults to 0.
+ * @param {boolean} [reset] - Whether to reset the current evaluation state.
+ * @returns {Promise<void>}
+ */
 export async function Evaluate (offset = 0, reset) {
     if (document.forms.check.elements['lat'].value !== string_lat || document.forms.check.elements['lon'].value !== string_lon) {
         string_lat = document.forms.check.elements['lat'].value;
@@ -611,11 +628,21 @@ export async function Evaluate (offset = 0, reset) {
     updatePermalinkHref();
 }
 
+/**
+ * Evaluate an example expression from a page element.
+ * @param {HTMLElement} element - Element containing the expression.
+ * @returns {boolean} False to prevent the default element action.
+ */
 export function EX (element) {
     newValue(element.innerHTML);
     return false;
 }
 
+/**
+ * Set and evaluate a new opening-hours expression.
+ * @param {string} value - Opening-hours expression to evaluate.
+ * @returns {void}
+ */
 export function newValue(value) {
     document.forms.check.elements['expression'].value = value;
     Evaluate();
@@ -645,6 +672,10 @@ function updatePermalinkHref() {
     document.getElementById('permalink-link-without-timestamp').href = `${baseUrl}?${params}`;
 }
 
+/**
+ * Request the user's current geolocation and update the form.
+ * @returns {void}
+ */
 export function setCurrentPosition() {
     if(navigator.geolocation) {
         navigator.geolocation.getCurrentPosition(onPositionUpdate);

--- a/site/js/i18n-resources.js
+++ b/site/js/i18n-resources.js
@@ -2006,6 +2006,11 @@ export const resources = { // English is fallback language.
 
 // Functions which generate localized HTML sections {{{
 
+/**
+ * Change the interface language and reload the page.
+ * @param {string} lang - Language code to activate.
+ * @returns {void}
+ */
 export function changeLanguage(lang) {
     localStorage.setItem('i18nextLng', lang);
     i18next.changeLanguage(lang, () => {
@@ -2013,6 +2018,10 @@ export function changeLanguage(lang) {
     });
 }
 
+/**
+ * Generate the language selection HTML.
+ * @returns {string} HTML for the language selection control.
+ */
 export function getUserSelectTranslateHTMLCode() {
     let res = '<label for="language-select" class="hd">';
     res += i18next.t('lang.choose')
@@ -2035,7 +2044,11 @@ export function getUserSelectTranslateHTMLCode() {
 }
 // }}}
 
-// Detect language: localStorage > browser language > fallback
+/**
+ * Detect the preferred language from localStorage first, then browser settings.
+ * Falls back to English when neither source provides a supported language.
+ * @returns {string} Selected language code, falling back to English.
+ */
 export function detectLanguage() {
     const stored = localStorage.getItem('i18nextLng');
     if (stored && resources[stored]) return stored;

--- a/site/js/main.js
+++ b/site/js/main.js
@@ -54,8 +54,11 @@ function generateTimeButtons() {
     return html;
 }
 
-// Helper function to update time button labels with current values
-
+/**
+ * Update the labels of the time selection buttons.
+ * @param {Date} date - Current date used for the displayed labels.
+ * @returns {void}
+ */
 export function updateTimeButtonLabels(date) {
     const yearLabel = document.getElementById('time-btn-value-year');
     const monthLabel = document.getElementById('time-btn-value-month');

--- a/src/index.js
+++ b/src/index.js
@@ -41,6 +41,12 @@ import { regionLanguages } from './locale-resolver/region-languages.mjs';
 import { normalizeToken } from './locale-resolver/normalize.mjs';
 import resolver_layers from './locale-resolver/layers.json';
 
+/**
+ * Creates an opening hours parser for an OSM opening-hours value.
+ * @param {string} value The opening-hours value to parse.
+ * @param {object|null} [nominatim_object] Location and address data used for holidays and solar times.
+ * @param {number|object} [optional_conf_parm] Parser mode or parser configuration.
+ */
 export default function(value, nominatim_object, optional_conf_parm) {
     // Short constants {{{
     const word_value_replacement = { // If the correct values can not be calculated.
@@ -417,10 +423,10 @@ export default function(value, nominatim_object, optional_conf_parm) {
     /* }}} */
 
     /* Helper functions {{{ */
-    /* Get regex string key from key osm_tag_defaults. {{{
-     *
-     * :param key: Tag key e.g. opening_hours:kitchen.
-     * :returns: Regex key from osm_tag_defaults e.g. opening_hours:.*
+    /**
+     * Get the regex key for an OpenStreetMap tag key. {{{
+     * @param {string} key Tag key, e.g. `opening_hours:kitchen`.
+     * @returns {string|undefined} Matching key from `osm_tag_defaults`.
      */
     function getRegexKeyForKeyFromOsmDefaults(key) {
         let regex_key;
@@ -443,11 +449,11 @@ export default function(value, nominatim_object, optional_conf_parm) {
     }
     /* }}} */
 
-    /* Check given element in optional_conf_parm. {{{
-     *
-     * :param key: Key of optional_conf_parm.
-     * :param expected_type: Expected `typeof()` the parameter.
-     * :returns: True if the expected type matches the given type.
+    /**
+     * Check the type of an optional constructor parameter. {{{
+     * @param {string} key Key of `optional_conf_parm`.
+     * @param {string} expected_type Expected result of `typeof`.
+     * @returns {boolean} Whether the value has the expected type.
      */
     function checkOptionalConfParm(key, expected_type) {
         if (typeof optional_conf_parm[key] === expected_type) {
@@ -460,24 +466,20 @@ export default function(value, nominatim_object, optional_conf_parm) {
     /* }}} */
     /* }}} */
 
-    /* Resolve the position a warning or error points to. {{{
-     *
+    /**
+     * Resolve the position a warning or error points to. {{{
      * Computes the base string and the character offset into it where the
      * `<--- ` marker belongs. This is the single source of truth for both the
      * formatted string (formatWarnErrorMessage) and the structured warning
      * objects (getStructuredWarnings), so both stay consistent.
-     *
-     * :param nrule: Rule number starting with 0.
-     *               -1: error during tokenization, `at` is remaining value.length.
-     *               string: prettified value, `at` is a byte offset into it.
-     * :param at: Token position. -1 means end of rule (no token at that position).
-     * :param tokens_to_use: Optional. Defaults to `tokens`. Pass `new_tokens` from
-     *               getWarnings() because new_tokens can have more entries than tokens
-     *               when Additional Rules are present.
-     * :returns: Object { value, position }. `value` is the string the offset
-     *               refers to (the input value, or the prettified value for
-     *               selector-reordering warnings). `position` is the character
-     *               offset, or null if it could not be determined.
+     * @param {number|string} nrule Rule number starting with 0. `-1` means an
+     *     error during tokenization; a string means the prettified value.
+     * @param {number} at Token position. `-1` means the end of a rule.
+     * @param {Array} [tokens_to_use] Token array, defaulting to `tokens`. Pass
+     *     `new_tokens` from `getWarnings()` because additional rules can make
+     *     it longer than `tokens`.
+     * @returns {{value: string, position: number|null}} The value the position
+     *     refers to and its character offset, or `null` if it is unknown.
      */
     function resolveWarnErrorPosition(nrule, at, tokens_to_use) {
         if (typeof tokens_to_use === 'undefined') {
@@ -529,13 +531,15 @@ export default function(value, nominatim_object, optional_conf_parm) {
     }
     /* }}} */
 
-    /* Format warning or error message for the user. {{{
-     *
-     * :param nrule: See resolveWarnErrorPosition.
-     * :param at: See resolveWarnErrorPosition.
-     * :param message: Human readable string with the message.
-     * :param tokens_to_use: See resolveWarnErrorPosition.
-     * :returns: String with position of the warning or error marked for the user.
+    /**
+     * Format a warning or error message and mark its position in the input. {{{
+     * @param {number|string} nrule Rule number, or the prettified value when the
+     *     position refers to that value.
+     * @param {number} at Token or character position to mark.
+     * @param {string} message Human-readable warning or error message.
+     * @param {Array} [tokens_to_use] Token array used to resolve the position.
+     * @returns {string} Message with the position marker, or the original message
+     *     when no position can be determined.
      */
     function formatWarnErrorMessage(nrule, at, message, tokens_to_use) {
         // console.log(`Called formatWarnErrorMessage: ${nrule}, ${at}, ${message}`);
@@ -547,11 +551,11 @@ export default function(value, nominatim_object, optional_conf_parm) {
     }
     /* }}} */
 
-    /* Format internal library error message. {{{
-     *
-     * :param message: Human readable string with the error message.
-     * :param text_template: Message template defined in the `lang` variable to use for the error message. Defaults to 'library bug'.
-     * :returns: Error message for the user.
+    /**
+     * Format an internal library error message. {{{
+     * @param {string} [message] Human-readable error message.
+     * @param {string} [text_template] Translation template, defaulting to `library bug`.
+     * @returns {string} Formatted error message.
      */
     function formatLibraryBugMessage(message, text_template) {
         if (typeof message === 'undefined') {
@@ -568,11 +572,10 @@ export default function(value, nominatim_object, optional_conf_parm) {
         return message;
     } /* }}} */
 
-    /* Tokenize input stream {{{
-     *
-     * :param value: Raw opening_hours value.
-     * :returns: Tokenized list object. Complex structure. Check the
-     *        internal documentation in the docs/ directory for details.
+    /**
+     * Tokenize an opening-hours input stream. {{{
+     * @param {string} value Raw opening-hours value.
+     * @returns {Array} Tokenized list. See the internal documentation in `docs/`.
      */
     function tokenize(value) {
         // Negative list approach: Match anything that's NOT punctuation, digits, or special chars

--- a/src/locale-resolver/normalize.mjs
+++ b/src/locale-resolver/normalize.mjs
@@ -9,6 +9,8 @@
  *
  * Lower-cases, trims and strips trailing abbreviation dots (e.g. German "Mo.")
  * so that generated layer keys and runtime lookups use the same shape.
+ * @param {string} value - Token value to normalize.
+ * @returns {string} Normalized token value.
  */
 export function normalizeToken(value) {
     return String(value ?? '')

--- a/src/locale-resolver/resolver.mjs
+++ b/src/locale-resolver/resolver.mjs
@@ -28,8 +28,8 @@
  *
  * Geo tier-2: the POI's country (from the nominatim country code) yields the set
  * of locally plausible languages. A foreign token that matches one of them is
- * accepted with a warning — this is what separates `Mo-Tr` @DE (reject, #588)
- * from `Mo-Tr` @LT (accept, Lithuanian) and `Mo-montag` @DE (accept, German).
+ * accepted with a warning — this is what separates `Mo-Tr` `@DE` (reject, #588)
+ * from `Mo-Tr` `@LT` (accept, Lithuanian) and `Mo-montag` `@DE` (accept, German).
  *
  * Coherence (two pass) resolves Layer 3 tokens against their neighbours:
  *   - `Mo-Tr` (en):  `Tr` only matches lt, no lt context, locale is en → ERROR (#588)
@@ -166,10 +166,9 @@ function resolveForeign(token, allForeign, localeLang, regionLangs, hasAnchor) {
 
 /**
  * Resolve a sequence of raw lexemes of a single grammatical type.
- *
  * @param {string[]} rawTokens - e.g. ['Mo', 'Tr'] for `Mo-Tr`, ['Jan', 'Mär'] for `Jan-Mär`.
- * @param {{ locale: string, type: 'weekday'|'month', layers: object, regionLangs?: Set<string> }} options
- * @returns {{ ok: boolean, confidence: string, tokens: object[] }}
+ * @param {{ locale: string, type: 'weekday'|'month', layers: object, regionLangs?: Set<string> }} options - Locale and resolver data.
+ * @returns {{ ok: boolean, confidence: string, tokens: object[] }} Resolved tokens and overall confidence.
  */
 export function resolveRange(rawTokens, { locale, type, layers, regionLangs }) {
     const localeLang = String(locale || '').split('-')[0].toLowerCase();

--- a/src/locales/i18n.js
+++ b/src/locales/i18n.js
@@ -8,10 +8,9 @@ import resources from './translations.yaml';
 /**
  * Replace `{{varName}}` (or `{{-varName}}`) placeholders in a translation string.
  * The `-` prefix is a legacy i18next no-HTML-escape marker; it has no effect here.
- *
  * @param {string} str  - Translation string containing `{{…}}` placeholders.
- * @param {Object} vars - Map of placeholder names to replacement values.
- * @returns {string}
+ * @param {object} vars - Map of placeholder names to replacement values.
+ * @returns {string} The interpolated translation string.
  */
 function interpolate(str, vars) {
     return str.replace(/{{-?([^{}]*)}}/g, function(match, varName) {
@@ -28,7 +27,6 @@ function interpolate(str, vars) {
  *
  * Accepts BCP 47 tags (e.g. 'de-DE') and POSIX identifiers per ISO 15897 (e.g. 'de_DE').
  * For non-strings, returns 'en' (the default fallback locale).
- *
  * @param {string|null|undefined} locale - Locale tag.
  * @returns {string} Base language, e.g. 'de'.
  */
@@ -45,9 +43,8 @@ function baseLanguage(locale) {
  * 'de-DE' → ['de-DE', 'de', 'en']
  * 'de'    → ['de', 'en']
  * null    → ['en']
- *
  * @param {string|null|undefined} locale - BCP 47 locale tag.
- * @returns {string[]}
+ * @returns {string[]} Locale tags ordered from most to least specific.
  */
 function localeChain(locale) {
     const base = baseLanguage(locale);
@@ -60,11 +57,10 @@ function localeChain(locale) {
  * a translation for the given key.
  *
  * Tree shape: resources[locale][section][…key segments]
- *
  * @param {string|null|undefined} locale  - BCP 47 locale tag.
  * @param {string}                section - 'texts' or 'pretty'.
  * @param {string}                key     - Translation key (dot-separated for nesting).
- * @returns {*} Matched value, or `undefined` if not found anywhere in the chain.
+ * @returns {string|object|undefined} Matched value, or `undefined` if not found anywhere in the chain.
  */
 function lookup(locale, section, key) {
     const keyPath = key.split('.');
@@ -80,13 +76,12 @@ function lookup(locale, section, key) {
 /**
  * Translate a key into the requested locale, falling back through the locale
  * chain to English. Returns the key itself when no translation is found.
- *
  * @param {string|null|undefined} locale  - BCP 47 locale tag (e.g. 'de', 'de-DE').
  * @param {string}                section - 'texts' (error/warning messages) or
  *                                          'pretty' (prettified output tokens).
  * @param {string}                key     - Translation key (dot-separated for nesting).
- * @param {Object}               [vars]   - Variables to interpolate via `{{varName}}`.
- * @returns {string}
+ * @param {object}               [vars]   - Variables to interpolate via `{{varName}}`.
+ * @returns {string} The translated string, or the key when no translation exists.
  */
 export function translate(locale, section, key, vars) {
     const result = lookup(locale, section, key);


### PR DESCRIPTION
With this PR, we are introducing `eslint-plugin-jsdoc`. Discussions around previous PRs (#580 and #619) already highlighted the need for proper JSDoc comments and better type checking in the JavaScript codebase.

This PR lays the groundwork without attempting a complete migration. The existing legacy comments are too numerous for a reliable automated conversion, and the autofix does not preserve Vim fold markers or existing descriptions in all cases. The remaining comments should therefore be migrated gradually and reviewed manually.