### PR TITLE
fix(parser): resolve "Sur rendez-vous" without quotes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -90,6 +90,31 @@ export default function(value, nominatim_object, optional_conf_parm) {
         'off': [ 'off', 'state' ],
         'unknown': [ 'unknown', 'state' ],
     }
+    // Flatten all replacement rules into one longest-pattern-first lookup list,
+    // so a specific phrase wins over a shorter pattern matching its prefix.
+    const correction_entries = Object.entries(word_error_correction)
+        .filter(([comment]) => comment !== 'Ambiguous words')
+        .flatMap(([comment, corrections]) => Object.entries(corrections)
+            .map(([pattern, replacement]) => ({ comment, pattern, replacement })))
+        .sort((left, right) => right.pattern.length - left.pattern.length);
+    // Multi-word rules only; single-word rules must not override valid tokens
+    // such as the month abbreviation "Mar" and are left to returnCorrectWordOrToken.
+    const phrase_correction_entries = correction_entries.filter(({ pattern }) =>
+        pattern.includes(' ') || pattern.includes('\\s')
+    );
+    const findPhraseCorrection = (input) => {
+        for (const correction of phrase_correction_entries) {
+            const match = input.match(new RegExp(
+                '^(' + correction.pattern + ')(\\.?)' +
+                '(?=$|[^\\p{L}\\p{N}_])',
+                'iu'
+            ));
+            if (match) {
+                    return match;
+            }
+        }
+        return undefined;
+    };
     const ambiguous_season_words = new Set([
         'spring', 'summer', 'autumn', 'winter', // en
         'frühling', 'fruehling', 'frühjahr', 'sommer', 'herbst', // de
@@ -710,18 +735,17 @@ export default function(value, nominatim_object, optional_conf_parm) {
             String.raw`^(?!${NUMERIC_DAY_OFFSET_PATTERN})(${ERROR_TOLERANCE_ALTERNATIVES})(\.?)`,
             'iu'
         );
-
         while (value !== '') {
             /* Ordered after likelihood of input for performance reasons.
              * Also, error tolerance is supposed to happen at the end.
              */
             // console.log("Parsing value: " + value);
 
-            // First regex: Match international words (2+ characters) with optional suffixes
-            // Pattern: word characters followed by word boundary, with optional ". before after" suffixes
-            let tmp = value.match(WORD_REGEX);
+            // Check correction phrases before the regular word and error-tolerance patterns.
+            const phrase_match = findPhraseCorrection(value);
+            let tmp = phrase_match || value.match(WORD_REGEX);
             let token_from_map = undefined;
-            if (tmp && tmp[2] === '') {
+            if (!phrase_match && tmp && tmp[2] === '') {
                 token_from_map = string_to_token_map[tmp[1].toLowerCase()];
             }
             if (typeof token_from_map === 'object') {
@@ -789,7 +813,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
                             'please_use_ok_for_ko', t('please use ok for ko', {'ko': tmp[0], 'ok': ok})]);
                 }
                 value = ok + value.substr(tmp[0].length);
-            } else if ((tmp = value.match(ERROR_TOLERANCE_REGEX))) {
+            } else if ((tmp = phrase_match || value.match(ERROR_TOLERANCE_REGEX))) {
                 /* Handle all remaining words and specific other characters with error tolerance.
                  *
                  * à|á: Word boundary does not work with Unicode chars: 'test à test'.match(/\bà\b/i)
@@ -801,6 +825,8 @@ export default function(value, nominatim_object, optional_conf_parm) {
                  */
                 const lower_word = tmp[1].toLowerCase();
                 const warn_count_before = parsing_warnings.length;
+                // returnCorrectWordOrToken looks up the same correction_entries,
+                // so a pre-matched phrase resolves here just like a single word.
                 let correct_val = returnCorrectWordOrToken(lower_word, value.length);
                 // A word_error_correction warning, if any, is the last one pushed by
                 // returnCorrectWordOrToken; remember its index so the resolver can
@@ -1015,36 +1041,22 @@ export default function(value, nominatim_object, optional_conf_parm) {
             return undefined;
         }
 
-        // Standard processing for all other words using flat structure
-        Object.keys(word_error_correction).forEach(function (comment) {
-            if (correctWordOrToken) {
-                return;
-            }
-            // Skip the ambiguous words section for auto-correction
-            if (comment === 'Ambiguous words') {
-                return;
-            }
-            Object.keys(word_error_correction[comment]).forEach(function (old_val) {
-                if (correctWordOrToken) {
-                    return;
-                }
-                if (new RegExp('^' + old_val + '$').test(word)) {
-                    const val = word_error_correction[comment][old_val];
+        const correction = correction_entries.find(entry =>
+            new RegExp('^' + entry.pattern + '$', 'iu').test(word)
+        );
+        if (correction) {
+            if (!done_with_warnings) {
+                const warningMessage = t(correction.comment, {'ko': word, 'ok': correction.replacement});
 
-                    if (!done_with_warnings) {
-                        const warningMessage = t(comment, {'ko': word, 'ok': val});
-
-                        parsing_warnings.push([
-                            -1,
-                            value_length - word.length,
-                            'word_error_correction',
-                            warningMessage
-                        ]);
-                    }
-                    correctWordOrToken = val;
-                }
-            });
-        });
+                parsing_warnings.push([
+                    -1,
+                    value_length - word.length,
+                    'word_error_correction',
+                    warningMessage
+                ]);
+            }
+            correctWordOrToken = correction.replacement;
+        }
 
         return correctWordOrToken;
     }

--- a/src/locales/word_error_correction.yaml
+++ b/src/locales/word_error_correction.yaml
@@ -109,6 +109,8 @@
   "by(?:_| )?appointments?": "\"by appointment\""
   "nach(?: |_)vereinbarung": "\"Nach Vereinbarung\""
   "nach(?: |_)absprache": "\"Nach Absprache\""
+  "sur(?: |_)rendez(?: |_|-)?vous": "\"Sur rendez-vous\""
+  "sur(?: |_)rdv": "\"Sur rendez-vous\""
   "bis": "-"
   "täglich": "Mo-Su"
   "(?:schul)?ferien": "SH"

--- a/src/locales/word_error_correction_manual.yaml
+++ b/src/locales/word_error_correction_manual.yaml
@@ -114,6 +114,8 @@
   'by(?:_| )?appointments?': '"by appointment"'
   'nach(?: |_)vereinbarung': '"Nach Vereinbarung"'
   'nach(?: |_)absprache': '"Nach Absprache"'
+  "sur(?: |_)rendez(?: |_|-)?vous": "\"Sur rendez-vous\""
+  "sur(?: |_)rdv": "\"Sur rendez-vous\""
   'bis': '-'
   'täglich': Mo-Su
   '(?:schul)?ferien': SH

--- a/test/test.de.log
+++ b/test/test.de.log
@@ -1368,6 +1368,13 @@ With [34m[1mwarnings[22m[39m:
 "Additional comment "on appointment"" for "Mo-Fr 08:00-12:00 open "appointment not needed", Mo-Fr 13:00-17:00 open on appointment": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
 	*Mo-Fr 08:00-12:00 open "appointment not needed", Mo-Fr 13:00-17:00 open on appointment <--- (Bitte verwende ""on appointment"" anstelle von "on appointment".)
+"Additional comment "Sur rendez-vous"" for "Mo-Fr 08:00-12:00 open "Sans rendez-vous", Mo-Fr 13:00-17:00 open "Sur rendez-vous"": [32m[1mPASSED[22m[39m
+"Additional comment "Sur rendez-vous"" for "Mo-Fr 08:00-12:00 open "Sans rendez-vous", Mo-Fr 13:00-17:00 open sur_rendez_vous": [32m[1mPASSED[22m[39m
+With [34m[1mwarnings[22m[39m:
+	*Mo-Fr 08:00-12:00 open "Sans rendez-vous", Mo-Fr 13:00-17:00 open sur_rendez_vous <--- (Bitte verwende ""Sur rendez-vous"" anstelle von "sur_rendez_vous".)
+"Additional comment "Sur rendez-vous"" for "Mo-Fr 08:00-12:00 open "Sans rendez-vous", Mo-Fr 13:00-17:00 open sur rendez vous": [32m[1mPASSED[22m[39m
+With [34m[1mwarnings[22m[39m:
+	*Mo-Fr 08:00-12:00 open "Sans rendez-vous", Mo-Fr 13:00-17:00 open sur rendez vous <--- (Bitte verwende ""Sur rendez-vous"" anstelle von "sur rendez vous".)
 "Additional comments" for "Mo,Tu 10:00-16:00 open "no warranty"; We 12:00-18:00 open "female only"; Th closed "Not open because we are coding :)"; Fr 10:00-16:00 open "male only"; Sa 10:00-12:00 "Maybe open. Call us."": [32m[1mPASSED[22m[39m
 "Additional comments for unknown" for "Sa 10:00-12:00 "Maybe open. Call us. (testing special tokens in comment: ; ;; ' || | test end)"": [32m[1mPASSED[22m[39m
 "Additional comments for unknown" for "Sa 10:00-12:00 unknown "Maybe open. Call us. (testing special tokens in comment: ; ;; ' || | test end)"": [32m[1mPASSED[22m[39m
@@ -2668,7 +2675,7 @@ Der optional_conf_parm["tag_key"] fehlt, ist aber notwendig wegen optional_conf_
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-1035/1035 tests passed. 0 did not pass.
+1038/1038 tests passed. 0 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.en.log
+++ b/test/test.en.log
@@ -1368,6 +1368,13 @@ With [34m[1mwarnings[22m[39m:
 "Additional comment "on appointment"" for "Mo-Fr 08:00-12:00 open "appointment not needed", Mo-Fr 13:00-17:00 open on appointment": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
 	*Mo-Fr 08:00-12:00 open "appointment not needed", Mo-Fr 13:00-17:00 open on appointment <--- (Please use notation ""on appointment"" for "on appointment".)
+"Additional comment "Sur rendez-vous"" for "Mo-Fr 08:00-12:00 open "Sans rendez-vous", Mo-Fr 13:00-17:00 open "Sur rendez-vous"": [32m[1mPASSED[22m[39m
+"Additional comment "Sur rendez-vous"" for "Mo-Fr 08:00-12:00 open "Sans rendez-vous", Mo-Fr 13:00-17:00 open sur_rendez_vous": [32m[1mPASSED[22m[39m
+With [34m[1mwarnings[22m[39m:
+	*Mo-Fr 08:00-12:00 open "Sans rendez-vous", Mo-Fr 13:00-17:00 open sur_rendez_vous <--- (Please use notation ""Sur rendez-vous"" for "sur_rendez_vous".)
+"Additional comment "Sur rendez-vous"" for "Mo-Fr 08:00-12:00 open "Sans rendez-vous", Mo-Fr 13:00-17:00 open sur rendez vous": [32m[1mPASSED[22m[39m
+With [34m[1mwarnings[22m[39m:
+	*Mo-Fr 08:00-12:00 open "Sans rendez-vous", Mo-Fr 13:00-17:00 open sur rendez vous <--- (Please use notation ""Sur rendez-vous"" for "sur rendez vous".)
 "Additional comments" for "Mo,Tu 10:00-16:00 open "no warranty"; We 12:00-18:00 open "female only"; Th closed "Not open because we are coding :)"; Fr 10:00-16:00 open "male only"; Sa 10:00-12:00 "Maybe open. Call us."": [32m[1mPASSED[22m[39m
 "Additional comments for unknown" for "Sa 10:00-12:00 "Maybe open. Call us. (testing special tokens in comment: ; ;; ' || | test end)"": [32m[1mPASSED[22m[39m
 "Additional comments for unknown" for "Sa 10:00-12:00 unknown "Maybe open. Call us. (testing special tokens in comment: ; ;; ' || | test end)"": [32m[1mPASSED[22m[39m
@@ -2658,7 +2665,7 @@ The optional_conf_parm["tag_key"] is missing, required by optional_conf_parm["ma
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-1025/1025 tests passed. 0 did not pass.
+1028/1028 tests passed. 0 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.js
+++ b/test/test.js
@@ -3830,6 +3830,15 @@ test.addTest('Additional comment "on appointment"', [
         [ '2012-10-01 13:00', '2012-10-01 17:00', false, 'on appointment' ],
     ], 1000 * 60 * 60 * (4 + 4), 0, true, {}, 'not only test');
 
+test.addTest('Additional comment "Sur rendez-vous"', [
+        'Mo-Fr 08:00-12:00 open "Sans rendez-vous", Mo-Fr 13:00-17:00 open "Sur rendez-vous"',
+        'Mo-Fr 08:00-12:00 open "Sans rendez-vous", Mo-Fr 13:00-17:00 open sur_rendez_vous',
+        'Mo-Fr 08:00-12:00 open "Sans rendez-vous", Mo-Fr 13:00-17:00 open sur rendez vous',
+    ], '2012-10-01 0:00', '2012-10-02 0:00', [
+        [ '2012-10-01 08:00', '2012-10-01 12:00', false, 'Sans rendez-vous' ],
+        [ '2012-10-01 13:00', '2012-10-01 17:00', false, 'Sur rendez-vous' ],
+    ], 1000 * 60 * 60 * (4 + 4), 0, true, {}, 'not only test');
+
 test.addTest('Additional comments', [
         'Mo,Tu 10:00-16:00 open "no warranty"; We 12:00-18:00 open "female only"; Th closed "Not open because we are coding :)"; Fr 10:00-16:00 open "male only"; Sa 10:00-12:00 "Maybe open. Call us."',
     ], '2012-10-01 0:00', '2012-10-08 0:00', [


### PR DESCRIPTION
This seems to cover the most common cases, based on a quick taginfo search.

Disclaimer: Although I have studied some French, I am not at all fluent

Inspired by https://community.openstreetmap.org/t/announcing-an-opening-hours-validator/145214/84, specifically
https://www.openstreetmap.org/node/3246854013/history/4