### PR TITLE
fix(docs): link to latest hosted version

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ See the [Testing](#testing) section for details around writing and running tests
 
 If you are a web developer and want to use this library you can do so by including the current version from here:
 
-<https://openingh.openstreetmap.de/opening_hours.js/opening_hours+deps.min.js>
+<https://openingh.openstreetmap.de/build/opening_hours+deps.min.js>
 
 To get started checkout the [simple_index.html](/examples/simple_index.html) file.
 

--- a/examples/simple_index.html
+++ b/examples/simple_index.html
@@ -6,7 +6,7 @@
     <title>Simple page using opening_hours.js</title>
     <meta charset="utf-8">
     <link rel="shortcut icon" type="image/svg+xml" href="https://openingh.openstreetmap.de/evaluation_tool/img/favicon.svg">
-    <script src="https://openingh.openstreetmap.de/opening_hours.js/opening_hours+deps.min.js"></script>
+    <script src="https://openingh.openstreetmap.de/build/opening_hours+deps.min.js"></script>
   </head>
 
   <body>


### PR DESCRIPTION
Having been caught out by this, the link that was listed is not the latest version.

Maybe the actual fix should be to stop hosting that?