### PR TITLE
fix(parser): warn about ambiguous single-digit hours

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -302,6 +302,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
         throw t('nothing');
     }
 
+    /** @typedef {[number, string, number] & { single_digit_lexeme?: boolean, meridian?: string }} ParserToken */
     const parsing_warnings = []; // Elements are arrays [nrule, at, type, message, tokens_to_use?] fed into formatWarnErrorMessage().
     let done_with_warnings = false; // The functions which returns warnings can be called multiple times.
     let done_with_selector_reordering = false;
@@ -857,6 +858,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
                             }
 
                             if (typeof hours_token === 'object') {
+                                hours_token.meridian = correct_val;
                                 if (correct_val === 'pm' && hours_token[0] < 12) {
                                     hours_token[0] += 12;
                                 }
@@ -930,6 +932,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
                                 'interpreted_as_year', t('interpreted as year', {number:  Number(tmp[1])})
                         ]);
                 } else {
+                    /** @type {ParserToken} */
                     const number_token = [ Number(tmp[1]), 'number', value.length ];
                     // Store whether the original numeric lexeme had a single digit (e.g. "9").
                     // Only consulted at hour positions, where a single digit (0-9) is ambiguous.
@@ -1929,6 +1932,48 @@ export default function(value, nominatim_object, optional_conf_parm) {
     /* }}} */
     /* }}} */
 
+    /**
+     * Warn about ambiguous single-digit hours in a time range.
+     * The start hour is also ambiguous when the end hour has an implicit PM
+     * meridian, as in `4-10 pm`.
+     * @param {Array<ParserToken>} tokens List of parser tokens.
+     * @param {number} start_at Token index of the start hour.
+     * @param {number} end_at Token index of the end hour.
+     * @param {number} nrule Rule number starting with 0.
+     * @returns {void}
+     */
+    function warnAmbiguousSingleDigitHours(tokens, start_at, end_at, nrule) {
+        /** @type {(token: ParserToken, hour: number) => boolean} */
+        const is_ambiguous_hour = (token, hour) =>
+            token.single_digit_lexeme === true && token.meridian === undefined && hour < 12;
+        const start_hour = tokens[start_at][0];
+        const end_hour = tokens[end_at][0];
+        const end_hour_is_ambiguous = is_ambiguous_hour(tokens[end_at], end_hour);
+        const start_hour_is_ambiguous = is_ambiguous_hour(tokens[start_at], start_hour);
+        const end_has_implicit_pm = tokens[end_at].meridian === 'pm';
+        const should_warn_start = start_hour_is_ambiguous &&
+            (end_hour_is_ambiguous || end_has_implicit_pm);
+
+        if (done_with_warnings || (!end_hour_is_ambiguous && !should_warn_start)) {
+            return;
+        }
+
+        const ambiguous_hours = [];
+        if (should_warn_start) {
+            ambiguous_hours.push([start_at, start_hour]);
+        }
+        if (end_hour_is_ambiguous) {
+            ambiguous_hours.push([end_at, end_hour]);
+        }
+
+        for (const [token_index, hour] of ambiguous_hours) {
+            parsing_warnings.push([nrule, token_index, 'ambiguous_single_digit_hour', t('ambiguous single digit hour', {
+                'hour':    hour,
+                'hour_pm': hour + 12,
+            })]);
+        }
+    }
+
     /* Time range parser (10:00-12:00,14:00-16:00) {{{
      *
      * :param tokens: List of token objects.
@@ -2021,30 +2066,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
                     } else {
                         if (has_normal_time[1]) {
                             minutes_to = getMinutesByHoursMinutes(tokens, nrule, at_end_time);
-                            const from_hour = tokens[at][0];
-                            const to_hour = tokens[at_end_time][0];
-                            // to_hour < 12: am/pm correction can raise the value of a single-digit
-                            // lexeme to >= 12 (e.g. "8pm" -> 20), which is not ambiguous.
-                            const ambiguous_end_hour = tokens[at_end_time].single_digit_lexeme === true && to_hour < 12;
-
-                            // The end hour is ambiguous regardless of the start type
-                            // (e.g. "12:00-6:00" or "sunrise-6:00").
-                            if (!done_with_warnings && ambiguous_end_hour) {
-                                const ambiguous_hours = [];
-                                // The start hour only adds ambiguity when it is a single-digit
-                                // clock time (not a variable time) and the end hour is ambiguous too.
-                                if (tokens[at].single_digit_lexeme === true && from_hour < 12) {
-                                    ambiguous_hours.push([at, from_hour]);
-                                }
-                                ambiguous_hours.push([at_end_time, to_hour]);
-
-                                for (const [token_index, hour] of ambiguous_hours) {
-                                    parsing_warnings.push([nrule, token_index, 'ambiguous_single_digit_hour', t('ambiguous single digit hour', {
-                                        'hour':    hour,
-                                        'hour_pm': hour + 12,
-                                    })]);
-                                }
-                            }
+                            warnAmbiguousSingleDigitHours(tokens, at, at_end_time, nrule);
                         } else {
                             timevar_string[1] = tokens[at_end_time+has_time_var_calc[1]][0];
                             minutes_to = word_value_replacement[timevar_string[1]];
@@ -2226,6 +2248,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
             } else if (matchTokens(tokens, at, 'number', '-', 'number')) { // "Mo 09-18" (Please don’t use this) -> "Mo 09:00-18:00".
                 minutes_from = tokens[at][0]   * 60;
                 minutes_to   = tokens[at+2][0] * 60;
+                warnAmbiguousSingleDigitHours(tokens, at, at + 2, nrule);
                 if (!done_with_warnings) {
                     parsing_warnings.push([nrule, at + 2, 'without_minutes', t('without minutes', {
                         'syntax': (tokens[at][0]   < 10 ? '0' : '') + tokens[at][0]   + ':00-'

--- a/test/test.de.log
+++ b/test/test.de.log
@@ -272,6 +272,7 @@ With [34m[1mwarnings[22m[39m:
 "Time ranges spanning midnight" for "22:00-26:00": [32m[1mPASSED[22m[39m
 "Time ranges spanning midnight" for "22-2": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
+	*22-2 <--- (Einstellige Stunde "2" ohne führende Null - könnte 2 Uhr (morgens) oder 14 Uhr (nachmittags) bedeuten. Führende Null ergänzen, z.B. "02", oder auf "14" ändern, um dies eindeutig zu machen.)
 	*22-2 <--- (Zeitspanne ohne Minutenangabe angegeben. Das ist nicht sehr eindeutig! Bitte verwende stattdessen folgende Syntax "22:00-02:00".)
 "Time ranges spanning midnight" for "22:00-26:00": [32m[1mPASSED[22m[39m
 "Time ranges spanning midnight" for "22-26": [32m[1mPASSED[22m[39m
@@ -2074,11 +2075,18 @@ With [34m[1mwarnings[22m[39m:
 "Structured warning: ambiguous single-digit end hour only" for "11:00-6:00": [32m[1mPASSED[22m[39m
 "Structured warning: ambiguous single-digit end hour with leading-zero start" for "09:00-6:00": [32m[1mPASSED[22m[39m
 "Structured warning: no warning for unambiguous single-digit hours" for "Mo 8:00-22:00": [32m[1mPASSED[22m[39m
-"Structured warning: no warning for afternoon single-digit end hour" for "9:00-15:00": [32m[1mPASSED[22m[39m
 "Structured warning: no warning for unambiguous end hour >= 12" for "7:00-13:00": [32m[1mPASSED[22m[39m
+"Structured warning: no ambiguity warning with am/pm" for "6:00am-7:00am": [32m[1mPASSED[22m[39m
+"Structured warning: implicit pm start hour" for "4-10 pm": [32m[1mPASSED[22m[39m
+"Structured warning: implicit pm start hour with minutes" for "4:00-10:00 pm": [32m[1mPASSED[22m[39m
+"Structured warning: no implicit pm warning with explicit am start" for "4 am-10 pm": [32m[1mPASSED[22m[39m
+"Structured warning: implicit pm start hour with corrected separator" for "2 a 6 pm": [32m[1mPASSED[22m[39m
 "Structured warning: ambiguous single-digit end hour with afternoon start" for "12:00-6:00": [32m[1mPASSED[22m[39m
 "Structured warning: ambiguous single-digit end hour with evening start" for "20:00-6:00": [32m[1mPASSED[22m[39m
 "Structured warning: ambiguous single-digit end hour with variable-time start" for "sunrise-9:00": [32m[1mPASSED[22m[39m
+"Structured warning: ambiguous single-digit hours without minutes" for "6-7": [32m[1mPASSED[22m[39m
+"Structured warning: ambiguous single-digit end hour without minutes" for "11-6": [32m[1mPASSED[22m[39m
+"Structured warning: no ambiguity warning for unambiguous hours without minutes" for "6-15": [32m[1mPASSED[22m[39m
 "Structured warning: no warning for variable-time start with unambiguous end hour" for "sunrise-15:00": [32m[1mPASSED[22m[39m
 "Structured warning: no warning for variable-time start with leading-zero end" for "sunrise-09:00": [32m[1mPASSED[22m[39m
 "Structured warning: no warning when leading zeros are used" for "09:00-06:00": [32m[1mPASSED[22m[39m
@@ -2691,7 +2699,7 @@ Der optional_conf_parm["tag_key"] fehlt, ist aber notwendig wegen optional_conf_
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-1044/1044 tests passed. 0 did not pass.
+1051/1051 tests passed. 0 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.en.log
+++ b/test/test.en.log
@@ -272,6 +272,7 @@ With [34m[1mwarnings[22m[39m:
 "Time ranges spanning midnight" for "22:00-26:00": [32m[1mPASSED[22m[39m
 "Time ranges spanning midnight" for "22-2": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
+	*22-2 <--- (Single-digit hour "2" without leading zero - could mean 2 (in the morning) or 14 (after midday). Add a leading zero like "02" or change it to "14" to be explicit.)
 	*22-2 <--- (Time range without minutes specified. Not very explicit! Please use this syntax instead "22:00-02:00".)
 "Time ranges spanning midnight" for "22:00-26:00": [32m[1mPASSED[22m[39m
 "Time ranges spanning midnight" for "22-26": [32m[1mPASSED[22m[39m
@@ -2074,11 +2075,18 @@ With [34m[1mwarnings[22m[39m:
 "Structured warning: ambiguous single-digit end hour only" for "11:00-6:00": [32m[1mPASSED[22m[39m
 "Structured warning: ambiguous single-digit end hour with leading-zero start" for "09:00-6:00": [32m[1mPASSED[22m[39m
 "Structured warning: no warning for unambiguous single-digit hours" for "Mo 8:00-22:00": [32m[1mPASSED[22m[39m
-"Structured warning: no warning for afternoon single-digit end hour" for "9:00-15:00": [32m[1mPASSED[22m[39m
 "Structured warning: no warning for unambiguous end hour >= 12" for "7:00-13:00": [32m[1mPASSED[22m[39m
+"Structured warning: no ambiguity warning with am/pm" for "6:00am-7:00am": [32m[1mPASSED[22m[39m
+"Structured warning: implicit pm start hour" for "4-10 pm": [32m[1mPASSED[22m[39m
+"Structured warning: implicit pm start hour with minutes" for "4:00-10:00 pm": [32m[1mPASSED[22m[39m
+"Structured warning: no implicit pm warning with explicit am start" for "4 am-10 pm": [32m[1mPASSED[22m[39m
+"Structured warning: implicit pm start hour with corrected separator" for "2 a 6 pm": [32m[1mPASSED[22m[39m
 "Structured warning: ambiguous single-digit end hour with afternoon start" for "12:00-6:00": [32m[1mPASSED[22m[39m
 "Structured warning: ambiguous single-digit end hour with evening start" for "20:00-6:00": [32m[1mPASSED[22m[39m
 "Structured warning: ambiguous single-digit end hour with variable-time start" for "sunrise-9:00": [32m[1mPASSED[22m[39m
+"Structured warning: ambiguous single-digit hours without minutes" for "6-7": [32m[1mPASSED[22m[39m
+"Structured warning: ambiguous single-digit end hour without minutes" for "11-6": [32m[1mPASSED[22m[39m
+"Structured warning: no ambiguity warning for unambiguous hours without minutes" for "6-15": [32m[1mPASSED[22m[39m
 "Structured warning: no warning for variable-time start with unambiguous end hour" for "sunrise-15:00": [32m[1mPASSED[22m[39m
 "Structured warning: no warning for variable-time start with leading-zero end" for "sunrise-09:00": [32m[1mPASSED[22m[39m
 "Structured warning: no warning when leading zeros are used" for "09:00-06:00": [32m[1mPASSED[22m[39m
@@ -2681,7 +2689,7 @@ The optional_conf_parm["tag_key"] is missing, required by optional_conf_parm["ma
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-1034/1034 tests passed. 0 did not pass.
+1041/1041 tests passed. 0 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.js
+++ b/test/test.js
@@ -5421,14 +5421,34 @@ test.addStructuredWarnings('Structured warning: no warning for unambiguous singl
     [],
     nominatim_default, 'not only test', { 'tag_key': 'opening_hours' });
 
-test.addStructuredWarnings('Structured warning: no warning for afternoon single-digit end hour',
-    '9:00-15:00',
-    [],
-    nominatim_default, 'not only test', { 'tag_key': 'opening_hours' });
-
 test.addStructuredWarnings('Structured warning: no warning for unambiguous end hour >= 12',
     '7:00-13:00',
     [],
+    nominatim_default, 'not only test', { 'tag_key': 'opening_hours' });
+
+test.addStructuredWarnings('Structured warning: no ambiguity warning with am/pm',
+    '6:00am-7:00am',
+    [ 'word_error_correction', 'word_error_correction' ],
+    nominatim_default, 'not only test', { 'tag_key': 'opening_hours' });
+
+test.addStructuredWarnings('Structured warning: implicit pm start hour',
+    '4-10 pm',
+    [ 'word_error_correction', 'ambiguous_single_digit_hour', 'without_minutes' ],
+    nominatim_default, 'not only test', { 'tag_key': 'opening_hours' });
+
+test.addStructuredWarnings('Structured warning: implicit pm start hour with minutes',
+    '4:00-10:00 pm',
+    [ 'word_error_correction', 'ambiguous_single_digit_hour' ],
+    nominatim_default, 'not only test', { 'tag_key': 'opening_hours' });
+
+test.addStructuredWarnings('Structured warning: no implicit pm warning with explicit am start',
+    '4 am-10 pm',
+    [ 'word_error_correction', 'word_error_correction', 'without_minutes' ],
+    nominatim_default, 'not only test', { 'tag_key': 'opening_hours' });
+
+test.addStructuredWarnings('Structured warning: implicit pm start hour with corrected separator',
+    '2 a 6 pm',
+    [ 'word_error_correction', 'word_error_correction', 'ambiguous_single_digit_hour', 'without_minutes' ],
     nominatim_default, 'not only test', { 'tag_key': 'opening_hours' });
 
 test.addStructuredWarnings('Structured warning: ambiguous single-digit end hour with afternoon start',
@@ -5444,6 +5464,21 @@ test.addStructuredWarnings('Structured warning: ambiguous single-digit end hour 
 test.addStructuredWarnings('Structured warning: ambiguous single-digit end hour with variable-time start',
     'sunrise-9:00',
     [ 'ambiguous_single_digit_hour' ],
+    nominatim_default, 'not only test', { 'tag_key': 'opening_hours' });
+
+test.addStructuredWarnings('Structured warning: ambiguous single-digit hours without minutes',
+    '6-7',
+    [ 'ambiguous_single_digit_hour', 'ambiguous_single_digit_hour', 'without_minutes' ],
+    nominatim_default, 'not only test', { 'tag_key': 'opening_hours' });
+
+test.addStructuredWarnings('Structured warning: ambiguous single-digit end hour without minutes',
+    '11-6',
+    [ 'ambiguous_single_digit_hour', 'without_minutes' ],
+    nominatim_default, 'not only test', { 'tag_key': 'opening_hours' });
+
+test.addStructuredWarnings('Structured warning: no ambiguity warning for unambiguous hours without minutes',
+    '6-15',
+    [ 'without_minutes' ],
     nominatim_default, 'not only test', { 'tag_key': 'opening_hours' });
 
 test.addStructuredWarnings('Structured warning: no warning for variable-time start with unambiguous end hour',


### PR DESCRIPTION
In two follow-up comments on [issue #581](https://github.com/opening-hours/opening_hours.js/issues/581), @confusedbuffalo reported additional cases where ambiguous single-digit hours were not detected: ranges without minutes such as `6-7`, and ranges where only the end hour specifies PM, such as `4-10 pm` or `2 a 6 pm`.

To solve this, I extracted the warning logic into `warnAmbiguousSingleDigitHours()` and call it from the relevant time-range parsing paths. It now covers these cases while respecting explicit AM/PM notation.