### PR TITLE
fix(locale-resolver): add Polish pn alias

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,8 @@ build/opening_hours.js \
 build/opening_hours.min.js \
 build/opening_hours.esm.mjs \
 build/opening_hours+deps.js \
-build/opening_hours+deps.min.js: src/index.js src/locales/word_error_correction.yaml
+build/opening_hours+deps.min.js: src/index.js src/locales/word_error_correction.yaml \
+src/locale-resolver/layers.json
 	node_modules/.bin/rollup -c
 
 .PHONY: check
@@ -514,6 +515,10 @@ osm-tag-data-gen-stats-sort:
 src/locales/word_error_correction.yaml: scripts/gen_word_error_correction.mjs
 	@echo "Generating word error correction data..."
 	$(NODEJS) scripts/gen_word_error_correction.mjs >/dev/null
+
+src/locale-resolver/layers.json: scripts/gen_locale_resolver_layers.mjs src/locale-resolver/manual-aliases.yaml
+	@echo "Generating locale resolver layers..."
+	$(NODEJS) scripts/gen_locale_resolver_layers.mjs >/dev/null
 
 README.html:
 

--- a/scripts/gen_locale_resolver_layers.mjs
+++ b/scripts/gen_locale_resolver_layers.mjs
@@ -209,7 +209,7 @@ for (const type of Object.keys(TYPES)) {
 const manualAliases = loadManualAliases();
 
 /** @type {Map<string, Map<string, Candidate>>} */
-const crossLocaleSets = new Map(); // token -> Map(`${lang}|${meaning}|${type}` -> candidate)
+const candidatesByToken = new Map(); // token -> Map(`${lang}|${meaning}|${type}` -> candidate)
 
 for (const locale of locales) {
     const baseLang = locale.split('-')[0].toLowerCase();
@@ -236,9 +236,9 @@ for (const locale of locales) {
             if (!officialLangs.has(baseLang)) {
                 continue;
             }
-            const set = crossLocaleSets.get(token) ?? new Map();
-            crossLocaleSets.set(token, set);
-            set.set(`${baseLang}|${meaning}|${type}`, {
+            const candidatesByKey = candidatesByToken.get(token) ?? new Map();
+            candidatesByToken.set(token, candidatesByKey);
+            candidatesByKey.set(`${baseLang}|${meaning}|${type}`, {
                 lang: baseLang,
                 meaning,
                 type: /** @type {LayerType} */ (type),
@@ -254,9 +254,9 @@ for (const [type, languages] of Object.entries(manualAliases)) {
             if (!token || token in canonical[type] || token in universal[type]) {
                 continue;
             }
-            const set = crossLocaleSets.get(token) ?? new Map();
-            crossLocaleSets.set(token, set);
-            set.set(`${lang}|${meaning}|${type}`, {
+            const candidatesByKey = candidatesByToken.get(token) ?? new Map();
+            candidatesByToken.set(token, candidatesByKey);
+            candidatesByKey.set(`${lang}|${meaning}|${type}`, {
                 lang,
                 meaning,
                 type: /** @type {LayerType} */ (type),
@@ -267,8 +267,8 @@ for (const [type, languages] of Object.entries(manualAliases)) {
 
 /** @type {Record<string, Candidate[]>} */
 const crossLocale = {};
-for (const [token, set] of crossLocaleSets) {
-    crossLocale[token] = [...set.values()].sort(
+for (const [token, candidatesByKey] of candidatesByToken) {
+    crossLocale[token] = [...candidatesByKey.values()].sort(
         (a, b) => a.lang.localeCompare(b.lang, 'en')
             || a.type.localeCompare(b.type, 'en')
             || a.meaning.localeCompare(b.meaning, 'en'),

--- a/scripts/gen_locale_resolver_layers.mjs
+++ b/scripts/gen_locale_resolver_layers.mjs
@@ -27,7 +27,7 @@
  * established non-CLDR abbreviations used in opening_hours data.
  * Output: src/locale-resolver/layers.json
  *
- * Run from the repo root:  node src/locale-resolver/gen-layers.mjs
+ * Run from the repo root:  node scripts/gen_locale_resolver_layers.mjs
  */
 
 /** @typedef {Record<string, any>} JsonObject */ // eslint-disable-line jsdoc/reject-any-type
@@ -39,17 +39,16 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import yaml from 'yaml';
-import { normalizeToken } from './normalize.mjs';
+import { normalizeToken } from '../src/locale-resolver/normalize.mjs';
 
-const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const basePath = process.cwd();
+const localeResolverPath = path.resolve(basePath, 'src/locale-resolver');
 const cldrDatesMainPath = path.resolve(basePath, 'node_modules/cldr-dates-full/main');
 const cldrPackageJson = path.resolve(basePath, 'node_modules/cldr-dates-full/package.json');
 const territoryInfoPath = path.resolve(basePath, 'node_modules/cldr-core/supplemental/territoryInfo.json');
-const manualAliasesPath = path.join(scriptDir, 'manual-aliases.yaml');
-const outputPath = path.join(scriptDir, 'layers.json');
+const manualAliasesPath = path.join(localeResolverPath, 'manual-aliases.yaml');
+const outputPath = path.join(localeResolverPath, 'layers.json');
 
 // Type definitions: canonical order matches src/index.js string_to_token_map.
 /** @type {Record<string, LayerSpec>} */

--- a/scripts/gen_locale_resolver_layers.mjs
+++ b/scripts/gen_locale_resolver_layers.mjs
@@ -293,6 +293,19 @@ const output = {
     regionLangs,
 };
 
+// Keep the date stable when the generated data is unchanged, so regular builds
+// do not create a needless diff in the generated file.
+if (fs.existsSync(outputPath)) {
+    const previous = readJson(outputPath);
+    const currentGenerated = output.meta.generated;
+    if (typeof previous.meta.generated === 'string') {
+        output.meta.generated = previous.meta.generated;
+        if (JSON.stringify(previous) !== JSON.stringify(output)) {
+            output.meta.generated = currentGenerated;
+        }
+    }
+}
+
 fs.writeFileSync(outputPath, `${JSON.stringify(output, null, 2)}\n`);
 console.log(`  Layer 3 tokens  : ${output.meta.crossLocaleTokens} (${candidateCount} candidates)`);
 console.log(`  Region langs    : ${output.meta.regionCount} countries`);

--- a/src/locale-resolver/gen-layers.mjs
+++ b/src/locale-resolver/gen-layers.mjs
@@ -23,7 +23,8 @@
  * to the geo/country languages). A former per-locale table would be 100 %
  * recoverable from crossLocale by base language, so it is not emitted.
  *
- * Source: pinned cldr-dates-full package (same data the existing generator uses).
+ * Sources: pinned cldr-dates-full package and manual-aliases.json for
+ * established non-CLDR abbreviations used in opening_hours data.
  * Output: src/locale-resolver/layers.json
  *
  * Run from the repo root:  node src/locale-resolver/gen-layers.mjs
@@ -32,6 +33,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import yaml from 'yaml';
 import { normalizeToken } from './normalize.mjs';
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
@@ -39,6 +41,7 @@ const basePath = process.cwd();
 const cldrDatesMainPath = path.resolve(basePath, 'node_modules/cldr-dates-full/main');
 const cldrPackageJson = path.resolve(basePath, 'node_modules/cldr-dates-full/package.json');
 const territoryInfoPath = path.resolve(basePath, 'node_modules/cldr-core/supplemental/territoryInfo.json');
+const manualAliasesPath = path.join(scriptDir, 'manual-aliases.yaml');
 const outputPath = path.join(scriptDir, 'layers.json');
 
 // Type definitions: canonical order matches src/index.js string_to_token_map.
@@ -120,6 +123,13 @@ function sortObject(obj) {
     );
 }
 
+function loadManualAliases() {
+    if (!fs.existsSync(manualAliasesPath)) {
+        return {};
+    }
+    return yaml.parse(fs.readFileSync(manualAliasesPath, 'utf8')) || {};
+}
+
 // Layer 2b (geo): official languages per country, from CLDR supplemental territoryInfo.
 // Only 2-letter country codes (matching nominatim country_code); only official +
 // de_facto_official status (regional/minority languages are intentionally excluded
@@ -166,6 +176,8 @@ for (const type of Object.keys(TYPES)) {
     universal[type] = TYPES[type].universal;
 }
 
+const manualAliases = loadManualAliases();
+
 const crossLocaleSets = new Map(); // token -> Map(`${lang}|${meaning}|${type}` -> candidate)
 
 for (const locale of locales) {
@@ -195,6 +207,19 @@ for (const locale of locales) {
             }
             const set = crossLocaleSets.get(token) || crossLocaleSets.set(token, new Map()).get(token);
             set.set(`${baseLang}|${meaning}|${type}`, { lang: baseLang, meaning, type });
+        }
+    }
+}
+
+for (const [type, languages] of Object.entries(manualAliases)) {
+    for (const [lang, aliases] of Object.entries(languages)) {
+        for (const [rawToken, meaning] of Object.entries(aliases)) {
+            const token = normalizeToken(rawToken);
+            if (!token || token in canonical[type] || token in universal[type]) {
+                continue;
+            }
+            const set = crossLocaleSets.get(token) || crossLocaleSets.set(token, new Map()).get(token);
+            set.set(`${lang}|${meaning}|${type}`, { lang, meaning, type });
         }
     }
 }

--- a/src/locale-resolver/gen-layers.mjs
+++ b/src/locale-resolver/gen-layers.mjs
@@ -23,12 +23,19 @@
  * to the geo/country languages). A former per-locale table would be 100 %
  * recoverable from crossLocale by base language, so it is not emitted.
  *
- * Sources: pinned cldr-dates-full package and manual-aliases.json for
+ * Sources: pinned cldr-dates-full package and manual-aliases.yaml for
  * established non-CLDR abbreviations used in opening_hours data.
  * Output: src/locale-resolver/layers.json
  *
  * Run from the repo root:  node src/locale-resolver/gen-layers.mjs
  */
+
+/** @typedef {Record<string, any>} JsonObject */ // eslint-disable-line jsdoc/reject-any-type
+/** @typedef {'weekday'|'month'} LayerType */
+/** @typedef {{ token: string, meaning: string }} LocaleTerm */
+/** @typedef {{ lang: string, meaning: string, type: LayerType }} Candidate */
+/** @typedef {Record<string, any>} GenericRecord */ // eslint-disable-line jsdoc/reject-any-type
+/** @typedef {{ keys: string[], meanings: string[], tables: (gregorian: JsonObject|undefined) => any[], canonical: Record<string, string>, universal: Record<string, string> }} LayerSpec */ // eslint-disable-line jsdoc/reject-any-type
 
 import fs from 'node:fs';
 import path from 'node:path';
@@ -45,6 +52,7 @@ const manualAliasesPath = path.join(scriptDir, 'manual-aliases.yaml');
 const outputPath = path.join(scriptDir, 'layers.json');
 
 // Type definitions: canonical order matches src/index.js string_to_token_map.
+/** @type {Record<string, LayerSpec>} */
 const TYPES = {
     weekday: {
         keys: ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'],
@@ -79,6 +87,10 @@ const TYPES = {
     },
 };
 
+/**
+ * @param {string} filePath - JSON file to read.
+ * @returns {JsonObject} Parsed JSON object.
+ */
 function readJson(filePath) {
     return JSON.parse(fs.readFileSync(filePath, 'utf8'));
 }
@@ -94,14 +106,25 @@ function listCldrLocales() {
         .sort((a, b) => a.localeCompare(b, 'en'));
 }
 
+/**
+ * @param {string} locale - CLDR locale identifier.
+ * @returns {JsonObject|undefined} Gregorian calendar data, if available.
+ */
 function loadGregorian(locale) {
     const filePath = path.join(cldrDatesMainPath, locale, 'ca-gregorian.json');
     return readJson(filePath)?.main?.[locale]?.dates?.calendars?.gregorian;
 }
 
-// All lexemes of a given type for a locale: wide + abbreviated, format + stand-alone.
+/**
+ * Collect all lexemes of a given type for a locale: wide + abbreviated,
+ * format + stand-alone.
+ * @param {JsonObject|undefined} gregorian - CLDR Gregorian calendar data.
+ * @param {string} type - Layer type to collect.
+ * @returns {LocaleTerm[]} Normalized locale terms.
+ */
 function localeTerms(gregorian, type) {
     const spec = TYPES[type];
+    /** @type {LocaleTerm[]} */
     const terms = [];
     for (const table of spec.tables(gregorian)) {
         if (!table) {
@@ -117,12 +140,17 @@ function localeTerms(gregorian, type) {
     return terms;
 }
 
+/**
+ * @param {GenericRecord} obj - Object to sort.
+ * @returns {GenericRecord} Sorted object.
+ */
 function sortObject(obj) {
     return Object.fromEntries(
         Object.keys(obj).sort((a, b) => a.localeCompare(b, 'en')).map(key => [key, obj[key]]),
     );
 }
 
+/** @returns {Record<string, Record<string, Record<string, string>>>} Manual aliases by type and language. */
 function loadManualAliases() {
     if (!fs.existsSync(manualAliasesPath)) {
         return {};
@@ -140,6 +168,7 @@ function buildRegionLangs() {
     }
     const info = readJson(territoryInfoPath).supplemental.territoryInfo;
     const OFFICIAL = new Set(['official', 'de_facto_official']);
+    /** @type {Record<string, string[]>} */
     const regionLangs = {};
     for (const [territory, data] of Object.entries(info)) {
         if (!/^[A-Z]{2}$/.test(territory)) {
@@ -169,7 +198,9 @@ console.log(`  CLDR locales: ${locales.length} (cldr-dates-full ${cldrVersion})`
 const regionLangs = buildRegionLangs();
 const officialLangs = new Set(Object.values(regionLangs).flat());
 
+/** @type {Record<string, Record<string, string>>} */
 const canonical = {};
+/** @type {Record<string, Record<string, string>>} */
 const universal = {};
 for (const type of Object.keys(TYPES)) {
     canonical[type] = TYPES[type].canonical;
@@ -178,6 +209,7 @@ for (const type of Object.keys(TYPES)) {
 
 const manualAliases = loadManualAliases();
 
+/** @type {Map<string, Map<string, Candidate>>} */
 const crossLocaleSets = new Map(); // token -> Map(`${lang}|${meaning}|${type}` -> candidate)
 
 for (const locale of locales) {
@@ -205,8 +237,13 @@ for (const locale of locales) {
             if (!officialLangs.has(baseLang)) {
                 continue;
             }
-            const set = crossLocaleSets.get(token) || crossLocaleSets.set(token, new Map()).get(token);
-            set.set(`${baseLang}|${meaning}|${type}`, { lang: baseLang, meaning, type });
+            const set = crossLocaleSets.get(token) ?? new Map();
+            crossLocaleSets.set(token, set);
+            set.set(`${baseLang}|${meaning}|${type}`, {
+                lang: baseLang,
+                meaning,
+                type: /** @type {LayerType} */ (type),
+            });
         }
     }
 }
@@ -218,12 +255,18 @@ for (const [type, languages] of Object.entries(manualAliases)) {
             if (!token || token in canonical[type] || token in universal[type]) {
                 continue;
             }
-            const set = crossLocaleSets.get(token) || crossLocaleSets.set(token, new Map()).get(token);
-            set.set(`${lang}|${meaning}|${type}`, { lang, meaning, type });
+            const set = crossLocaleSets.get(token) ?? new Map();
+            crossLocaleSets.set(token, set);
+            set.set(`${lang}|${meaning}|${type}`, {
+                lang,
+                meaning,
+                type: /** @type {LayerType} */ (type),
+            });
         }
     }
 }
 
+/** @type {Record<string, Candidate[]>} */
 const crossLocale = {};
 for (const [token, set] of crossLocaleSets) {
     crossLocale[token] = [...set.values()].sort(

--- a/src/locale-resolver/layers.json
+++ b/src/locale-resolver/layers.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "generated": "2026-07-10",
+    "generated": "2026-08-09",
     "cldrDatesFull": "48.2.0",
     "localeCount": 766,
     "types": [
@@ -8,7 +8,7 @@
       "month"
     ],
     "crossLocaleTokens": 2870,
-    "crossLocaleCandidates": 3685,
+    "crossLocaleCandidates": 3686,
     "regionCount": 250
   },
   "canonical": {
@@ -11339,6 +11339,11 @@
       {
         "lang": "lt",
         "meaning": "Fr",
+        "type": "weekday"
+      },
+      {
+        "lang": "pl",
+        "meaning": "Mo",
         "type": "weekday"
       }
     ],

--- a/src/locale-resolver/manual-aliases.yaml
+++ b/src/locale-resolver/manual-aliases.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: © opening_hours.js contributors
+# SPDX-License-Identifier: LGPL-3.0-only
+---
+# Established weekday abbreviations not included in CLDR.
+weekday:
+  pl:
+    # CLDR provides "pon." for Polish Monday. "pn" is also an established
+    # Polish calendar abbreviation, but conflicts with Lithuanian "pn" = Friday.
+    pn: Mo

--- a/src/locale-resolver/region-languages.mjs
+++ b/src/locale-resolver/region-languages.mjs
@@ -17,7 +17,7 @@ const cache = new Map();
 
 /**
  * @param {string|undefined} countryCode - e.g. "de", "LT" (case-insensitive).
- * @param {object} layers - generated layer data; uses `layers.regionLangs`.
+ * @param {{ regionLangs?: Record<string, string[]> }} layers - generated layer data; uses `layers.regionLangs`.
  * @returns {Set<string>} language codes plausible at that location (may be empty).
  */
 export function regionLanguages(countryCode, layers) {

--- a/src/locale-resolver/region-languages.mjs
+++ b/src/locale-resolver/region-languages.mjs
@@ -9,7 +9,7 @@
  * plausible at that location (its official languages).
  *
  * The data itself is generated from CLDR `territoryInfo` into `layers.regionLangs`
- * (see gen-layers.mjs), so this module ships no CLDR dependency — it only looks
+ * (see gen_locale_resolver_layers.mjs), so this module ships no CLDR dependency — it only looks
  * up and caches.
  */
 

--- a/test/test.de.log
+++ b/test/test.de.log
@@ -1780,6 +1780,22 @@ With [34m[1mwarnings[22m[39m:
 "Time intervals (not specified/documented use of colon, please avoid this)" for "00:00-24:00; Mo: 15:00-16:00 off": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
 	*00:00-24:00; Mo:  <--- (Du hast das optionale Symbol <separator_for_readability> an der falschen Stelle benutzt. Bitte lies die Syntax-Spezifikation um zu sehen, wo es verwendet werden kann, oder entferne es.)
+"Polish pn means Monday" for "Mo 10:00-12:00": [32m[1mPASSED[22m[39m
+"Polish pn means Monday" for "pn 10:00-12:00": [32m[1mPASSED[22m[39m
+With [34m[1mwarnings[22m[39m:
+	*pn <--- (Bitte benutze die englische Abkürzung "Mo" für "pn". Beachte, dass "pn" anderswo auch Fr (lt) bedeuten kann.)
+"Polish pn means Monday" for "pn. 10:00-12:00": [32m[1mPASSED[22m[39m
+With [34m[1mwarnings[22m[39m:
+	*pn <--- (Bitte benutze die englische Abkürzung "Mo" für "pn". Beachte, dass "pn" anderswo auch Fr (lt) bedeuten kann.)
+	*pn. <--- (Bitte verzichte auf ".".)
+"Lithuanian pn means Friday" for "Fr 10:00-12:00": [32m[1mPASSED[22m[39m
+"Lithuanian pn means Friday" for "pn 10:00-12:00": [32m[1mPASSED[22m[39m
+With [34m[1mwarnings[22m[39m:
+	*pn <--- (Bitte benutze die englische Abkürzung "Fr" für "pn". Beachte, dass "pn" anderswo auch Mo (pl) bedeuten kann.)
+"Lithuanian pn means Friday" for "pn. 10:00-12:00": [32m[1mPASSED[22m[39m
+With [34m[1mwarnings[22m[39m:
+	*pn <--- (Bitte benutze die englische Abkürzung "Fr" für "pn". Beachte, dass "pn" anderswo auch Mo (pl) bedeuten kann.)
+	*pn. <--- (Bitte verzichte auf ".".)
 "Reordered selectors without comments still emit switched warnings" for "Mo-Fr 10:00-20:00 open; open We 10:00-16:00": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
 	*Mo-Fr 10:00-20:00 open; We <--- (Der Selektor "weekday" wurde für eine bessere Lesbarkeit und der Vollständigkeit halber mit "state" getauscht.)
@@ -2675,7 +2691,7 @@ Der optional_conf_parm["tag_key"] fehlt, ist aber notwendig wegen optional_conf_
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-1038/1038 tests passed. 0 did not pass.
+1044/1044 tests passed. 0 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.en.log
+++ b/test/test.en.log
@@ -1780,6 +1780,22 @@ With [34m[1mwarnings[22m[39m:
 "Time intervals (not specified/documented use of colon, please avoid this)" for "00:00-24:00; Mo: 15:00-16:00 off": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
 	*00:00-24:00; Mo:  <--- (You have used the optional symbol <separator_for_readability> in the wrong place. Please check the syntax specification to see where it could be used or remove it.)
+"Polish pn means Monday" for "Mo 10:00-12:00": [32m[1mPASSED[22m[39m
+"Polish pn means Monday" for "pn 10:00-12:00": [32m[1mPASSED[22m[39m
+With [34m[1mwarnings[22m[39m:
+	*pn <--- (Please use the English abbreviation "Mo" for "pn". Note that "pn" can also mean Fr (lt) in other languages.)
+"Polish pn means Monday" for "pn. 10:00-12:00": [32m[1mPASSED[22m[39m
+With [34m[1mwarnings[22m[39m:
+	*pn <--- (Please use the English abbreviation "Mo" for "pn". Note that "pn" can also mean Fr (lt) in other languages.)
+	*pn. <--- (Please omit ".".)
+"Lithuanian pn means Friday" for "Fr 10:00-12:00": [32m[1mPASSED[22m[39m
+"Lithuanian pn means Friday" for "pn 10:00-12:00": [32m[1mPASSED[22m[39m
+With [34m[1mwarnings[22m[39m:
+	*pn <--- (Please use the English abbreviation "Fr" for "pn". Note that "pn" can also mean Mo (pl) in other languages.)
+"Lithuanian pn means Friday" for "pn. 10:00-12:00": [32m[1mPASSED[22m[39m
+With [34m[1mwarnings[22m[39m:
+	*pn <--- (Please use the English abbreviation "Fr" for "pn". Note that "pn" can also mean Mo (pl) in other languages.)
+	*pn. <--- (Please omit ".".)
 "Reordered selectors without comments still emit switched warnings" for "Mo-Fr 10:00-20:00 open; open We 10:00-16:00": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
 	*Mo-Fr 10:00-20:00 open; We <--- (The selector "weekday" was switched with the selector "state" for readability and compatibility reasons.)
@@ -2665,7 +2681,7 @@ The optional_conf_parm["tag_key"] is missing, required by optional_conf_parm["ma
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-1028/1028 tests passed. 0 did not pass.
+1034/1034 tests passed. 0 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.js
+++ b/test/test.js
@@ -5478,6 +5478,20 @@ test.addStructuredWarnings('Structured warning: word error correction has stable
         [ 'word_error_correction', 'vague' ],
         nominatim_default, 'not only test', { 'tag_key': 'opening_hours' });
 
+test.addTest('Polish pn means Monday',
+    [ 'Mo 10:00-12:00', 'pn 10:00-12:00', 'pn. 10:00-12:00' ],
+    '2012-10-01 0:00', '2012-10-08 0:00', [
+        [ '2012-10-01 10:00', '2012-10-01 12:00' ],
+    ], 1000 * 60 * 60 * 2, 0, true,
+    { address: { country_code: 'pl' } }, 'not only test', { 'tag_key': 'opening_hours' });
+
+test.addTest('Lithuanian pn means Friday',
+    [ 'Fr 10:00-12:00', 'pn 10:00-12:00', 'pn. 10:00-12:00' ],
+    '2012-10-01 0:00', '2012-10-08 0:00', [
+        [ '2012-10-05 10:00', '2012-10-05 12:00' ],
+    ], 1000 * 60 * 60 * 2, 0, true,
+    { address: { country_code: 'lt' } }, 'not only test', { 'tag_key': 'opening_hours' });
+
 test.addStructuredWarnings('Structured warning: no warnings yields empty list',
         'Mo 10:00-12:00',
         [],


### PR DESCRIPTION
In [this comment on issue #588](https://github.com/opening-hours/opening_hours.js/issues/588#issuecomment-5159517880), @confusedbuffalo reported that Polish `pn` is incorrectly interpreted as Friday.

The reason is that `pn` has different meanings depending on the language: it means Monday in Polish, but Friday in Lithuanian. The first commit fixes this while keeping the Lithuanian interpretation unchanged. Two new regression tests cover both cases.

Since I was already working on the generator script, I took the opportunity to make the following additional changes to it:

- Fix the type issues.
- Move it to `scripts/`.
- Implement it into the build step.