### PR TITLE
data(je): fix Jersey holiday data

### DIFF
--- a/src/holidays/generated-openholidays.js
+++ b/src/holidays/generated-openholidays.js
@@ -11665,11 +11665,8 @@ export const it = {
 };
 
 export const je = {
-  "Jersey": {
-    "_state_code": "je",
-    "_nominatim_url": "https://nominatim.openstreetmap.org/reverse?format=json&lat=49.2&lon=-2.1&zoom=11&addressdetails=1&accept-language=en",
-    PH: [{"name":"New Year’s Day","fixed_date":[1,1]},{"name":"Good Friday","variable_date":"easter","offset":-2},{"name":"Easter Monday","variable_date":"easter","offset":1},{"name":"Early May bank holiday","variable_date":"firstMayMonday"},{"name":"Liberation Day","fixed_date":[5,9]},{"name":"Spring bank holiday","variable_date":"lastMayMonday"},{"name":"Summer bank holiday","variable_date":"lastAugustMonday"},{"name":"Christmas Day","fixed_date":[12,25]},{"name":"Boxing Day","fixed_date":[12,26]}]
-  }
+  PH: [{"name":"New Year’s Day","fixed_date":[1,1],"substitute_rule":"if saturday then next monday"},{"name":"Good Friday","variable_date":"easter","offset":-2},{"name":"Easter Monday","variable_date":"easter","offset":1},{"name":"Early May bank holiday","variable_date":"firstMayMonday"},{"name":"Liberation Day","fixed_date":[5,9]},{"name":"Spring bank holiday","variable_date":"lastMayMonday"},{"name":"Summer bank holiday","variable_date":"lastAugustMonday"},{"name":"Christmas Day","fixed_date":[12,25],"substitute_rule":"if saturday then next monday if sunday then next tuesday"},{"name":"Boxing Day","fixed_date":[12,26],"substitute_rule":"if saturday then next monday if sunday then next tuesday"}],
+  "_nominatim_url": "https://nominatim.openstreetmap.org/reverse?format=json&lat=49.2&lon=-2.1&zoom=11&addressdetails=1&accept-language=en"
 };
 
 export const jp = {

--- a/src/holidays/je.yaml
+++ b/src/holidays/je.yaml
@@ -2,17 +2,15 @@
 # SPDX-License-Identifier: ODbL-1.0
 ---
 
-'Jersey':
-  _state_code: je
-  _nominatim_url: https://nominatim.openstreetmap.org/reverse?format=json&lat=49.2&lon=-2.1&zoom=11&addressdetails=1&accept-language=en
+_nominatim_url: https://nominatim.openstreetmap.org/reverse?format=json&lat=49.2&lon=-2.1&zoom=11&addressdetails=1&accept-language=en
 
-  PH:  # https://www.gov.je/leisure/events/whatson/pages/bankholidaydates.aspx
-    - {'name': 'New Year’s Day', 'fixed_date': [1, 1]}
-    - {'name': 'Good Friday', 'variable_date': easter, 'offset': -2}
-    - {'name': 'Easter Monday', 'variable_date': easter, 'offset': 1}
-    - {'name': 'Early May bank holiday', 'variable_date': firstMayMonday}
-    - {'name': 'Liberation Day', 'fixed_date': [5, 9]}
-    - {'name': 'Spring bank holiday', 'variable_date': lastMayMonday}
-    - {'name': 'Summer bank holiday', 'variable_date': lastAugustMonday}
-    - {'name': 'Christmas Day', 'fixed_date': [12, 25]}
-    - {'name': 'Boxing Day', 'fixed_date': [12, 26]}
+PH:  # https://www.gov.je/leisure/events/whatson/pages/bankholidaydates.aspx
+  - {'name': 'New Year’s Day', 'fixed_date': [1, 1]}
+  - {'name': 'Good Friday', 'variable_date': easter, 'offset': -2}
+  - {'name': 'Easter Monday', 'variable_date': easter, 'offset': 1}
+  - {'name': 'Early May bank holiday', 'variable_date': firstMayMonday}
+  - {'name': 'Liberation Day', 'fixed_date': [5, 9]}
+  - {'name': 'Spring bank holiday', 'variable_date': lastMayMonday}
+  - {'name': 'Summer bank holiday', 'variable_date': lastAugustMonday}
+  - {'name': 'Christmas Day', 'fixed_date': [12, 25]}
+  - {'name': 'Boxing Day', 'fixed_date': [12, 26]}

--- a/src/holidays/je.yaml
+++ b/src/holidays/je.yaml
@@ -5,12 +5,12 @@
 _nominatim_url: https://nominatim.openstreetmap.org/reverse?format=json&lat=49.2&lon=-2.1&zoom=11&addressdetails=1&accept-language=en
 
 PH:  # https://www.gov.je/leisure/events/whatson/pages/bankholidaydates.aspx
-  - {'name': 'New Year’s Day', 'fixed_date': [1, 1]}
+  - {'name': 'New Year’s Day', 'fixed_date': [1, 1], 'substitute_rule': 'if saturday then next monday'}
   - {'name': 'Good Friday', 'variable_date': easter, 'offset': -2}
   - {'name': 'Easter Monday', 'variable_date': easter, 'offset': 1}
   - {'name': 'Early May bank holiday', 'variable_date': firstMayMonday}
   - {'name': 'Liberation Day', 'fixed_date': [5, 9]}
   - {'name': 'Spring bank holiday', 'variable_date': lastMayMonday}
   - {'name': 'Summer bank holiday', 'variable_date': lastAugustMonday}
-  - {'name': 'Christmas Day', 'fixed_date': [12, 25]}
-  - {'name': 'Boxing Day', 'fixed_date': [12, 26]}
+  - {'name': 'Christmas Day', 'fixed_date': [12, 25], 'substitute_rule': 'if saturday then next monday if sunday then next tuesday'}
+  - {'name': 'Boxing Day', 'fixed_date': [12, 26], 'substitute_rule': 'if saturday then next monday if sunday then next tuesday'}

--- a/src/holidays/je.yaml
+++ b/src/holidays/je.yaml
@@ -2,9 +2,12 @@
 # SPDX-License-Identifier: ODbL-1.0
 ---
 
+# @attrib https://github.com/commenthol/date-holidays/blob/master/data/countries/JE.yaml
+# @attrib https://www.gov.je/leisure/events/whatson/pages/bankholidaydates.aspx
+
 _nominatim_url: https://nominatim.openstreetmap.org/reverse?format=json&lat=49.2&lon=-2.1&zoom=11&addressdetails=1&accept-language=en
 
-PH:  # https://www.gov.je/leisure/events/whatson/pages/bankholidaydates.aspx
+PH:
   - {'name': 'New Year’s Day', 'fixed_date': [1, 1], 'substitute_rule': 'if saturday then next monday'}
   - {'name': 'Good Friday', 'variable_date': easter, 'offset': -2}
   - {'name': 'Easter Monday', 'variable_date': easter, 'offset': 1}


### PR DESCRIPTION
The holidays file for Jersey included Jersey as if it was a state of itself.

According to the [sample Nominatim API call](https://nominatim.openstreetmap.org/reverse?format=json&lat=49.2&lon=-2.1&zoom=11&addressdetails=1&accept-language=en) there is no state defined.

This is confirmed when attempting to parse [a value with holidays](https://openingh.ypid.de/evaluation_tool/?EXP=Mo-Fr+10%3A00-20%3A00%3B+PH+off&lat=49.1856637&lon=-2.1102277&mode=0&DATE=1785955440000) in Jersey which states "There are no holidays (PH) defined for country je and state undefined."

I'm not sure of how to test this, do I need to do some regeneration of the holidays?