### PR TITLE
feat(parser): warn on past date ranges and explicit dates

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4029,13 +4029,15 @@ export default function(value, nominatim_object, optional_conf_parm) {
                     checkIfDateIsValid(month, range_to - 1 /* added previously */,
                         nrule, at_range_to);
 
-                    // An explicit range that already fully elapsed.
-                    if (has_year && is_range && new Date(year, month, range_to) < new Date()) {
+                    // An explicit date or range that already fully elapsed.
+                    if (has_year && new Date(year, month, range_to) < new Date()) {
+                        const warning_type = is_range ? 'date_range_past' : 'date_past';
+                        const warning_message = is_range ? t('date range past') : t('date past');
                         parsing_warnings.push([
                             nrule,
                             at_range_to,
-                            'date_range_past',
-                            t('date range past')
+                            warning_type,
+                            warning_message
                         ]);
                     }
                     /* }}} */

--- a/src/index.js
+++ b/src/index.js
@@ -3961,6 +3961,18 @@ export default function(value, nominatim_object, optional_conf_parm) {
                     }
                 }}(tokens, at, nrule, has_year, has_event, has_calc, at_sec_event_or_month, has_constrained_weekday);
 
+                // An explicit-year range that has already ended is permanently inactive.
+                const [, next_change] = selector(new Date());
+                const is_past_explicit_range = has_year[0] && typeof next_change === 'undefined';
+                if (is_past_explicit_range) {
+                    parsing_warnings.push([
+                        nrule,
+                        has_year[1] ? at_sec_event_or_month - 1 : at,
+                        'date_range_past',
+                        t('date range past')
+                    ]);
+                }
+
                 if (push_to_month === true)
                     rule.month.push(selector);
                 else
