### PR TITLE
refactor(prettify): extract helpers and add unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
   "scripts": {
     "build": "make build",
     "test-quick": "make check",
-    "test": "make check-full",
+    "test:unit": "node --test test/unit/*.test.mjs",
+    "test": "npm run test:unit && make check-full",
     "lint": "eslint",
     "typecheck": "tsc --project jsconfig.json",
     "lint:fix": "eslint --fix",

--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,7 @@ import word_error_correction from './locales/word_error_correction.yaml';
 
 import { getTimes } from 'suncalc';
 import { translate } from './locales/i18n';
+import { compareSelectorOrder, formatPrettifySelectorToken, getRuleSeparator, matchTokens, normalizePrettifyConf, shouldSortPrettifiedGroup } from './prettify-helpers.mjs';
 
 import { resolveRange } from './locale-resolver/resolver.mjs';
 import { regionLanguages } from './locale-resolver/region-languages.mjs';
@@ -1477,16 +1478,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
 
         }
 
-        Object.keys(default_prettify_conf).forEach(function (key) {
-            if (typeof user_conf[key] === 'undefined') {
-                user_conf[key] = default_prettify_conf[key];
-            }
-        });
-
-        // Locale-aware day/month order and separator for month-day pairs.
-        // Uses Intl.DateTimeFormat#formatToParts to derive both the order (e.g. "6 mars" vs "March 6")
-        // and the literal separator (e.g. ". " for de, " de " for long es).
-        // Skipped for 'en' (always month-first) and 'all' ('all' is not a valid BCP 47 tag).
+        user_conf = normalizePrettifyConf(user_conf, default_prettify_conf);
         let day_before_month = false;
         let day_month_sep = ' ';
         const locale = /** @type {string} */ (user_conf['locale']);
@@ -1520,19 +1512,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
                 if (rule_index !== nrule) continue;
             } else {
                 if (nrule !== 0)
-                    prettified_value += (
-                        new_tokens[nrule][1]
-                            ? user_conf.rule_sep_string + '|| '
-                            : (
-                                new_tokens[nrule][0][0][1] === 'rule separator'
-                                ? ','
-                                : (
-                                    user_conf.print_semicolon
-                                    ? ';'
-                                    : ''
-                                )
-                            ) +
-                        user_conf.rule_sep_string);
+                    prettified_value += getRuleSeparator(new_tokens[nrule], user_conf);
             }
 
             let selector_start_end_type = [ 0, 0, undefined ];
@@ -1569,19 +1549,9 @@ export default function(value, nominatim_object, optional_conf_parm) {
             } while (selector_start_end_type[1] < new_tokens[nrule][0].length);
             // console.log('Prettified value: ' + JSON.stringify(prettified_group_value, null, '    '));
             const not_sorted_prettified_group_value = prettified_group_value.slice();
