### PR TITLE
refactor(prettify): simplify locale-aware date formatting

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1454,6 +1454,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
      * :returns: Prettified value string or object if get_internals is true.
      */
     function prettifyValue(argument_hash) {
+        /** @type {{ [key: string]: string | boolean }} */
         let user_conf = {};
         let get_internals = false;
         let rule_index;
@@ -1486,18 +1487,27 @@ export default function(value, nominatim_object, optional_conf_parm) {
         // Uses Intl.DateTimeFormat#formatToParts to derive both the order (e.g. "6 mars" vs "March 6")
         // and the literal separator (e.g. ". " for de, " de " for long es).
         // Skipped for 'en' (always month-first) and 'all' ('all' is not a valid BCP 47 tag).
-        const _is_en_or_all = user_conf['locale'] === 'en' || user_conf['locale'] === 'all';
         let day_before_month = false;
         let day_month_sep = ' ';
-        if (!_is_en_or_all) {
-            const dmParts = new Intl.DateTimeFormat(user_conf['locale'], { day: 'numeric', month: user_conf['date_format'], calendar: 'gregory' })
-                .formatToParts(INTL_DAY_MONTH_REF_DATE);
-            const dayIdx   = dmParts.findIndex(p => p.type === 'day');
-            const monthIdx = dmParts.findIndex(p => p.type === 'month');
-            day_before_month = dayIdx < monthIdx;
-            day_month_sep = dmParts
-                .slice(Math.min(dayIdx, monthIdx) + 1, Math.max(dayIdx, monthIdx))
-                .map(p => p.value).join('');
+        const locale = /** @type {string} */ (user_conf['locale']);
+        const date_format = /** @type {'short' | 'long'} */ (user_conf['date_format']);
+        const uses_locale_aware_order = locale !== 'en' && locale !== 'all';
+        if (uses_locale_aware_order) {
+            try {
+                const dmParts = new Intl.DateTimeFormat(locale, {
+                    day: 'numeric',
+                    month: date_format,
+                    calendar: 'gregory',
+                }).formatToParts(INTL_DAY_MONTH_REF_DATE);
+                const dayIdx = dmParts.findIndex(part => part.type === 'day');
+                const monthIdx = dmParts.findIndex(part => part.type === 'month');
+                if (dayIdx !== -1 && monthIdx !== -1) {
+                    day_before_month = dayIdx < monthIdx;
+                    day_month_sep = dmParts
+                        .slice(Math.min(dayIdx, monthIdx) + 1, Math.max(dayIdx, monthIdx))
+                        .map(part => part.value).join('');
+                }
+            } catch { /* Keep fallback order if locale is unsupported in runtime. */ }
         }
         user_conf['day_before_month'] = day_before_month;
         user_conf['day_month_sep']    = day_month_sep;
@@ -4455,14 +4465,19 @@ export default function(value, nominatim_object, optional_conf_parm) {
                     && matchTokens(tokens, at-1, 'year')) {
                 prettified_value += ' ' + tokens[at][0];
             } else if (matchTokens(tokens, at, 'month')) {
-                if (conf.day_before_month && at + 1 <= selector_end && matchTokens(tokens, at+1, 'number')) {
-                    prettified_value += tokens[at+1][0] + conf.day_month_sep + translatePrettyToken(token_value, 'month', conf);
+                const month_pretty = translatePrettyToken(token_value, 'month', conf);
+                if (conf.day_before_month
+                        && at + 1 <= selector_end
+                        && matchTokens(tokens, at+1, 'number')) {
+                    // Consume the day together with the month when the locale puts it first.
+                    prettified_value += tokens[at+1][0] + conf.day_month_sep + month_pretty;
                     at++;
                 } else {
-                    prettified_value += translatePrettyToken(token_value, 'month', conf);
-                    if (at + 1 <= selector_end && matchTokens(tokens, at+1, 'weekday'))
-                        prettified_value += ' ';
+                    prettified_value += month_pretty;
                 }
+                // Keep the separator before a following weekday in both output orders.
+                if (at + 1 <= selector_end && matchTokens(tokens, at+1, 'weekday'))
+                    prettified_value += ' ';
             } else if (at + 2 <= selector_end
                     && (matchTokens(tokens, at, '-') || matchTokens(tokens, at, '+'))
                     && matchTokens(tokens, at+1, 'number', 'calcday')) {

--- a/test/test.de.log
+++ b/test/test.de.log
@@ -2689,6 +2689,7 @@ Der optional_conf_parm["tag_key"] fehlt, ist aber notwendig wegen optional_conf_
 "locale-aware day/month order: month range without day unaffected (de)" for "Jan-Jul": [32m[1mPASSED[22m[39m
 "locale-aware day/month order (es)" for "Jan 06-Jul 15": [32m[1mPASSED[22m[39m
 "locale-aware day/month order: Gregorian calendar" for "Mar 06-Jul 15": [32m[1mPASSED[22m[39m
+"locale-aware day/month order (all)" for "Jan 06-Jul 15": [32m[1mPASSED[22m[39m
 "Test isEqualTo function: Full range" for "open": [32m[1mPASSED[22m[39m
 "Test isEqualTo function: Full range" for "24/7": [32m[1mPASSED[22m[39m
 "Test isEqualTo function: Full range" for "2000-2100": [32m[1mPASSED[22m[39m
@@ -2707,7 +2708,7 @@ Der optional_conf_parm["tag_key"] fehlt, ist aber notwendig wegen optional_conf_
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-1059/1059 tests passed. 0 did not pass.
+1060/1060 tests passed. 0 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.en.log
+++ b/test/test.en.log
@@ -2679,6 +2679,7 @@ The optional_conf_parm["tag_key"] is missing, required by optional_conf_parm["ma
 "locale-aware day/month order: month range without day unaffected (de)" for "Jan-Jul": [32m[1mPASSED[22m[39m
 "locale-aware day/month order (es)" for "Jan 06-Jul 15": [32m[1mPASSED[22m[39m
 "locale-aware day/month order: Gregorian calendar" for "Mar 06-Jul 15": [32m[1mPASSED[22m[39m
+"locale-aware day/month order (all)" for "Jan 06-Jul 15": [32m[1mPASSED[22m[39m
 "Test isEqualTo function: Full range" for "open": [32m[1mPASSED[22m[39m
 "Test isEqualTo function: Full range" for "24/7": [32m[1mPASSED[22m[39m
 "Test isEqualTo function: Full range" for "2000-2100": [32m[1mPASSED[22m[39m
@@ -2697,7 +2698,7 @@ The optional_conf_parm["tag_key"] is missing, required by optional_conf_parm["ma
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-1049/1049 tests passed. 0 did not pass.
+1050/1050 tests passed. 0 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.js
+++ b/test/test.js
@@ -5946,6 +5946,8 @@ test.addPrettifyValueForLocale('locale-aware day/month order: month range withou
 test.addPrettifyValueForLocale('locale-aware day/month order (es)', ['Jan 06-Jul 15'], 'es', '6 ene-15 jul');
 // fa: Gregorian calendar, despite the locale's default Persian calendar
 test.addPrettifyValueForLocale('locale-aware day/month order: Gregorian calendar', ['Mar 06-Jul 15'], 'fa', '6 مارس-15 ژوئیه');
+// all: deterministic month-first order regardless of the runtime locale
+test.addPrettifyValueForLocale('locale-aware day/month order (all)', ['Jan 06-Jul 15'], 'all', 'Jan 06-Jul 15');
 
 /* }}} */
 


### PR DESCRIPTION
This is mostly a cleanup of the locale-aware date formatting code.

The ordering and separator logic is easier to follow now, and the fallback handling around Intl date parts is more robust when locale data is unavailable or incomplete. I also cleaned up and narrowed the types in the touched area, resolving the related type-checking diagnostics.