@@ -3986,7 +3998,8 @@ export default function(value, nominatim_object, optional_conf_parm) {
                     const range_from = tokens[at+1 + has_year][0];
                     is_range = matchTokens(tokens, at+2+has_year, '-', 'number');
                     let period = undefined;
-                    const range_to = tokens[at+has_year+(is_range ? 3 : 1)][0] + 1;
+                    const at_range_to = at+has_year+(is_range ? 3 : 1); // position of the range_to token
+                    const range_to = tokens[at_range_to][0] + 1;
                     if (is_range && matchTokens(tokens, at+has_year+4, '/', 'number')) {
                         period = tokens[at+has_year+5][0];
                         tokens[at+has_year+5][4] = 'positive_number';
@@ -4014,7 +4027,17 @@ export default function(value, nominatim_object, optional_conf_parm) {
 
                     checkIfDateIsValid(month, range_from, nrule, at+1 + has_year);
                     checkIfDateIsValid(month, range_to - 1 /* added previously */,
-                        nrule, at+has_year+(is_range ? 3 : 1));
+                        nrule, at_range_to);
+
+                    // An explicit range that already fully elapsed.
+                    if (has_year && is_range && new Date(year, month, range_to) < new Date()) {
+                        parsing_warnings.push([
+                            nrule,
+                            at_range_to,
+                            'date_range_past',
+                            t('date range past')
+                        ]);
+                    }
                     /* }}} */
 
                     const selector = function(year, has_year, month, range_from, range_to, period) { return function(date) {

--- a/src/locales/translations.yaml
+++ b/src/locales/translations.yaml
@@ -103,6 +103,7 @@ en:
     'year range one year': 'A year range in which the start year is equal to the end year does not make sense. Please remove the end year. E.g. "{{year}} May 23"'
     'year range reverse': 'A year range in which the start year is greater than the end year does not make sense. Please turn it over.'
     'year past': 'The year is in the past.'
+    'date range past': 'This date range is entirely in the past.'
     'unexpected token year range': 'Unexpected token in year range: {{token}}'
     'week range reverse': 'You have specified a week range in reverse order or leaping over a year. This is (currently) not supported.'
     'week negative': 'You have specified a week date less then one. A valid week date range is 1-53.'
@@ -250,6 +251,7 @@ de:
     year range one year: "Eine Jahres-Spanne mit gleichem Jahr als Beginn und Ende ergibt keinen Sinn. Bitte entferne das Ende-Jahr. zum Beispiel: \"{{year}} May 23\""
     year range reverse: "Eine Jahres-Spanne mit Beginn größer als Ende ergibt keinen Sinn. Bitte umdrehen."
     year past: "Das Jahr liegt in der Vergangenheit."
+    date range past: "Dieser Datumsbereich liegt vollständig in der Vergangenheit."
     unexpected token year range: "Unerwartetes Token in der Jahres-Spanne: {{token}}"
     week range reverse: "Du hast eine Wochen-Spanne in umgekehrter Reihenfolge oder mehrere Jahre umfassende angegeben. Dies ist aktuell nicht unterstützt."
     week negative: "Du hast eine Kalenderwoche kleiner 1 angegeben. Korrekte Angaben sind 1-53."
@@ -417,6 +419,7 @@ fr:
     year range one year: "Une plage d'années avec la même année comme début et fin n'a pas de sens. Veuillez supprimer l'année de fin. Par exemple : \"{{year}} May 23\"."
     year range reverse: "Une plage d'années avec un début supérieur à la fin n'a pas de sens. Veuillez inverser."
     year past: "L'année est dans le passé."
+    date range past: "Cette plage de dates est entièrement dans le passé."
     unexpected token year range: "Token inattendu dans la plage d'années : {{token}}"
     week range reverse: "Vous avez spécifié une plage de semaines en ordre inverse ou couvrant plusieurs années. Ceci n'est actuellement pas pris en charge."
     week negative: "Vous avez spécifié un numéro de semaine inférieur à 1. Les valeurs valides sont 1-53."

--- a/src/locales/translations.yaml
+++ b/src/locales/translations.yaml
@@ -103,6 +103,7 @@ en:
     'year range one year': 'A year range in which the start year is equal to the end year does not make sense. Please remove the end year. E.g. "{{year}} May 23"'
     'year range reverse': 'A year range in which the start year is greater than the end year does not make sense. Please turn it over.'
     'year past': 'The year is in the past.'
+    'date past': 'This date is in the past.'
     'date range past': 'This date range is entirely in the past.'
     'unexpected token year range': 'Unexpected token in year range: {{token}}'
     'week range reverse': 'You have specified a week range in reverse order or leaping over a year. This is (currently) not supported.'
@@ -251,6 +252,7 @@ de:
     year range one year: "Eine Jahres-Spanne mit gleichem Jahr als Beginn und Ende ergibt keinen Sinn. Bitte entferne das Ende-Jahr. zum Beispiel: \"{{year}} May 23\""
     year range reverse: "Eine Jahres-Spanne mit Beginn größer als Ende ergibt keinen Sinn. Bitte umdrehen."
     year past: "Das Jahr liegt in der Vergangenheit."
+    date past: "Dieses Datum liegt in der Vergangenheit."
     date range past: "Dieser Datumsbereich liegt vollständig in der Vergangenheit."
     unexpected token year range: "Unerwartetes Token in der Jahres-Spanne: {{token}}"
     week range reverse: "Du hast eine Wochen-Spanne in umgekehrter Reihenfolge oder mehrere Jahre umfassende angegeben. Dies ist aktuell nicht unterstützt."
@@ -419,6 +421,7 @@ fr:
     year range one year: "Une plage d'années avec la même année comme début et fin n'a pas de sens. Veuillez supprimer l'année de fin. Par exemple : \"{{year}} May 23\"."
     year range reverse: "Une plage d'années avec un début supérieur à la fin n'a pas de sens. Veuillez inverser."
     year past: "L'année est dans le passé."
+    date past: "Cette date est dans le passé."
     date range past: "Cette plage de dates est entièrement dans le passé."
     unexpected token year range: "Token inattendu dans la plage d'années : {{token}}"
     week range reverse: "Vous avez spécifié une plage de semaines en ordre inverse ou couvrant plusieurs années. Ceci n'est actuellement pas pris en charge."

--- a/test/test.de.log
+++ b/test/test.de.log
@@ -1108,6 +1108,7 @@ With [34m[1mwarnings[22m[39m:
 	*Jan 01,Dec 24,25; Nov Th[4] <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
 "Month ranges" for "2012 Jan 01,2012 Dec 24-25; 2012 Nov Th[4]": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
+	*2012 Jan 01 <--- (Dieses Datum liegt in der Vergangenheit.)
 	*2012 Jan 01,2012 Dec 24-25 <--- (Dieser Datumsbereich liegt vollständig in der Vergangenheit.)
 	*2012 Jan 01,2012 Dec 24-25; 2012  <--- (Das Jahr liegt in der Vergangenheit.)
 	*2012 Jan 01,2012 Dec 24-25 <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
@@ -1149,9 +1150,13 @@ With [34m[1mwarnings[22m[39m:
 	*Dec 31-Jan 01 <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
 "Full day (with year)" for "2013 Dec 31,2014 Jan 05": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
+	*2013 Dec 31 <--- (Dieses Datum liegt in der Vergangenheit.)
+	*2013 Dec 31,2014 Jan 05 <--- (Dieses Datum liegt in der Vergangenheit.)
 	*2013 Dec 31,2014 Jan 05 <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
 "Full day (with year)" for "2013 Dec 31; 2014 Jan 05": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
+	*2013 Dec 31 <--- (Dieses Datum liegt in der Vergangenheit.)
+	*2013 Dec 31; 2014 Jan 05 <--- (Dieses Datum liegt in der Vergangenheit.)
 	*2013 Dec 31 <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
 	*2013 Dec 31; 2014 Jan 05 <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
 "Full day (with year)" for "2013/10 Dec 31; 2014/10 Jan 05": [32m[1mPASSED[22m[39m
@@ -1162,9 +1167,12 @@ With [34m[1mwarnings[22m[39m:
 	*2013/10 Dec 31; 2014/10 Jan 05 <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
 "Date range which only applies for one year" for "2013 Dec 31": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
+	*2013 Dec 31 <--- (Dieses Datum liegt in der Vergangenheit.)
 	*2013 Dec 31 <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
 "Date range which only applies for one year" for "2013 Dec 31; 2014 Jan 05; 2014+ off": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
+	*2013 Dec 31 <--- (Dieses Datum liegt in der Vergangenheit.)
+	*2013 Dec 31; 2014 Jan 05 <--- (Dieses Datum liegt in der Vergangenheit.)
 	*2013 Dec 31; 2014 Jan 05; 2014 <--- (Das Jahr liegt in der Vergangenheit.)
 	*2013 Dec 31 <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
 	*2013 Dec 31; 2014 Jan 05 <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
@@ -1206,9 +1214,11 @@ With [34m[1mwarnings[22m[39m:
 "Complex monthday ranges" for "Jan 23-Feb 11,Feb 12 00:00-24:00": [32m[1mPASSED[22m[39m
 "Leap year monthday" for "2016 Feb 29": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
+	*2016 Feb 29 <--- (Dieses Datum liegt in der Vergangenheit.)
 	*2016 Feb 29 <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
 "Leap year monthday" for "2015 Feb 29": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
+	*2015 Feb 29 <--- (Dieses Datum liegt in der Vergangenheit.)
 	*2015 Feb 29 <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
 "Last day in month" for "Jan 31,Mar 31,Apr 30,May 31,Jun 30,Jul 31,Aug 31,Sep 30,Oct 31,Nov 30,Dec 31 open "last day in month"; Feb 29 open "last day in month (Feb, leap year)"; 2009/4,2010/4,2011/4 Feb 28 open "last day in month (Feb, not leap year)"": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
@@ -2115,9 +2125,12 @@ With [34m[1mwarnings[22m[39m:
 "Structured warning: no warning when leading zeros are used" for "09:00-06:00": [32m[1mPASSED[22m[39m
 "Structured warning: no warning with leading zeros and weekdays" for "Tu-Sa 09:00-06:00": [32m[1mPASSED[22m[39m
 "Structured warning: year in the past" for "2024 00:00-24:00": [32m[1mPASSED[22m[39m
+"Structured warning: date in the past" for "2012 Jan 01 00:00-24:00": [32m[1mPASSED[22m[39m
 "Structured warning: fully past explicit date range" for "2024 Sep 06 - 2024 Oct 05 Fr-Sa 10:00-17:00; Su 12:00-17:00": [32m[1mPASSED[22m[39m
 "Structured warning: date range ending today is not past yet" for "2025 May 01-23 00:00-24:00": [32m[1mPASSED[22m[39m
 "Structured warning: date range ending yesterday is past" for "2025 May 01-22 00:00-24:00": [32m[1mPASSED[22m[39m
+"Structured warning: single date of today is not past yet" for "2025 May 23 00:00-24:00": [32m[1mPASSED[22m[39m
+"Structured warning: single date of yesterday is past" for "2025 May 22 00:00-24:00": [32m[1mPASSED[22m[39m
 "Structured warning: time range without minutes" for "Mo 10-12": [32m[1mPASSED[22m[39m
 "Structured warning: word error correction has stable type" for "Mon": [32m[1mPASSED[22m[39m
 "Structured warning: no warnings yields empty list" for "Mo 10:00-12:00": [32m[1mPASSED[22m[39m
@@ -2735,7 +2748,7 @@ Der optional_conf_parm["tag_key"] fehlt, ist aber notwendig wegen optional_conf_
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-1064/1064 tests passed. 0 did not pass.
+1067/1067 tests passed. 0 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.de.log
+++ b/test/test.de.log
@@ -1108,6 +1108,7 @@ With [34m[1mwarnings[22m[39m:
 	*Jan 01,Dec 24,25; Nov Th[4] <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
 "Month ranges" for "2012 Jan 01,2012 Dec 24-25; 2012 Nov Th[4]": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
+	*2012 Jan 01,2012 Dec 24-25 <--- (Dieser Datumsbereich liegt vollständig in der Vergangenheit.)
 	*2012 Jan 01,2012 Dec 24-25; 2012  <--- (Das Jahr liegt in der Vergangenheit.)
 	*2012 Jan 01,2012 Dec 24-25 <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
 	*2012 Jan 01,2012 Dec 24-25; 2012 Nov Th[4] <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
@@ -1121,6 +1122,8 @@ With [34m[1mwarnings[22m[39m:
 "Monthday ranges" for "Jan 23-Feb 12 00:00-24:00": [32m[1mPASSED[22m[39m
 "Monthday ranges" for "Jan 23-Feb 12: 00:00-24:00": [32m[1mPASSED[22m[39m
 "Monthday ranges" for "2012 Jan 23-2012 Feb 12 00:00-24:00": [32m[1mPASSED[22m[39m
+With [34m[1mwarnings[22m[39m:
+	*2012 Jan 23-2012  <--- (Dieser Datumsbereich liegt vollständig in der Vergangenheit.)
 "Monthday ranges" for "Jan 31-Feb 01,Aug 00:00-24:00": [32m[1mPASSED[22m[39m
 "Monthday ranges" for "Jan 31-Feb 01,Aug: 00:00-24:00": [32m[1mPASSED[22m[39m
 "Monthday ranges" for "Aug,Jan 31-Feb 01": [32m[1mPASSED[22m[39m
@@ -1138,6 +1141,9 @@ With [34m[1mwarnings[22m[39m:
 With [34m[1mwarnings[22m[39m:
 	*Dec 24. <--- (Bitte verzichte auf ".".)
 "Monthday ranges (with year)" for "2012 Jan 23-31 00:00-24:00; 2012 Feb 01-12 00:00-24:00": [32m[1mPASSED[22m[39m
+With [34m[1mwarnings[22m[39m:
+	*2012 Jan 23-31  <--- (Dieser Datumsbereich liegt vollständig in der Vergangenheit.)
+	*2012 Jan 23-31 00:00-24:00; 2012 Feb 01-12  <--- (Dieser Datumsbereich liegt vollständig in der Vergangenheit.)
 "Monthday ranges spanning year boundary" for "Dec 31-Jan 01": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
 	*Dec 31-Jan 01 <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
@@ -1164,8 +1170,12 @@ With [34m[1mwarnings[22m[39m:
 	*2013 Dec 31; 2014 Jan 05 <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
 "Monthday (with year) ranges spanning year boundary" for "2013 Dec 31-2014 Jan 02": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
+	*2013 Dec 31-2014  <--- (Dieser Datumsbereich liegt vollständig in der Vergangenheit.)
 	*2013 Dec 31-2014 Jan 02 <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
 "Monthday (with year) ranges spanning year boundary" for "open; 2010 Jan 01-2013 Dec 30 off; 2014 Jan 03-2016 Jan 01 off": [32m[1mPASSED[22m[39m
+With [34m[1mwarnings[22m[39m:
+	*open; 2010 Jan 01-2013  <--- (Dieser Datumsbereich liegt vollständig in der Vergangenheit.)
+	*open; 2010 Jan 01-2013 Dec 30 off; 2014 Jan 03-2016  <--- (Dieser Datumsbereich liegt vollständig in der Vergangenheit.)
 "Monthday ranges with constrained weekday" for "Jan Su[2]-Jan 15": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
 	*Jan Su[2]-Jan 15 <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
@@ -1190,6 +1200,7 @@ With [34m[1mwarnings[22m[39m:
 	*Mar Su[-1]-Oct Su[-1] -1 day open <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
 "Month ranges with year" for "2012 Jan 10-15,Jan 11": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
+	*2012 Jan 10-15 <--- (Dieser Datumsbereich liegt vollständig in der Vergangenheit.)
 	*2012 Jan 10-15,Jan 11 <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
 "Complex monthday ranges" for "Jan 23-31,Feb 01-12 00:00-24:00": [32m[1mPASSED[22m[39m
 "Complex monthday ranges" for "Jan 23-Feb 11,Feb 12 00:00-24:00": [32m[1mPASSED[22m[39m
@@ -1217,20 +1228,28 @@ With [34m[1mwarnings[22m[39m:
 	*Jan 01-31/8 <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
 "Periodical monthdays" for "2012 Jan 01-31/8": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
+	*2012 Jan 01-31 <--- (Dieser Datumsbereich liegt vollständig in der Vergangenheit.)
 	*2012 Jan 01-31/8 <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
 "Periodical monthdays" for "2012 Jan 01-31/8; 2010 Dec 01-31/8": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
+	*2012 Jan 01-31 <--- (Dieser Datumsbereich liegt vollständig in der Vergangenheit.)
+	*2012 Jan 01-31/8; 2010 Dec 01-31 <--- (Dieser Datumsbereich liegt vollständig in der Vergangenheit.)
 	*2012 Jan 01-31/8 <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
 	*2012 Jan 01-31/8; 2010 Dec 01-31/8 <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
 "Periodical monthdays" for "2012 Jan 01-31/8; 2015 Dec 01-31/8": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
+	*2012 Jan 01-31 <--- (Dieser Datumsbereich liegt vollständig in der Vergangenheit.)
+	*2012 Jan 01-31/8; 2015 Dec 01-31 <--- (Dieser Datumsbereich liegt vollständig in der Vergangenheit.)
 	*2012 Jan 01-31/8 <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
 	*2012 Jan 01-31/8; 2015 Dec 01-31/8 <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
 "Periodical monthdays" for "2012 Jan 01-31/8; 2025 Dec 01-31/8": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
+	*2012 Jan 01-31 <--- (Dieser Datumsbereich liegt vollständig in der Vergangenheit.)
 	*2012 Jan 01-31/8 <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
 	*2012 Jan 01-31/8; 2025 Dec 01-31/8 <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
 "Periodical monthdays" for "2012 Jan 01-31/8: 00:00-24:00": [32m[1mPASSED[22m[39m
+With [34m[1mwarnings[22m[39m:
+	*2012 Jan 01-31 <--- (Dieser Datumsbereich liegt vollständig in der Vergangenheit.)
 "Periodical monthdays" for "Jan 10-31/7": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
 	*Jan 10-31/7 <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
@@ -1503,6 +1522,8 @@ With [34m[1mwarnings[22m[39m:
 "Calculations based on variable events" for "easter-Apr 20: open "Around easter"": [32m[1mPASSED[22m[39m
 "Calculations based on variable events" for "easter-Apr 02: open "Around easter"": [32m[1mPASSED[22m[39m
 "Calculations based on variable events" for "2012 easter -2 days-2012 easter +2 days: open "Around easter"": [32m[1mPASSED[22m[39m
+With [34m[1mwarnings[22m[39m:
+	*2012 easter -2 days-2012  <--- (Dieser Datumsbereich liegt vollständig in der Vergangenheit.)
 "Calculations based on variable events" for "easter -2 days-easter +2 days: open "Around easter"": [32m[1mPASSED[22m[39m
 "Calculations based on variable events" for "easter -2 days-easter +2 days open "Around easter"": [32m[1mPASSED[22m[39m
 "Additional rules with comment" for "Fr 08:00-12:00, Fr 12:00-16:00 open "Notfallsprechstunde"": [32m[1mPASSED[22m[39m
@@ -1537,6 +1558,8 @@ With [34m[1mwarnings[22m[39m:
 "Points in time, extrem example useful for ComplexAlarm" for "Mo-We 07:00; Th,Fr 05:45; Mo[1] 07:30; SH Mo-Fr (sunrise+03:00); PH off": [32m[1mPASSED[22m[39m
 "Points in time, extrem example useful for ComplexAlarm" for "Mo-We 07:00; Th 05:45; week 01-53/2 Fr 07:05; week 02-53/2 Fr 05:45; SH Mo-Fr (sunrise+03:00); PH off": [32m[1mPASSED[22m[39m
 "Points in time, extrem example useful for ComplexAlarm" for "Mo-We 07:00; Th 05:45; week 01-53/2 Fr 07:05; week 02-53/2 Fr 05:45; SH Mo-Fr (sunrise+03:00); PH off; easter -2 days-easter +2 days off "My little break from work every year."; 2024 Sep 02-2024 Sep 06 off "My vacations …"": [32m[1mPASSED[22m[39m
+With [34m[1mwarnings[22m[39m:
+	*Mo-We 07:00; Th 05:45; week 01-53/2 Fr 07:05; week 02-53/2 Fr 05:45; SH Mo-Fr (sunrise+03:00); PH off; easter -2 days-easter +2 days off "My little break from work every year."; 2024 Sep 02-2024  <--- (Dieser Datumsbereich liegt vollständig in der Vergangenheit.)
 "Points in time, period times" for "Mo-Fr 10:00-16:00/01:30": [32m[1mPASSED[22m[39m
 "Points in time, period times" for "Mo-Fr 10:00-16:00/90": [32m[1mPASSED[22m[39m
 "Points in time, period times" for "Mo-Fr 10:00-16:00/90; Sa off "testing at end for parser"": [32m[1mPASSED[22m[39m
@@ -2091,6 +2114,10 @@ With [34m[1mwarnings[22m[39m:
 "Structured warning: no warning for variable-time start with leading-zero end" for "sunrise-09:00": [32m[1mPASSED[22m[39m
 "Structured warning: no warning when leading zeros are used" for "09:00-06:00": [32m[1mPASSED[22m[39m
 "Structured warning: no warning with leading zeros and weekdays" for "Tu-Sa 09:00-06:00": [32m[1mPASSED[22m[39m
+"Structured warning: year in the past" for "2024 00:00-24:00": [32m[1mPASSED[22m[39m
+"Structured warning: fully past explicit date range" for "2024 Sep 06 - 2024 Oct 05 Fr-Sa 10:00-17:00; Su 12:00-17:00": [32m[1mPASSED[22m[39m
+"Structured warning: date range ending today is not past yet" for "2025 May 01-23 00:00-24:00": [32m[1mPASSED[22m[39m
+"Structured warning: date range ending yesterday is past" for "2025 May 01-22 00:00-24:00": [32m[1mPASSED[22m[39m
 "Structured warning: time range without minutes" for "Mo 10-12": [32m[1mPASSED[22m[39m
 "Structured warning: word error correction has stable type" for "Mon": [32m[1mPASSED[22m[39m
 "Structured warning: no warnings yields empty list" for "Mo 10:00-12:00": [32m[1mPASSED[22m[39m
@@ -2708,7 +2735,7 @@ Der optional_conf_parm["tag_key"] fehlt, ist aber notwendig wegen optional_conf_
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-1060/1060 tests passed. 0 did not pass.
+1064/1064 tests passed. 0 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.en.log
+++ b/test/test.en.log
@@ -1108,6 +1108,7 @@ With [34m[1mwarnings[22m[39m:
 	*Jan 01,Dec 24,25; Nov Th[4] <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
 "Month ranges" for "2012 Jan 01,2012 Dec 24-25; 2012 Nov Th[4]": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
+	*2012 Jan 01,2012 Dec 24-25 <--- (This date range is entirely in the past.)
 	*2012 Jan 01,2012 Dec 24-25; 2012  <--- (The year is in the past.)
 	*2012 Jan 01,2012 Dec 24-25 <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
 	*2012 Jan 01,2012 Dec 24-25; 2012 Nov Th[4] <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
@@ -1121,6 +1122,8 @@ With [34m[1mwarnings[22m[39m:
 "Monthday ranges" for "Jan 23-Feb 12 00:00-24:00": [32m[1mPASSED[22m[39m
 "Monthday ranges" for "Jan 23-Feb 12: 00:00-24:00": [32m[1mPASSED[22m[39m
 "Monthday ranges" for "2012 Jan 23-2012 Feb 12 00:00-24:00": [32m[1mPASSED[22m[39m
+With [34m[1mwarnings[22m[39m:
+	*2012 Jan 23-2012  <--- (This date range is entirely in the past.)
 "Monthday ranges" for "Jan 31-Feb 01,Aug 00:00-24:00": [32m[1mPASSED[22m[39m
 "Monthday ranges" for "Jan 31-Feb 01,Aug: 00:00-24:00": [32m[1mPASSED[22m[39m
 "Monthday ranges" for "Aug,Jan 31-Feb 01": [32m[1mPASSED[22m[39m
@@ -1138,6 +1141,9 @@ With [34m[1mwarnings[22m[39m:
 With [34m[1mwarnings[22m[39m:
 	*Dec 24. <--- (Please omit ".".)
 "Monthday ranges (with year)" for "2012 Jan 23-31 00:00-24:00; 2012 Feb 01-12 00:00-24:00": [32m[1mPASSED[22m[39m
+With [34m[1mwarnings[22m[39m:
+	*2012 Jan 23-31  <--- (This date range is entirely in the past.)
+	*2012 Jan 23-31 00:00-24:00; 2012 Feb 01-12  <--- (This date range is entirely in the past.)
 "Monthday ranges spanning year boundary" for "Dec 31-Jan 01": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
 	*Dec 31-Jan 01 <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
@@ -1164,8 +1170,12 @@ With [34m[1mwarnings[22m[39m:
 	*2013 Dec 31; 2014 Jan 05 <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
 "Monthday (with year) ranges spanning year boundary" for "2013 Dec 31-2014 Jan 02": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
+	*2013 Dec 31-2014  <--- (This date range is entirely in the past.)
 	*2013 Dec 31-2014 Jan 02 <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
 "Monthday (with year) ranges spanning year boundary" for "open; 2010 Jan 01-2013 Dec 30 off; 2014 Jan 03-2016 Jan 01 off": [32m[1mPASSED[22m[39m
+With [34m[1mwarnings[22m[39m:
+	*open; 2010 Jan 01-2013  <--- (This date range is entirely in the past.)
+	*open; 2010 Jan 01-2013 Dec 30 off; 2014 Jan 03-2016  <--- (This date range is entirely in the past.)
 "Monthday ranges with constrained weekday" for "Jan Su[2]-Jan 15": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
 	*Jan Su[2]-Jan 15 <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
@@ -1190,6 +1200,7 @@ With [34m[1mwarnings[22m[39m:
 	*Mar Su[-1]-Oct Su[-1] -1 day open <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
 "Month ranges with year" for "2012 Jan 10-15,Jan 11": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
+	*2012 Jan 10-15 <--- (This date range is entirely in the past.)
 	*2012 Jan 10-15,Jan 11 <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
 "Complex monthday ranges" for "Jan 23-31,Feb 01-12 00:00-24:00": [32m[1mPASSED[22m[39m
 "Complex monthday ranges" for "Jan 23-Feb 11,Feb 12 00:00-24:00": [32m[1mPASSED[22m[39m
@@ -1217,20 +1228,28 @@ With [34m[1mwarnings[22m[39m:
 	*Jan 01-31/8 <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
 "Periodical monthdays" for "2012 Jan 01-31/8": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
+	*2012 Jan 01-31 <--- (This date range is entirely in the past.)
 	*2012 Jan 01-31/8 <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
 "Periodical monthdays" for "2012 Jan 01-31/8; 2010 Dec 01-31/8": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
+	*2012 Jan 01-31 <--- (This date range is entirely in the past.)
+	*2012 Jan 01-31/8; 2010 Dec 01-31 <--- (This date range is entirely in the past.)
 	*2012 Jan 01-31/8 <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
 	*2012 Jan 01-31/8; 2010 Dec 01-31/8 <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
 "Periodical monthdays" for "2012 Jan 01-31/8; 2015 Dec 01-31/8": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
+	*2012 Jan 01-31 <--- (This date range is entirely in the past.)
+	*2012 Jan 01-31/8; 2015 Dec 01-31 <--- (This date range is entirely in the past.)
 	*2012 Jan 01-31/8 <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
 	*2012 Jan 01-31/8; 2015 Dec 01-31/8 <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
 "Periodical monthdays" for "2012 Jan 01-31/8; 2025 Dec 01-31/8": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
+	*2012 Jan 01-31 <--- (This date range is entirely in the past.)
 	*2012 Jan 01-31/8 <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
 	*2012 Jan 01-31/8; 2025 Dec 01-31/8 <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
 "Periodical monthdays" for "2012 Jan 01-31/8: 00:00-24:00": [32m[1mPASSED[22m[39m
+With [34m[1mwarnings[22m[39m:
+	*2012 Jan 01-31 <--- (This date range is entirely in the past.)
 "Periodical monthdays" for "Jan 10-31/7": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
 	*Jan 10-31/7 <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
@@ -1503,6 +1522,8 @@ With [34m[1mwarnings[22m[39m:
 "Calculations based on variable events" for "easter-Apr 20: open "Around easter"": [32m[1mPASSED[22m[39m
 "Calculations based on variable events" for "easter-Apr 02: open "Around easter"": [32m[1mPASSED[22m[39m
 "Calculations based on variable events" for "2012 easter -2 days-2012 easter +2 days: open "Around easter"": [32m[1mPASSED[22m[39m
+With [34m[1mwarnings[22m[39m:
+	*2012 easter -2 days-2012  <--- (This date range is entirely in the past.)
 "Calculations based on variable events" for "easter -2 days-easter +2 days: open "Around easter"": [32m[1mPASSED[22m[39m
 "Calculations based on variable events" for "easter -2 days-easter +2 days open "Around easter"": [32m[1mPASSED[22m[39m
 "Additional rules with comment" for "Fr 08:00-12:00, Fr 12:00-16:00 open "Notfallsprechstunde"": [32m[1mPASSED[22m[39m
@@ -1537,6 +1558,8 @@ With [34m[1mwarnings[22m[39m:
 "Points in time, extrem example useful for ComplexAlarm" for "Mo-We 07:00; Th,Fr 05:45; Mo[1] 07:30; SH Mo-Fr (sunrise+03:00); PH off": [32m[1mPASSED[22m[39m
 "Points in time, extrem example useful for ComplexAlarm" for "Mo-We 07:00; Th 05:45; week 01-53/2 Fr 07:05; week 02-53/2 Fr 05:45; SH Mo-Fr (sunrise+03:00); PH off": [32m[1mPASSED[22m[39m
 "Points in time, extrem example useful for ComplexAlarm" for "Mo-We 07:00; Th 05:45; week 01-53/2 Fr 07:05; week 02-53/2 Fr 05:45; SH Mo-Fr (sunrise+03:00); PH off; easter -2 days-easter +2 days off "My little break from work every year."; 2024 Sep 02-2024 Sep 06 off "My vacations …"": [32m[1mPASSED[22m[39m
+With [34m[1mwarnings[22m[39m:
+	*Mo-We 07:00; Th 05:45; week 01-53/2 Fr 07:05; week 02-53/2 Fr 05:45; SH Mo-Fr (sunrise+03:00); PH off; easter -2 days-easter +2 days off "My little break from work every year."; 2024 Sep 02-2024  <--- (This date range is entirely in the past.)
 "Points in time, period times" for "Mo-Fr 10:00-16:00/01:30": [32m[1mPASSED[22m[39m
 "Points in time, period times" for "Mo-Fr 10:00-16:00/90": [32m[1mPASSED[22m[39m
 "Points in time, period times" for "Mo-Fr 10:00-16:00/90; Sa off "testing at end for parser"": [32m[1mPASSED[22m[39m
@@ -2091,6 +2114,10 @@ With [34m[1mwarnings[22m[39m:
 "Structured warning: no warning for variable-time start with leading-zero end" for "sunrise-09:00": [32m[1mPASSED[22m[39m
 "Structured warning: no warning when leading zeros are used" for "09:00-06:00": [32m[1mPASSED[22m[39m
 "Structured warning: no warning with leading zeros and weekdays" for "Tu-Sa 09:00-06:00": [32m[1mPASSED[22m[39m
+"Structured warning: year in the past" for "2024 00:00-24:00": [32m[1mPASSED[22m[39m
+"Structured warning: fully past explicit date range" for "2024 Sep 06 - 2024 Oct 05 Fr-Sa 10:00-17:00; Su 12:00-17:00": [32m[1mPASSED[22m[39m
+"Structured warning: date range ending today is not past yet" for "2025 May 01-23 00:00-24:00": [32m[1mPASSED[22m[39m
+"Structured warning: date range ending yesterday is past" for "2025 May 01-22 00:00-24:00": [32m[1mPASSED[22m[39m
 "Structured warning: time range without minutes" for "Mo 10-12": [32m[1mPASSED[22m[39m
 "Structured warning: word error correction has stable type" for "Mon": [32m[1mPASSED[22m[39m
 "Structured warning: no warnings yields empty list" for "Mo 10:00-12:00": [32m[1mPASSED[22m[39m
@@ -2698,7 +2725,7 @@ The optional_conf_parm["tag_key"] is missing, required by optional_conf_parm["ma
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-1050/1050 tests passed. 0 did not pass.
+1054/1054 tests passed. 0 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.en.log
+++ b/test/test.en.log
@@ -1108,6 +1108,7 @@ With [34m[1mwarnings[22m[39m:
 	*Jan 01,Dec 24,25; Nov Th[4] <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
 "Month ranges" for "2012 Jan 01,2012 Dec 24-25; 2012 Nov Th[4]": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
+	*2012 Jan 01 <--- (This date is in the past.)
 	*2012 Jan 01,2012 Dec 24-25 <--- (This date range is entirely in the past.)
 	*2012 Jan 01,2012 Dec 24-25; 2012  <--- (The year is in the past.)
 	*2012 Jan 01,2012 Dec 24-25 <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
@@ -1149,9 +1150,13 @@ With [34m[1mwarnings[22m[39m:
 	*Dec 31-Jan 01 <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
 "Full day (with year)" for "2013 Dec 31,2014 Jan 05": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
+	*2013 Dec 31 <--- (This date is in the past.)
+	*2013 Dec 31,2014 Jan 05 <--- (This date is in the past.)
 	*2013 Dec 31,2014 Jan 05 <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
 "Full day (with year)" for "2013 Dec 31; 2014 Jan 05": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
+	*2013 Dec 31 <--- (This date is in the past.)
+	*2013 Dec 31; 2014 Jan 05 <--- (This date is in the past.)
 	*2013 Dec 31 <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
 	*2013 Dec 31; 2014 Jan 05 <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
 "Full day (with year)" for "2013/10 Dec 31; 2014/10 Jan 05": [32m[1mPASSED[22m[39m
@@ -1162,9 +1167,12 @@ With [34m[1mwarnings[22m[39m:
 	*2013/10 Dec 31; 2014/10 Jan 05 <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
 "Date range which only applies for one year" for "2013 Dec 31": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
+	*2013 Dec 31 <--- (This date is in the past.)
 	*2013 Dec 31 <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
 "Date range which only applies for one year" for "2013 Dec 31; 2014 Jan 05; 2014+ off": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
+	*2013 Dec 31 <--- (This date is in the past.)
+	*2013 Dec 31; 2014 Jan 05 <--- (This date is in the past.)
 	*2013 Dec 31; 2014 Jan 05; 2014 <--- (The year is in the past.)
 	*2013 Dec 31 <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
 	*2013 Dec 31; 2014 Jan 05 <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
@@ -1206,9 +1214,11 @@ With [34m[1mwarnings[22m[39m:
 "Complex monthday ranges" for "Jan 23-Feb 11,Feb 12 00:00-24:00": [32m[1mPASSED[22m[39m
 "Leap year monthday" for "2016 Feb 29": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
+	*2016 Feb 29 <--- (This date is in the past.)
 	*2016 Feb 29 <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
 "Leap year monthday" for "2015 Feb 29": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
+	*2015 Feb 29 <--- (This date is in the past.)
 	*2015 Feb 29 <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
 "Last day in month" for "Jan 31,Mar 31,Apr 30,May 31,Jun 30,Jul 31,Aug 31,Sep 30,Oct 31,Nov 30,Dec 31 open "last day in month"; Feb 29 open "last day in month (Feb, leap year)"; 2009/4,2010/4,2011/4 Feb 28 open "last day in month (Feb, not leap year)"": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
@@ -2115,9 +2125,12 @@ With [34m[1mwarnings[22m[39m:
 "Structured warning: no warning when leading zeros are used" for "09:00-06:00": [32m[1mPASSED[22m[39m
 "Structured warning: no warning with leading zeros and weekdays" for "Tu-Sa 09:00-06:00": [32m[1mPASSED[22m[39m
 "Structured warning: year in the past" for "2024 00:00-24:00": [32m[1mPASSED[22m[39m
+"Structured warning: date in the past" for "2012 Jan 01 00:00-24:00": [32m[1mPASSED[22m[39m
 "Structured warning: fully past explicit date range" for "2024 Sep 06 - 2024 Oct 05 Fr-Sa 10:00-17:00; Su 12:00-17:00": [32m[1mPASSED[22m[39m
 "Structured warning: date range ending today is not past yet" for "2025 May 01-23 00:00-24:00": [32m[1mPASSED[22m[39m
 "Structured warning: date range ending yesterday is past" for "2025 May 01-22 00:00-24:00": [32m[1mPASSED[22m[39m
+"Structured warning: single date of today is not past yet" for "2025 May 23 00:00-24:00": [32m[1mPASSED[22m[39m
+"Structured warning: single date of yesterday is past" for "2025 May 22 00:00-24:00": [32m[1mPASSED[22m[39m
 "Structured warning: time range without minutes" for "Mo 10-12": [32m[1mPASSED[22m[39m
 "Structured warning: word error correction has stable type" for "Mon": [32m[1mPASSED[22m[39m
 "Structured warning: no warnings yields empty list" for "Mo 10:00-12:00": [32m[1mPASSED[22m[39m
@@ -2725,7 +2738,7 @@ The optional_conf_parm["tag_key"] is missing, required by optional_conf_parm["ma
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-1054/1054 tests passed. 0 did not pass.
+1057/1057 tests passed. 0 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.js
+++ b/test/test.js
@@ -5508,6 +5508,11 @@ test.addStructuredWarnings('Structured warning: year in the past',
     [ 'year_past' ],
     nominatim_default, 'not only test', { 'tag_key': 'opening_hours' });
 
+test.addStructuredWarnings('Structured warning: date in the past',
+    '2012 Jan 01 00:00-24:00',
+    [ 'date_past' ],
+    nominatim_default, 'not only test', { 'tag_key': 'opening_hours' });
+
 test.addStructuredWarnings('Structured warning: fully past explicit date range',
     '2024 Sep 06 - 2024 Oct 05 Fr-Sa 10:00-17:00; Su 12:00-17:00',
     [ 'date_range_past' ],
@@ -5522,6 +5527,16 @@ test.addStructuredWarnings('Structured warning: date range ending today is not p
 test.addStructuredWarnings('Structured warning: date range ending yesterday is past',
     '2025 May 01-22 00:00-24:00',
     [ 'date_range_past' ],
+    nominatim_default, 'not only test', { 'tag_key': 'opening_hours' });
+
+test.addStructuredWarnings('Structured warning: single date of today is not past yet',
+    '2025 May 23 00:00-24:00',
+    [],
+    nominatim_default, 'not only test', { 'tag_key': 'opening_hours' });
+
+test.addStructuredWarnings('Structured warning: single date of yesterday is past',
+    '2025 May 22 00:00-24:00',
+    [ 'date_past' ],
     nominatim_default, 'not only test', { 'tag_key': 'opening_hours' });
 
 test.addStructuredWarnings('Structured warning: time range without minutes',

--- a/test/test.js
+++ b/test/test.js
@@ -5503,6 +5503,27 @@ test.addStructuredWarnings('Structured warning: no warning with leading zeros an
 // }}}
 
 // getStructuredWarnings: machine-readable warning objects {{{
+test.addStructuredWarnings('Structured warning: year in the past',
+    '2024 00:00-24:00',
+    [ 'year_past' ],
+    nominatim_default, 'not only test', { 'tag_key': 'opening_hours' });
+
+test.addStructuredWarnings('Structured warning: fully past explicit date range',
+    '2024 Sep 06 - 2024 Oct 05 Fr-Sa 10:00-17:00; Su 12:00-17:00',
+    [ 'date_range_past' ],
+    nominatim_default, 'not only test', { 'tag_key': 'opening_hours' });
+
+// Regression: a range ending on the frozen "today" must not warn yet.
+test.addStructuredWarnings('Structured warning: date range ending today is not past yet',
+    '2025 May 01-23 00:00-24:00',
+    [],
+    nominatim_default, 'not only test', { 'tag_key': 'opening_hours' });
+
+test.addStructuredWarnings('Structured warning: date range ending yesterday is past',
+    '2025 May 01-22 00:00-24:00',
+    [ 'date_range_past' ],
+    nominatim_default, 'not only test', { 'tag_key': 'opening_hours' });
+
 test.addStructuredWarnings('Structured warning: time range without minutes',
         'Mo 10-12',
         [ 'without_minutes' ],

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,6 +5,7 @@ declare module 'opening_hours' {
     | 'additional_rule_which_evaluates_to_closed'
     | 'ambiguous_word'
     | 'combine_rules'
+    | 'date_past'
     | 'date_range_past'
     | 'default_state'
     | 'empty_comment'

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,6 +5,7 @@ declare module 'opening_hours' {
     | 'additional_rule_which_evaluates_to_closed'
     | 'ambiguous_word'
     | 'combine_rules'
+    | 'date_range_past'
     | 'default_state'
     | 'empty_comment'
     | 'hour_min_separator'


### PR DESCRIPTION
With this the parser warns when explicit dates or date ranges are already fully in the past.

Fixes #636.