-            const contains_comment_selector = prettified_group_value.some(function (array) {
-                return array[0][2] === 'comment';
-            });
-
-            if (!done_with_selector_reordering && !rules_without_selector_reordering.has(nrule) && !contains_comment_selector) {
-                prettified_group_value.sort(
-                    function (a, b) {
-                        const selector_order = [ 'year', 'month', 'week', 'holiday', 'weekday', 'time', '24/7', 'state', 'comment'];
-                        return selector_order.indexOf(a[0][2]) - selector_order.indexOf(b[0][2]);
-                    }
-                );
+            if (shouldSortPrettifiedGroup(done_with_selector_reordering, rules_without_selector_reordering, nrule, prettified_group_value)) {
+                prettified_group_value.sort(compareSelectorOrder);
             }
-
             const old_prettified_value_length = prettified_value.length;
 
             prettified_value += prettified_group_value.map(function (array) {
@@ -1621,26 +1591,6 @@ export default function(value, nominatim_object, optional_conf_parm) {
     }
     /* }}} */
 
-    /* Check selector array of tokens for specific token name pattern. {{{
-     *
-     * :param tokens: List of token objects.
-     * :param at: Position at which the matching should begin.
-     * :param token_name(s): One or many token_name strings which have to match in that order.
-     * :returns: true if token_name(s) match in order false otherwise.
-     */
-    function matchTokens(tokens, at /*, matches... */) {
-        if (at + arguments.length - 2 > tokens.length)
-            return false;
-        for (let i = 0; i < arguments.length - 2; i++) {
-            if (tokens[at + i][1] !== arguments[i + 2]) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-    /* }}} */
-
     /* Generate selector wrapper with time offset {{{
      *
      * :param func: Generated selector code function.
@@ -1661,7 +1611,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
 
     /* Top-level parser {{{
      *
-     * :param tokens: List of token objects.
+     * :param tokens: List of tokens.
      * :param at: Position where to start.
      * :param rule: Reference to rule object.
      * :param nrule: Rule number starting with 0.
@@ -4371,59 +4321,6 @@ export default function(value, nominatim_object, optional_conf_parm) {
     };
     /* }}} */
 
-    /* Memoized localized month/weekday names for prettified output.
-     * :param conf: Prettify configuration (locale/date_format).
-     * :param kind: Either 'weekday' or 'month'.
-     * :returns: Localized name array with stable index mapping.
-     */
-    const localized_name_cache = {};
-
-    function getLocalizedNames(conf, kind) {
-        const useEnglishShortNames =
-            (conf['locale'] === 'en' || conf['locale'] === 'all') && conf['date_format'] === 'short';
-        if (useEnglishShortNames) {
-            return kind === 'weekday' ? weekdays : months;
-        }
-
-        const cache_key = kind + '|' + conf['locale'] + '|' + conf['date_format'];
-        if (!localized_name_cache[cache_key]) {
-            localized_name_cache[cache_key] = kind === 'weekday'
-                // 2026-02-01 is a Sunday, so day 1..7 maps to Su..Sa.
-                ? [1, 2, 3, 4, 5, 6, 7].map(function (weekday) {
-                    return new Date(2026, 1, weekday).toLocaleString(conf['locale'], {weekday: conf['date_format'], calendar: 'gregory'});
-                })
-                // The year is arbitrary; only the month index affects the name.
-                : [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].map(function (month) {
-                    return new Date(2026, month - 1, 1).toLocaleString(conf['locale'], {month: conf['date_format'], calendar: 'gregory'});
-                });
-        }
-        return localized_name_cache[cache_key];
-    }
-
-    /* Translate prettify output token-wise (fixes PH/SH inside grouped selectors, #319).
-     * :param value: Token value (index for month/weekday, string otherwise).
-     * :param token_type: Token type, e.g. 'weekday', 'month', 'state'.
-     * :param conf: Prettify configuration (locale/date_format).
-     * :returns: Translated token string or unchanged value.
-     */
-    function translatePrettyToken(value, token_type, conf) {
-        if (token_type === 'weekday') {
-            return getLocalizedNames(conf, 'weekday')[value];
-        }
-
-        if (token_type === 'month') {
-            return getLocalizedNames(conf, 'month')[value];
-        }
-
-        // Other tokens (e.g. holidays 'PH'/'SH' or the 'off'/'closed' state)
-        // only need translation for non-English locales.
-        if (typeof conf['locale'] !== 'string' || conf['locale'] === 'en') {
-            return value;
-        }
-
-        return translate(conf['locale'], 'pretty', value);
-    }
-
     /* Generate prettified value for selector based on tokens. {{{
      *
      * :param tokens: List of token objects.
@@ -4433,106 +4330,23 @@ export default function(value, nominatim_object, optional_conf_parm) {
      * :returns: Prettified value.
      */
     function prettifySelector(tokens, selector_start, selector_end, selector_type, conf) {
-
         let prettified_value = '';
         let at = selector_start;
-        // Preserve a leading malformed ':' before a time selector so the
-        // prettified form keeps the same meaning as the tolerated input.
-        if (selector_type === 'time'
-                && selector_start > 1
-                && matchTokens(tokens, selector_start - 1, 'timesep')
-                && matchTokens(tokens, selector_start, 'number')
-                && (matchTokens(tokens, selector_start - 2, 'rule separator')
-                    || matchTokens(tokens, selector_start - 2, ','))) {
-            prettified_value += ':';
-        }
-        // console.log(selector_type);
         while (at <= selector_end) {
-            const token_value = tokens[at][0];
-            const token_type = tokens[at][1];
-            // console.log('At: ' + at + ', token: ' + tokens[at]);
-            if (matchTokens(tokens, at, 'weekday')) {
-                if (!conf.leave_weekday_sep_one_day_betw
-                    && at - selector_start > 1 && (matchTokens(tokens, at-1, ',') || matchTokens(tokens, at-1, '-'))
-                    && matchTokens(tokens, at-2, 'weekday')
-                    && tokens[at][0] === (tokens[at-2][0] + 1) % 7) {
-                        prettified_value = prettified_value.substring(0, prettified_value.length - 1) + conf.sep_one_day_between;
-                }
-                prettified_value += translatePrettyToken(token_value, 'weekday', conf);
-            } else if (at - selector_start > 0 // e.g. '09:0' -> '09:00'
-                    && selector_type === 'time'
-                    && matchTokens(tokens, at-1, 'timesep')
-                    && matchTokens(tokens, at, 'number')) {
-                prettified_value += (tokens[at][0] < 10 ? '0' : '') + tokens[at][0].toString();
-            } else if (selector_type === 'time' // e.g. '9:00' -> ' 09:00'
-                    && conf.zero_pad_hour
-                    && at !== tokens.length
-                    && matchTokens(tokens, at, 'number')
-                    && matchTokens(tokens, at+1, 'timesep')) {
-                prettified_value += (
-                        tokens[at][0] < 10 ?
-                            (tokens[at][0] === 0 && conf.one_zero_if_hour_zero ?
-                             '' : '0') :
-                            '') + tokens[at][0].toString();
-            } else if (selector_type === 'time' // e.g. '9-18' -> '09:00-18:00'
-                    && at + 2 <= selector_end
-                    && matchTokens(tokens, at, 'number')
-                    && matchTokens(tokens, at+1, '-')
-                    && matchTokens(tokens, at+2, 'number')
-                    && tokens[at][0] !== tokens[at+2][0]) {
-                prettified_value += (tokens[at][0] < 10 ?
-                        (tokens[at][0] === 0 && conf.one_zero_if_hour_zero ? '' : '0')
-                        : '') + tokens[at][0].toString();
-                prettified_value += ':00-'
-                    + (tokens[at+2][0] < 10 ? '0' : '') + tokens[at+2][0].toString()
-                    + ':00';
-                at += 2;
-            } else if (matchTokens(tokens, at, 'comment')) {
-                prettified_value += '"' + tokens[at][0].toString() + '"';
-            } else if (matchTokens(tokens, at, 'closed')) {
-                prettified_value += translatePrettyToken(conf.leave_off_closed ? token_value : conf.keyword_for_off_closed, 'state', conf);
-            } else if (at - selector_start > 0 && matchTokens(tokens, at, 'number')
-                    && (selector_type === 'month' || selector_type === 'week')) {
-                prettified_value +=
-                    (matchTokens(tokens, at-1, 'month') || matchTokens(tokens, at-1, 'week') ? ' ' : '')
-                    + (conf.zero_pad_month_and_week_numbers && tokens[at][4] !== 'positive_number' && tokens[at][0] < 10 ? '0' : '')
-                    + tokens[at][0];
-            } else if (at - selector_start > 0 && matchTokens(tokens, at, 'month')
-                    && matchTokens(tokens, at-1, 'year')) {
-                prettified_value += ' ' + translatePrettyToken(token_value, 'month', conf);
-            } else if (at - selector_start > 0 && matchTokens(tokens, at, 'event')
-                    && matchTokens(tokens, at-1, 'year')) {
-                prettified_value += ' ' + tokens[at][0];
-            } else if (matchTokens(tokens, at, 'month')) {
-                const month_pretty = translatePrettyToken(token_value, 'month', conf);
-                if (conf.day_before_month
-                        && at + 1 <= selector_end
-                        && matchTokens(tokens, at+1, 'number')) {
-                    // Consume the day together with the month when the locale puts it first.
-                    prettified_value += tokens[at+1][0] + conf.day_month_sep + month_pretty;
-                    at++;
-                } else {
-                    prettified_value += month_pretty;
-                }
-                // Keep the separator before a following weekday in both output orders.
-                if (at + 1 <= selector_end && matchTokens(tokens, at+1, 'weekday'))
-                    prettified_value += ' ';
-            } else if (at + 2 <= selector_end
-                    && (matchTokens(tokens, at, '-') || matchTokens(tokens, at, '+'))
-                    && matchTokens(tokens, at+1, 'number', 'calcday')) {
-                prettified_value += ' ' + tokens[at][0] + tokens[at+1][0] + ' day' + (Math.abs(tokens[at+1][0]) === 1 ? '' : 's');
-                at += 2;
-            } else if (at === selector_end
-                    && selector_type === 'weekday'
-                    && tokens[at][0] === ':') {
-                // Do nothing.
-            } else if (at === selector_end
-                    && selector_type === 'time'
-                    && tokens[at][0] === ',') {
-                /* Remove trailing , which is ignored in parseTimeRange. */
-            } else {
-                prettified_value += translatePrettyToken(token_value.toString(), token_type, conf);
-            }
+            const formatted = formatPrettifySelectorToken(
+                prettified_value,
+                tokens,
+                at,
+                selector_start,
+                selector_end,
+                selector_type,
+                conf,
+                months,
+                weekdays,
+                translate
+            );
+            prettified_value = formatted.value;
+            at += formatted.advance;
             at++;
         }
         return prettified_value;

--- a/src/prettify-helpers.mjs
+++ b/src/prettify-helpers.mjs
@@ -1,0 +1,307 @@
+// SPDX-FileCopyrightText: © opening_hours.js contributors
+// SPDX-License-Identifier: LGPL-3.0-only
+
+/**
+ * Pure helpers for prettifyValue / prettifySelector.
+ * None of these functions close over parser state; they are safe to import
+ * and test in isolation.
+ */
+// eslint-disable-next-line jsdoc/reject-any-type
+/** @typedef {Record<string, any>} PrettifyConf */
+// eslint-disable-next-line jsdoc/reject-any-type
+/** @typedef {Array<any>} PrettifyToken */
+/** @typedef {Array<PrettifyToken>} PrettifyTokens */
+
+/**
+ * Canonical order in which selectors should appear inside a rule group.
+ * Used by the sort comparator below.
+ */
+export const SELECTOR_ORDER = [
+    'year', 'month', 'week', 'holiday', 'weekday', 'time', '24/7', 'state', 'comment',
+];
+
+/**
+ * Sort comparator for prettified_group_value entries based on SELECTOR_ORDER.
+ * @param {PrettifyToken} a - [selector_start_end_type, string] tuple
+ * @param {PrettifyToken} b - [selector_start_end_type, string] tuple
+ * @returns {number} Ordering difference between the two selector groups.
+ */
+export function compareSelectorOrder(a, b) {
+    return SELECTOR_ORDER.indexOf(a[0][2]) - SELECTOR_ORDER.indexOf(b[0][2]);
+}
+
+/**
+ * Returns true when a prettified rule group contains a comment selector.
+ * Reordering the group in that case may change the semantics of the value.
+ * @param {Array<PrettifyToken>} group - prettified_group_value array
+ * @returns {boolean} Whether the group contains a comment selector.
+ */
+export function hasCommentSelector(group) {
+    return group.some(entry => entry[0][2] === 'comment');
+}
+
+/** @type {Record<string, string[]>} */
+const localized_name_cache = {};
+
+/**
+ * Build the separator string between two rules for prettifyValue.
+ * @param {PrettifyToken} ruleTokens - token list of one rule, as stored in new_tokens[nrule]
+ * @param {PrettifyConf} conf - prettify configuration object
+ * @returns {string} Separator to append before the next rule.
+ */
+export function getRuleSeparator(ruleTokens, conf) {
+    return ruleTokens[1]
+        ? conf.rule_sep_string + '|| '
+        : (
+            ruleTokens[0][0][1] === 'rule separator'
+                ? ','
+                : (conf.print_semicolon ? ';' : '')
+        ) + conf.rule_sep_string;
+}
+
+/**
+ * Merge user prettify configuration with defaults without mutating the input.
+ * @param {PrettifyConf} userConf - caller-provided prettify config
+ * @param {PrettifyConf} defaultConf - built-in defaults
+ * @returns {PrettifyConf} Normalized configuration containing every default key.
+ */
+export function normalizePrettifyConf(userConf, defaultConf) {
+    /** @type {PrettifyConf} */
+    const conf = {};
+
+    Object.keys(defaultConf).forEach(function (key) {
+        conf[key] = typeof userConf[key] === 'undefined' ? defaultConf[key] : userConf[key];
+    });
+
+    return conf;
+}
+
+/**
+ * Decide whether a prettified group may be reordered safely.
+ * @param {boolean} doneWithSelectorReordering - global one-way switch
+ * @param {Set<number>} rulesWithoutSelectorReordering - rule indices that must keep input order
+ * @param {number} nrule - current rule index
+ * @param {Array<PrettifyToken>} group - prettified_group_value array
+ * @returns {boolean} Whether the group can be safely reordered.
+ */
+export function shouldSortPrettifiedGroup(doneWithSelectorReordering, rulesWithoutSelectorReordering, nrule, group) {
+    return !doneWithSelectorReordering
+        && !rulesWithoutSelectorReordering.has(nrule)
+        && !hasCommentSelector(group);
+}
+
+/**
+ * Resolve localized month/weekday names, memoized by locale/date format.
+ * @param {PrettifyConf} conf - Prettify configuration
+ * @param {'weekday'|'month'} kind - Name kind to resolve
+ * @param {string[]} canonicalWeekdays - Canonical weekday names
+ * @param {string[]} canonicalMonths - Canonical month names
+ * @returns {string[]} Localized names with stable index mapping
+ */
+function getLocalizedNames(conf, kind, canonicalWeekdays, canonicalMonths) {
+    const useEnglishShortNames =
+        (conf['locale'] === 'en' || conf['locale'] === 'all') && conf['date_format'] === 'short';
+    if (useEnglishShortNames) {
+        return kind === 'weekday' ? canonicalWeekdays : canonicalMonths;
+    }
+
+    const cache_key = kind + '|' + conf['locale'] + '|' + conf['date_format'];
+    if (!localized_name_cache[cache_key]) {
+        localized_name_cache[cache_key] = kind === 'weekday'
+            // 2026-02-01 is a Sunday, so day 1..7 maps to Su..Sa.
+            ? [1, 2, 3, 4, 5, 6, 7].map(function (weekday) {
+                return new Date(2026, 1, weekday).toLocaleString(conf['locale'], { weekday: conf['date_format'], calendar: 'gregory' });
+            })
+            // The year is arbitrary; only the month index affects the name.
+            : [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].map(function (month) {
+                return new Date(2026, month - 1, 1).toLocaleString(conf['locale'], { month: conf['date_format'], calendar: 'gregory' });
+            });
+    }
+
+    return localized_name_cache[cache_key];
+}
+
+/**
+ * Translate a single prettify token by type.
+ * @param {string|number} value - Token value (index for month/weekday)
+ * @param {string} token_type - Token type
+ * @param {PrettifyConf} conf - Prettify configuration
+ * @param {string[]} canonicalWeekdays - Canonical weekday names
+ * @param {string[]} canonicalMonths - Canonical month names
+ * @param {function(string, string, string|number): (string|number)} translateFn - i18n translate function
+ * @returns {string|number} Translated token output
+ */
+function translatePrettyToken(value, token_type, conf, canonicalWeekdays, canonicalMonths, translateFn) {
+    if (token_type === 'weekday') {
+        return getLocalizedNames(conf, 'weekday', canonicalWeekdays, canonicalMonths)[Number(value)];
+    }
+
+    if (token_type === 'month') {
+        return getLocalizedNames(conf, 'month', canonicalWeekdays, canonicalMonths)[Number(value)];
+    }
+
+    if (typeof conf['locale'] !== 'string' || conf['locale'] === 'en') {
+        return value;
+    }
+
+    return translateFn(conf['locale'], 'pretty', value);
+}
+
+/**
+ * Check whether token types match at a given position.
+ *
+ * Matches are strict and ordered: each provided token name must equal
+ * the token type at `tokens[at + i][1]`.
+ * @param {PrettifyTokens} tokens - Token list in parser/prettify format
+ * @param {number} at - Start index for matching
+ * @param {...string} tokenNames - Expected token type names in order
+ * @returns {boolean} Whether all requested token types match.
+ */
+export function matchTokens(tokens, at, ...tokenNames) {
+    if (at + tokenNames.length > tokens.length) {
+        return false;
+    }
+
+    for (let i = 0; i < tokenNames.length; i++) {
+        if (tokens[at + i][1] !== tokenNames[i]) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+/**
+ * Check whether a malformed leading time separator must be preserved.
+ * @param {PrettifyTokens} tokens - Token list in parser/prettify format
+ * @param {number} selector_start - First token index of the selector
+ * @param {string} selector_type - Selector type
+ * @returns {boolean} Whether the malformed prefix should be preserved.
+ */
+function shouldPreserveLeadingMalformedTimePrefix(tokens, selector_start, selector_type) {
+    return selector_type === 'time'
+        && selector_start > 1
+        && matchTokens(tokens, selector_start - 1, 'timesep')
+        && matchTokens(tokens, selector_start, 'number')
+        && (matchTokens(tokens, selector_start - 2, 'rule separator')
+            || matchTokens(tokens, selector_start - 2, ','));
+}
+
+/**
+ * Format one token while prettifying a selector.
+ * @param {string} prettifiedValue - Current output string
+ * @param {PrettifyTokens} tokens - Token list
+ * @param {number} at - Current token index
+ * @param {number} selector_start - First token index of the selector
+ * @param {number} selector_end - Last token index of the selector
+ * @param {string} selector_type - Selector type
+ * @param {PrettifyConf} conf - Prettify configuration
+ * @param {string[]} canonicalMonths - Canonical month names
+ * @param {string[]} canonicalWeekdays - Canonical weekday names
+ * @param {function(string, string, string|number): (string|number)} translateFn - i18n translate function
+ * @returns {{ value: string, advance: number }} Formatted output and token advance.
+ */
+export function formatPrettifySelectorToken(
+    prettifiedValue,
+    tokens,
+    at,
+    selector_start,
+    selector_end,
+    selector_type,
+    conf,
+    canonicalMonths,
+    canonicalWeekdays,
+    translateFn
+) {
+    let value = prettifiedValue;
+    let advance = 0;
+    const token_value = tokens[at][0];
+    const token_type = tokens[at][1];
+
+    if (at === selector_start && shouldPreserveLeadingMalformedTimePrefix(tokens, selector_start, selector_type)) {
+        value += ':';
+    }
+
+    if (matchTokens(tokens, at, 'weekday')) {
+        if (!conf.leave_weekday_sep_one_day_betw
+            && at - selector_start > 1 && (matchTokens(tokens, at - 1, ',') || matchTokens(tokens, at - 1, '-'))
+            && matchTokens(tokens, at - 2, 'weekday')
+            && tokens[at][0] === (tokens[at - 2][0] + 1) % 7) {
+            value = value.substring(0, value.length - 1) + conf.sep_one_day_between;
+        }
+        value += translatePrettyToken(token_value, 'weekday', conf, canonicalWeekdays, canonicalMonths, translateFn);
+    } else if (at - selector_start > 0 // e.g. '09:0' -> '09:00'
+            && selector_type === 'time'
+            && matchTokens(tokens, at - 1, 'timesep')
+            && matchTokens(tokens, at, 'number')) {
+        value += (tokens[at][0] < 10 ? '0' : '') + tokens[at][0].toString();
+    } else if (selector_type === 'time' // e.g. '9:00' -> ' 09:00'
+            && conf.zero_pad_hour
+            && at !== tokens.length
+            && matchTokens(tokens, at, 'number')
+            && matchTokens(tokens, at + 1, 'timesep')) {
+        value += (
+                tokens[at][0] < 10 ?
+                    (tokens[at][0] === 0 && conf.one_zero_if_hour_zero ?
+                     '' : '0') :
+                    '') + tokens[at][0].toString();
+    } else if (selector_type === 'time' // e.g. '9-18' -> '09:00-18:00'
+            && at + 2 <= selector_end
+            && matchTokens(tokens, at, 'number')
+            && matchTokens(tokens, at + 1, '-')
+            && matchTokens(tokens, at + 2, 'number')
+            && tokens[at][0] !== tokens[at + 2][0]) {
+        value += (tokens[at][0] < 10 ?
+                (tokens[at][0] === 0 && conf.one_zero_if_hour_zero ? '' : '0')
+                : '') + tokens[at][0].toString();
+        value += ':00-'
+            + (tokens[at + 2][0] < 10 ? '0' : '') + tokens[at + 2][0].toString()
+            + ':00';
+        advance = 2;
+    } else if (matchTokens(tokens, at, 'comment')) {
+        value += '"' + tokens[at][0].toString() + '"';
+    } else if (matchTokens(tokens, at, 'closed')) {
+        value += translatePrettyToken(conf.leave_off_closed ? token_value : conf.keyword_for_off_closed,
+            'state', conf, canonicalWeekdays, canonicalMonths, translateFn);
+    } else if (at - selector_start > 0 && matchTokens(tokens, at, 'number')
+            && (selector_type === 'month' || selector_type === 'week')) {
+        value +=
+            (matchTokens(tokens, at - 1, 'month') || matchTokens(tokens, at - 1, 'week') ? ' ' : '')
+            + (conf.zero_pad_month_and_week_numbers && tokens[at][4] !== 'positive_number' && tokens[at][0] < 10 ? '0' : '')
+            + tokens[at][0];
+    } else if (at - selector_start > 0 && matchTokens(tokens, at, 'month')
+            && matchTokens(tokens, at - 1, 'year')) {
+        value += ' ' + translatePrettyToken(token_value, 'month', conf, canonicalWeekdays, canonicalMonths, translateFn);
+    } else if (at - selector_start > 0 && matchTokens(tokens, at, 'event')
+            && matchTokens(tokens, at - 1, 'year')) {
+        value += ' ' + tokens[at][0];
+    } else if (matchTokens(tokens, at, 'month')) {
+        if (conf.day_before_month && at + 1 <= selector_end && matchTokens(tokens, at + 1, 'number')) {
+            value += tokens[at + 1][0] + conf.day_month_sep
+                + translatePrettyToken(token_value, 'month', conf, canonicalWeekdays, canonicalMonths, translateFn);
+            advance = 1;
+        } else {
+            value += translatePrettyToken(token_value, 'month', conf, canonicalWeekdays, canonicalMonths, translateFn);
+            if (at + 1 <= selector_end && matchTokens(tokens, at + 1, 'weekday')) {
+                value += ' ';
+            }
+        }
+    } else if (at + 2 <= selector_end
+            && (matchTokens(tokens, at, '-') || matchTokens(tokens, at, '+'))
+            && matchTokens(tokens, at + 1, 'number', 'calcday')) {
+        value += ' ' + tokens[at][0] + tokens[at + 1][0] + ' day' + (Math.abs(tokens[at + 1][0]) === 1 ? '' : 's');
+        advance = 2;
+    } else if (at === selector_end
+            && selector_type === 'weekday'
+            && tokens[at][0] === ':') {
+        // Do nothing.
+    } else if (at === selector_end
+            && selector_type === 'time'
+            && tokens[at][0] === ',') {
+        /* Remove trailing , which is ignored in parseTimeRange. */
+    } else {
+        value += translatePrettyToken(token_value.toString(), token_type, conf, canonicalWeekdays, canonicalMonths, translateFn);
+    }
+
+    return { value, advance };
+}

--- a/test/unit/prettify-helpers.test.mjs
+++ b/test/unit/prettify-helpers.test.mjs
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: © opening_hours.js contributors
+// SPDX-License-Identifier: LGPL-3.0-only
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+    compareSelectorOrder,
+    formatPrettifySelectorToken,
+    getRuleSeparator,
+    matchTokens,
+    normalizePrettifyConf,
+    shouldSortPrettifiedGroup,
+} from '../../src/prettify-helpers.mjs';
+
+const canonicalMonths = ['Jan', 'Feb', 'Mar'];
+const canonicalWeekdays = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
+const translate = (locale, category, value) => `${locale}:${category}:${value}`;
+
+const format = (tokens, selectorType, conf = {}) => formatPrettifySelectorToken(
+    '',
+    tokens,
+    0,
+    0,
+    tokens.length - 1,
+    selectorType,
+    {
+        leave_weekday_sep_one_day_between: false,
+        zero_pad_hour: true,
+        one_zero_if_hour_zero: false,
+        zero_pad_month_and_week_numbers: true,
+        leave_off_closed: false,
+        keyword_for_off_closed: 'off',
+        ...conf,
+    },
+    canonicalMonths,
+    canonicalWeekdays,
+    translate,
+);
+
+test('normalizePrettifyConf applies defaults without mutating input', () => {
+    const userConf = { locale: 'de' };
+    const defaults = { locale: 'en', date_format: 'short' };
+
+    assert.deepEqual(normalizePrettifyConf(userConf, defaults), {
+        locale: 'de',
+        date_format: 'short',
+    });
+    assert.deepEqual(userConf, { locale: 'de' });
+});
+
+test('matchTokens requires an exact ordered token sequence', () => {
+    const tokens = [[1, 'number'], [':', 'timesep']];
+
+    assert.equal(matchTokens(tokens, 0, 'number', 'timesep'), true);
+    assert.equal(matchTokens(tokens, 0, 'timesep'), false);
+    assert.equal(matchTokens(tokens, 1, 'timesep', 'number'), false);
+});
+
+test('getRuleSeparator preserves additional-rule and semicolon separators', () => {
+    const conf = { rule_sep_string: ' ' , print_semicolon: true };
+
+    assert.equal(getRuleSeparator([[], true], conf), ' || ');
+    assert.equal(getRuleSeparator([[['x', 'rule separator']]], conf), ', ');
+    assert.equal(getRuleSeparator([[['x', 'weekday']]], conf), '; ');
+});
+
+test('formatPrettifySelectorToken formats shorthand time ranges', () => {
+    assert.deepEqual(format([[9, 'number'], ['-', '-'], [18, 'number']], 'time'), {
+        value: '09:00-18:00',
+        advance: 2,
+    });
+});
+
+test('formatPrettifySelectorToken preserves malformed leading time separators', () => {
+    const tokens = [[';', 'rule separator'], [':', 'timesep'], [9, 'number']];
+
+    assert.equal(formatPrettifySelectorToken(
+        '',
+        tokens,
+        2,
+        2,
+        2,
+        'time',
+        { zero_pad_hour: true, one_zero_if_hour_zero: false },
+        canonicalMonths,
+        canonicalWeekdays,
+        translate,
+    ).value, ':9');
+});
+
+test('formatPrettifySelectorToken formats locale day before month', () => {
+    assert.equal(format([[2, 'month'], [6, 'number']], 'month', {
+        locale: 'de',
+        date_format: 'short',
+        day_before_month: true,
+        day_month_sep: '. ',
+    }).value, '6. Mär');
+});
+
+test('selector sorting honors comments and rule exclusions', () => {
+    const time = [[[0, 0, 'time'], '09:00']];
+    const weekday = [[[0, 0, 'weekday'], 'Mo']];
+    const comment = [[[0, 0, 'comment'], '"note"']];
+
+    assert.equal(compareSelectorOrder(time[0], weekday[0]) > 0, true);
+    assert.equal(shouldSortPrettifiedGroup(false, new Set(), 0, [time[0], weekday[0]]), true);
+    assert.equal(shouldSortPrettifiedGroup(false, new Set(), 0, [comment[0]]), false);
+    assert.equal(shouldSortPrettifiedGroup(false, new Set([0]), 0, [time[0]]), false);
+});


### PR DESCRIPTION
This change extracts some helper functions from `src/index.js` into a new file and introduces initial unit tests using `node:test`.

**Background:** `src/index.js` has grown very large. To improve maintainability, I think the logic should gradually be moved into smaller, self-contained testable modules. This is a small, incremental step in that direction.