### PR TITLE
feat: locale-aware day/month order in prettifyValue output

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,6 +57,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
     };
     const months   = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
     const weekdays = ['Su','Mo','Tu','We','Th','Fr','Sa'];
+    const INTL_DAY_MONTH_REF_DATE = new Date(2024, 2, 6); // fixed reference date for Intl.DateTimeFormat#formatToParts
     const string_to_token_map = {
         'su': [ 0, 'weekday' ],
         'mo': [ 1, 'weekday' ],
@@ -1480,6 +1481,26 @@ export default function(value, nominatim_object, optional_conf_parm) {
                 user_conf[key] = default_prettify_conf[key];
             }
         });
+
+        // Locale-aware day/month order and separator for month-day pairs.
+        // Uses Intl.DateTimeFormat#formatToParts to derive both the order (e.g. "6 mars" vs "March 6")
+        // and the literal separator (e.g. ". " for de, " de " for long es).
+        // Skipped for 'en' (always month-first) and 'all' ('all' is not a valid BCP 47 tag).
+        const _is_en_or_all = user_conf['locale'] === 'en' || user_conf['locale'] === 'all';
+        let day_before_month = false;
+        let day_month_sep = ' ';
+        if (!_is_en_or_all) {
+            const dmParts = new Intl.DateTimeFormat(user_conf['locale'], { day: 'numeric', month: user_conf['date_format'] })
+                .formatToParts(INTL_DAY_MONTH_REF_DATE);
+            const dayIdx   = dmParts.findIndex(p => p.type === 'day');
+            const monthIdx = dmParts.findIndex(p => p.type === 'month');
+            day_before_month = dayIdx < monthIdx;
+            day_month_sep = dmParts
+                .slice(Math.min(dayIdx, monthIdx) + 1, Math.max(dayIdx, monthIdx))
+                .map(p => p.value).join('');
+        }
+        user_conf['day_before_month'] = day_before_month;
+        user_conf['day_month_sep']    = day_month_sep;
 
         for (let nrule = 0; nrule < new_tokens.length; nrule++) {
             if (new_tokens[nrule][0].length === 0) continue;
@@ -4434,9 +4455,14 @@ export default function(value, nominatim_object, optional_conf_parm) {
                     && matchTokens(tokens, at-1, 'year')) {
                 prettified_value += ' ' + tokens[at][0];
             } else if (matchTokens(tokens, at, 'month')) {
-                prettified_value += translatePrettyToken(token_value, 'month', conf);
-                if (at + 1 <= selector_end && matchTokens(tokens, at+1, 'weekday'))
-                    prettified_value += ' ';
+                if (conf.day_before_month && at + 1 <= selector_end && matchTokens(tokens, at+1, 'number')) {
+                    prettified_value += tokens[at+1][0] + conf.day_month_sep + translatePrettyToken(token_value, 'month', conf);
+                    at++;
+                } else {
+                    prettified_value += translatePrettyToken(token_value, 'month', conf);
+                    if (at + 1 <= selector_end && matchTokens(tokens, at+1, 'weekday'))
+                        prettified_value += ' ';
+                }
             } else if (at + 2 <= selector_end
                     && (matchTokens(tokens, at, '-') || matchTokens(tokens, at, '+'))
                     && matchTokens(tokens, at+1, 'number', 'calcday')) {

--- a/test/test.de.log
+++ b/test/test.de.log
@@ -2681,6 +2681,8 @@ Der optional_conf_parm["tag_key"] fehlt, ist aber notwendig wegen optional_conf_
 "Regression: prettifyValue should keep bare time ranges unchanged (#596)" for "Su 8-8, Mo Closed, Tu-Th 12-8, F-Sa 12-9": [32m[1mPASSED[22m[39m
 "Regression: prettifyValue should not reorder comments across state (#596)" for "Mo-Fr 11:00-14:00 "Mittagessen" open": [32m[1mPASSED[22m[39m
 "Regression: prettifyValue should preserve malformed time selectors (#596)" for "Tu-We 09:00-12:30,14:00-18:00; Th 09:00-12:30,:15:00-18:00, Fr 09:00-12:30, 14:00-18:00; Sa 09:00-12:30,13:30-16:30": [32m[1mPASSED[22m[39m
+"locale-aware day/month order (de)" for "Jan 06-Jul 15": [32m[1mPASSED[22m[39m
+"locale-aware day/month order: month range without day unaffected (de)" for "Jan-Jul": [32m[1mPASSED[22m[39m
 "Test isEqualTo function: Full range" for "open": [32m[1mPASSED[22m[39m
 "Test isEqualTo function: Full range" for "24/7": [32m[1mPASSED[22m[39m
 "Test isEqualTo function: Full range" for "2000-2100": [32m[1mPASSED[22m[39m
@@ -2699,7 +2701,7 @@ Der optional_conf_parm["tag_key"] fehlt, ist aber notwendig wegen optional_conf_
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-1051/1051 tests passed. 0 did not pass.
+1053/1053 tests passed. 0 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.js
+++ b/test/test.js
@@ -5933,6 +5933,18 @@ test.addPrettifyValue('Regression: prettifyValue should preserve malformed time 
         'Tu-We 09:00-12:30,14:00-18:00; Th 09:00-12:30,:15:00-18:00, Fr 09:00-12:30, 14:00-18:00; Sa 09:00-12:30,13:30-16:30',
     ], 'all', 'Tu-We 09:00-12:30,14:00-18:00; Th 09:00-12:30, :15:00-18:00, Fr 09:00-12:30,14:00-18:00; Sa 09:00-12:30,13:30-16:30');
 
+// locale-aware day/month order (issue #587)
+// fr: space separator, no zero-padding when day is before month
+test.addPrettifyValue('locale-aware day/month order (fr)', ['Mar 06-Jul 15'], 'fr', '6 mars-15 juil.', 'not only test');
+test.addPrettifyValue('locale-aware day/month order: month range without day unaffected (fr)', ['Mar-Jul'], 'fr', 'mars-juil.', 'not only test');
+test.addPrettifyValue('locale-aware day/month order: year+month+day unaffected (fr)', ['2024 Mar 06'], 'fr', '2024 mars 06', 'not only test');
+test.addPrettifyValue('locale-aware day/month order: week unaffected (fr)', ['week 01-05/2'], 'fr', 'week 01-05/2', 'not only test');
+// de: ". " separator, no zero-padding when day is before month
+test.addPrettifyValue('locale-aware day/month order (de)', ['Jan 06-Jul 15'], 'de', '6. Jan-15. Jul', 'not only test');
+test.addPrettifyValue('locale-aware day/month order: month range without day unaffected (de)', ['Jan-Jul'], 'de', 'Jan-Jul', 'not only test');
+// es: space separator (short)
+test.addPrettifyValue('locale-aware day/month order (es)', ['Jan 06-Jul 15'], 'es', '6 ene-15 jul', 'not only test');
+
 /* }}} */
 
 /* isEqualTo {{{ */


### PR DESCRIPTION
Fixes #587.

`prettifyValue()` always outputs month-day pairs in `<month> <day>` order regardless of locale. In French (and German, Spanish, Italian, Dutch…) the natural order is day first, with a locale-specific separator.

The fix uses `Intl.DateTimeFormat#formatToParts` to extract two things per locale: whether the day comes before the month, and the literal separator (`". "` in German, `" de "` in long Spanish, `" "` in French). Both are stored in `conf` and passed to `prettifySelector`, which reorders via a lookahead on `month` tokens. When the day is printed before the month it is never zero-padded. Week selectors and year-month pairs are untouched.

```
fr  Mar 06-Jul 15   →  6 mars-15 juil.
de  Jan 06-Jul 15   →  6. Jan-15. Jul
es  Jan 06-Jul 15   →  6 ene-15 jul
en  Jan 06-Jul 15   →  Jan 06-Jul 15  (unchanged)
```

`en` and `all` skip the `Intl` call entirely — `en` is always month-first, and `all` is not a valid BCP 47 locale tag. Existing `en` and `de` reference logs are unchanged.