### PR TITLE
chore: create .npmrc with security settings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,7 @@ permissions:
 env:
   npm_config_cache: /tmp/npm-cache
   npm_config_min_release_age: 7
+  NODE_EXTRA_CA_CERTS: /etc/ssl/certs/ca-certificates.crt
 
 jobs:
   code-style-check:
@@ -29,8 +30,8 @@ jobs:
       - name: "Use Node.js"
         uses: actions/setup-node@v7
         with:
-          node-version: lts/*
-          cache: "npm"
+          node-version: "26.x"
+          package-manager-cache: false
       - name: Install dependencies
         run: npm ci --ignore-scripts
       - name: Run linter tests
@@ -51,6 +52,33 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Use latest Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: "26.x"
+          package-manager-cache: false
+      - id: npm-cache
+        name: Restore npm cache
+        uses: actions/cache@v6
+        with:
+          key: npm-cache-${{ github.ref_name }}
+          path: ${{ env.npm_config_cache }}
+      - name: Install dependencies
+        run: git submodule update --init --recursive && npm install
+      - name: Build
+        run: make build
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: opening-hours-build
+          path: build/
+
+  test:
+    needs: build
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         node-version:
@@ -66,13 +94,17 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
-      - id: npm-cache
-        name: Restore npm cache
-        uses: actions/cache@v6
-        with:
-          key: npm-cache-${{ github.ref_name }}
-          path: ${{ env.npm_config_cache }}
+          package-manager-cache: false
       - name: Install dependencies
-        run: make dependencies-get
+        # Simplify once all matrix Node.js versions ship npm 11; npm 10
+        # cannot bootstrap npm 11 from the project because of devEngines.
+        run: cd /tmp && npx --yes npm@11 --prefix "$GITHUB_WORKSPACE" ci --ignore-scripts
+      - name: Download build artifact
+        uses: actions/download-artifact@v6
+        with:
+          name: opening-hours-build
+          path: build/
+      - name: Mark build artifact as current
+        run: touch build/*
       - name: Run full test suite
         run: make check-full

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: © opening_hours.js contributors
+# SPDX-License-Identifier: CC0-1.0
+
+# npm security best practices
+
+# SECURITY: do not run any lifecycle scripts (postinstall) etc
+ignore-scripts=true
+
+# SECURITY: reject git-source dependencies (git+ssh:// etc)
+allow-git=none
+
+# SECURITY: block packages newer than 7 days
+min-release-age=7

--- a/.npmrc
+++ b/.npmrc
@@ -3,8 +3,8 @@
 
 # npm security best practices
 
-# SECURITY: do not run any lifecycle scripts (postinstall) etc
-ignore-scripts=true
+# SECURITY: reject unapproved dependency lifecycle scripts
+strict-allow-scripts=true
 
 # SECURITY: reject git-source dependencies (git+ssh:// etc)
 allow-git=none

--- a/package.json
+++ b/package.json
@@ -107,6 +107,16 @@
   "engines": {
     "node": ">=14"
   },
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "version": ">=11",
+      "onFail": "error"
+    }
+  },
+  "allowScripts": {
+    "fsevents": false
+  },
   "config": {
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"


### PR DESCRIPTION
To fight supply chain attacs most projects use the (a bit new) npm option `min-release-age` with 7 or even 14 days.

https://docs.npmjs.com/cli/v12/using-npm/config#min-release-age

Most compromited packages are found within hours or few days. So using older packages would save us from installing such bad packages.

I think a file in root `.npmrc` with this would be a good idea.

I hope the new file is not too restrictive for this project.

Disclaimer:
Completely done via browser text interface with no check (outside from CI).