### PR TITLE
fix(locale): force Gregorian date formatting

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1490,7 +1490,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
         let day_before_month = false;
         let day_month_sep = ' ';
         if (!_is_en_or_all) {
-            const dmParts = new Intl.DateTimeFormat(user_conf['locale'], { day: 'numeric', month: user_conf['date_format'] })
+            const dmParts = new Intl.DateTimeFormat(user_conf['locale'], { day: 'numeric', month: user_conf['date_format'], calendar: 'gregory' })
                 .formatToParts(INTL_DAY_MONTH_REF_DATE);
             const dayIdx   = dmParts.findIndex(p => p.type === 'day');
             const monthIdx = dmParts.findIndex(p => p.type === 'month');
@@ -4341,11 +4341,11 @@ export default function(value, nominatim_object, optional_conf_parm) {
             localized_name_cache[cache_key] = kind === 'weekday'
                 // 2026-02-01 is a Sunday, so day 1..7 maps to Su..Sa.
                 ? [1, 2, 3, 4, 5, 6, 7].map(function (weekday) {
-                    return new Date(2026, 1, weekday).toLocaleString(conf['locale'], {weekday: conf['date_format']});
+                    return new Date(2026, 1, weekday).toLocaleString(conf['locale'], {weekday: conf['date_format'], calendar: 'gregory'});
                 })
                 // The year is arbitrary; only the month index affects the name.
                 : [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].map(function (month) {
-                    return new Date(2026, month - 1, 1).toLocaleString(conf['locale'], {month: conf['date_format']});
+                    return new Date(2026, month - 1, 1).toLocaleString(conf['locale'], {month: conf['date_format'], calendar: 'gregory'});
                 });
         }
         return localized_name_cache[cache_key];

--- a/test/test.de.log
+++ b/test/test.de.log
@@ -2681,8 +2681,14 @@ Der optional_conf_parm["tag_key"] fehlt, ist aber notwendig wegen optional_conf_
 "Regression: prettifyValue should keep bare time ranges unchanged (#596)" for "Su 8-8, Mo Closed, Tu-Th 12-8, F-Sa 12-9": [32m[1mPASSED[22m[39m
 "Regression: prettifyValue should not reorder comments across state (#596)" for "Mo-Fr 11:00-14:00 "Mittagessen" open": [32m[1mPASSED[22m[39m
 "Regression: prettifyValue should preserve malformed time selectors (#596)" for "Tu-We 09:00-12:30,14:00-18:00; Th 09:00-12:30,:15:00-18:00, Fr 09:00-12:30, 14:00-18:00; Sa 09:00-12:30,13:30-16:30": [32m[1mPASSED[22m[39m
+"locale-aware day/month order (fr)" for "Mar 06-Jul 15": [32m[1mPASSED[22m[39m
+"locale-aware day/month order: month range without day unaffected (fr)" for "Mar-Jul": [32m[1mPASSED[22m[39m
+"locale-aware day/month order: year+month+day unaffected (fr)" for "2024 Mar 06": [32m[1mPASSED[22m[39m
+"locale-aware day/month order: week unaffected (fr)" for "week 01-05/2": [32m[1mPASSED[22m[39m
 "locale-aware day/month order (de)" for "Jan 06-Jul 15": [32m[1mPASSED[22m[39m
 "locale-aware day/month order: month range without day unaffected (de)" for "Jan-Jul": [32m[1mPASSED[22m[39m
+"locale-aware day/month order (es)" for "Jan 06-Jul 15": [32m[1mPASSED[22m[39m
+"locale-aware day/month order: Gregorian calendar" for "Mar 06-Jul 15": [32m[1mPASSED[22m[39m
 "Test isEqualTo function: Full range" for "open": [32m[1mPASSED[22m[39m
 "Test isEqualTo function: Full range" for "24/7": [32m[1mPASSED[22m[39m
 "Test isEqualTo function: Full range" for "2000-2100": [32m[1mPASSED[22m[39m
@@ -2701,7 +2707,7 @@ Der optional_conf_parm["tag_key"] fehlt, ist aber notwendig wegen optional_conf_
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-1053/1053 tests passed. 0 did not pass.
+1059/1059 tests passed. 0 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.en.log
+++ b/test/test.en.log
@@ -2671,6 +2671,14 @@ The optional_conf_parm["tag_key"] is missing, required by optional_conf_parm["ma
 "Regression: prettifyValue should keep bare time ranges unchanged (#596)" for "Su 8-8, Mo Closed, Tu-Th 12-8, F-Sa 12-9": [32m[1mPASSED[22m[39m
 "Regression: prettifyValue should not reorder comments across state (#596)" for "Mo-Fr 11:00-14:00 "Mittagessen" open": [32m[1mPASSED[22m[39m
 "Regression: prettifyValue should preserve malformed time selectors (#596)" for "Tu-We 09:00-12:30,14:00-18:00; Th 09:00-12:30,:15:00-18:00, Fr 09:00-12:30, 14:00-18:00; Sa 09:00-12:30,13:30-16:30": [32m[1mPASSED[22m[39m
+"locale-aware day/month order (fr)" for "Mar 06-Jul 15": [32m[1mPASSED[22m[39m
+"locale-aware day/month order: month range without day unaffected (fr)" for "Mar-Jul": [32m[1mPASSED[22m[39m
+"locale-aware day/month order: year+month+day unaffected (fr)" for "2024 Mar 06": [32m[1mPASSED[22m[39m
+"locale-aware day/month order: week unaffected (fr)" for "week 01-05/2": [32m[1mPASSED[22m[39m
+"locale-aware day/month order (de)" for "Jan 06-Jul 15": [32m[1mPASSED[22m[39m
+"locale-aware day/month order: month range without day unaffected (de)" for "Jan-Jul": [32m[1mPASSED[22m[39m
+"locale-aware day/month order (es)" for "Jan 06-Jul 15": [32m[1mPASSED[22m[39m
+"locale-aware day/month order: Gregorian calendar" for "Mar 06-Jul 15": [32m[1mPASSED[22m[39m
 "Test isEqualTo function: Full range" for "open": [32m[1mPASSED[22m[39m
 "Test isEqualTo function: Full range" for "24/7": [32m[1mPASSED[22m[39m
 "Test isEqualTo function: Full range" for "2000-2100": [32m[1mPASSED[22m[39m
@@ -2689,7 +2697,7 @@ The optional_conf_parm["tag_key"] is missing, required by optional_conf_parm["ma
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-1041/1041 tests passed. 0 did not pass.
+1049/1049 tests passed. 0 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.js
+++ b/test/test.js
@@ -5935,15 +5935,17 @@ test.addPrettifyValue('Regression: prettifyValue should preserve malformed time 
 
 // locale-aware day/month order (issue #587)
 // fr: space separator, no zero-padding when day is before month
-test.addPrettifyValue('locale-aware day/month order (fr)', ['Mar 06-Jul 15'], 'fr', '6 mars-15 juil.', 'not only test');
-test.addPrettifyValue('locale-aware day/month order: month range without day unaffected (fr)', ['Mar-Jul'], 'fr', 'mars-juil.', 'not only test');
-test.addPrettifyValue('locale-aware day/month order: year+month+day unaffected (fr)', ['2024 Mar 06'], 'fr', '2024 mars 06', 'not only test');
-test.addPrettifyValue('locale-aware day/month order: week unaffected (fr)', ['week 01-05/2'], 'fr', 'week 01-05/2', 'not only test');
+test.addPrettifyValueForLocale('locale-aware day/month order (fr)', ['Mar 06-Jul 15'], 'fr', '6 mars-15 juil.');
+test.addPrettifyValueForLocale('locale-aware day/month order: month range without day unaffected (fr)', ['Mar-Jul'], 'fr', 'mars-juil.');
+test.addPrettifyValueForLocale('locale-aware day/month order: year+month+day unaffected (fr)', ['2024 Mar 06'], 'fr', '2024 mars 06');
+test.addPrettifyValueForLocale('locale-aware day/month order: week unaffected (fr)', ['week 01-05/2'], 'fr', 'week 01-05/2');
 // de: ". " separator, no zero-padding when day is before month
-test.addPrettifyValue('locale-aware day/month order (de)', ['Jan 06-Jul 15'], 'de', '6. Jan-15. Jul', 'not only test');
-test.addPrettifyValue('locale-aware day/month order: month range without day unaffected (de)', ['Jan-Jul'], 'de', 'Jan-Jul', 'not only test');
+test.addPrettifyValueForLocale('locale-aware day/month order (de)', ['Jan 06-Jul 15'], 'de', '6. Jan-15. Jul');
+test.addPrettifyValueForLocale('locale-aware day/month order: month range without day unaffected (de)', ['Jan-Jul'], 'de', 'Jan-Jul');
 // es: space separator (short)
-test.addPrettifyValue('locale-aware day/month order (es)', ['Jan 06-Jul 15'], 'es', '6 ene-15 jul', 'not only test');
+test.addPrettifyValueForLocale('locale-aware day/month order (es)', ['Jan 06-Jul 15'], 'es', '6 ene-15 jul');
+// fa: Gregorian calendar, despite the locale's default Persian calendar
+test.addPrettifyValueForLocale('locale-aware day/month order: Gregorian calendar', ['Mar 06-Jul 15'], 'fa', '6 مارس-15 ژوئیه');
 
 /* }}} */
 
@@ -6736,6 +6738,17 @@ function opening_hours_test() {
     // }}}
 
     // add test to check if prettifyValue feature works {{{
+    this.addPrettifyValueForLocale = function(name, values, prettify_locale, expected_prettified_value, last) {
+        this.handle_only_test(last);
+
+        if (typeof values === 'string') {
+            this.tests_prettify_value.push([name, values, prettify_locale, expected_prettified_value]);
+        } else {
+            for (let value_ind = 0; value_ind < values.length; value_ind++)
+                this.tests_prettify_value.push([name, values[value_ind], prettify_locale, expected_prettified_value]);
+        }
+    };
+
     this.addPrettifyValue = function(name, values, only_test_for_locale, expected_prettified_value, last) {
         if (this.last === true)  {
             return;
@@ -6745,14 +6758,8 @@ function opening_hours_test() {
         if (
                 typeof only_test_for_locale === 'string'
                 && (argv.locale === only_test_for_locale || only_test_for_locale === 'all')
-           ) {
-
-            if (typeof values === 'string') {
-                this.tests_prettify_value.push([name, values, only_test_for_locale, expected_prettified_value]);
-            } else {
-                for (let value_ind = 0; value_ind < values.length; value_ind++)
-                    this.tests_prettify_value.push([name, values[value_ind], only_test_for_locale, expected_prettified_value]);
-            }
+            ) {
+            this.addPrettifyValueForLocale(name, values, only_test_for_locale, expected_prettified_value);
         }
     };
     // }}}


### PR DESCRIPTION
While working on PR #649, I noticed that `prettifyValue()` could format Gregorian dates using a locale's default calendar. For example, Farsi could format `Mar 06-Jul 15` as `6 اسفند (Esfand)-15 تیر (Tir)` instead of `6 مارس (March)-15 ژوئیه (July)`. `Esfand` and `Tir` are months in the Persian calendar, not the Gregorian months March and July, so this mixed up two calendar systems.

The output now explicitly uses the Gregorian calendar while preserving localized names and formatting. The tests also introduce `addPrettifyValueForLocale`, so locale-specific regression tests always run independently of the selected test locale.