### PR TITLE
ci: require Node >=22 for development

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,11 @@
     "node": ">=14"
   },
   "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": ">=22",
+      "onFail": "error"
+    },
     "packageManager": {
       "name": "npm",
       "version": ">=11",


### PR DESCRIPTION
This fixes  #648.