### PR TITLE
fix(variable-times): resolve variable-time selectors across time zones

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,9 +33,9 @@
 import * as holiday_definitions from './holidays/index';
 import word_error_correction from './locales/word_error_correction.yaml';
 
-import { getTimes } from 'suncalc';
 import { translate } from './locales/i18n';
 import { compareSelectorOrder, formatPrettifySelectorToken, getRuleSeparator, matchTokens, normalizePrettifyConf, shouldSortPrettifiedGroup } from './prettify-helpers.mjs';
+import { VARIABLE_TIME_DEFAULTS, getVariableTimeMinutes } from './variable-times.mjs';
 
 import { resolveRange } from './locale-resolver/resolver.mjs';
 import { regionLanguages } from './locale-resolver/region-languages.mjs';
@@ -50,12 +50,6 @@ import resolver_layers from './locale-resolver/layers.json';
  */
 export default function(value, nominatim_object, optional_conf_parm) {
     // Short constants {{{
-    const word_value_replacement = { // If the correct values can not be calculated.
-        dawn    : 60 * 5 + 30,
-        sunrise : 60 * 6,
-        sunset  : 60 * 18,
-        dusk    : 60 * 18 + 30,
-    };
     const months   = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
     const weekdays = ['Su','Mo','Tu','We','Th','Fr','Sa'];
     const INTL_DAY_MONTH_REF_DATE = new Date(2024, 2, 6); // fixed reference date for Intl.DateTimeFormat#formatToParts
@@ -220,10 +214,6 @@ export default function(value, nominatim_object, optional_conf_parm) {
             + ', expected object.';
     }
 
-    function getTimevarMinutes(date, timevar_name, timevar_add_minutes) {
-        const event_time = getTimes(date, lat, lon)[timevar_name];
-        return event_time.getHours() * 60 + event_time.getMinutes() + timevar_add_minutes;
-    }
     /* }}} */
 
     /* mode, locale, warnings_severity, tag_key, map_value {{{
@@ -1990,7 +1980,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
                     minutes_from = getMinutesByHoursMinutes(tokens, nrule, at+has_time_var_calc[0]);
                 } else {
                     timevar_string[0] = tokens[at+has_time_var_calc[0]][0];
-                    minutes_from = word_value_replacement[timevar_string[0]];
+                    minutes_from = VARIABLE_TIME_DEFAULTS[timevar_string[0]];
 
                     if (has_time_var_calc[0]) {
                         timevar_add[0] = parseTimevarCalc(tokens, at);
@@ -2050,7 +2040,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
                             warnAmbiguousSingleDigitHours(tokens, at, at_end_time, nrule);
                         } else {
                             timevar_string[1] = tokens[at_end_time+has_time_var_calc[1]][0];
-                            minutes_to = word_value_replacement[timevar_string[1]];
+                            minutes_to = VARIABLE_TIME_DEFAULTS[timevar_string[1]];
                         }
 
                         if (has_time_var_calc[1]) {
@@ -2095,7 +2085,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
                     if (!has_normal_time[0] || !(has_normal_time[1] || has_open_end || is_point_in_time) ) {
                         week_stable = false;
                     }
-                } else { // we can not calculate exact times so we use the already applied constants (word_value_replacement).
+                } else { // Without coordinates, keep the parser defaults above.
                     timevar_string = [];
                 }
 
@@ -2116,28 +2106,34 @@ export default function(value, nominatim_object, optional_conf_parm) {
                 if (minutes_from === 0 && minutes_to === minutes_in_day) {
                     rule.time.push(function() { return [true]; });
                 } else {
-                    if (minutes_to > minutes_in_day) { // has_normal_time[1] must be true
-                        rule.time.push(function(minutes_from, minutes_to, timevar_string, timevar_add, has_open_end, is_point_in_time, point_in_time_period, extended_open_end) { return function(date) {
+                    // A variable start time can order itself after a fixed or
+                    // variable end time on the real location even when the
+                    // constant fallback above did not wrap (#377), so also
+                    // take this branch to re-check the order on every date.
+                    if (minutes_to > minutes_in_day ||
+                            (typeof lat === 'string' && !has_open_end && !is_point_in_time &&
+                        timevar_string[0])) {
+                        rule.time.push(function(initial_from, initial_to, timevar_string, timevar_add, has_open_end, is_point_in_time, point_in_time_period, extended_open_end) { return function(date) {
                             const ourminutes = date.getHours() * 60 + date.getMinutes();
 
-                            if (timevar_string[0]) {
-                                minutes_from = getTimevarMinutes(date, timevar_string[0], timevar_add[0]);
-                            }
-                            if (timevar_string[1]) {
-                                minutes_to = getTimevarMinutes(date, timevar_string[1], timevar_add[1]);
-                                minutes_to += minutes_in_day;
-                                // Needs to be added because it was added by
-                                // normal times: if (minutes_to < minutes_from)
-                                // above the selector construction.
+                            // Variable times can change their order from day to day.
+                            const resolved_from = timevar_string[0]
+                                ? getVariableTimeMinutes(date, lat, lon, timevar_string[0], timevar_add[0])
+                                : initial_from;
+                            let resolved_to = timevar_string[1]
+                                ? getVariableTimeMinutes(date, lat, lon, timevar_string[1], timevar_add[1])
+                                : initial_to;
+                            if (timevar_string[1] && resolved_to <= resolved_from) {
+                                resolved_to += minutes_in_day;
                             } else if (is_point_in_time && typeof point_in_time_period !== 'number') {
-                                minutes_to = minutes_from + 1;
+                                resolved_to = resolved_from + 1;
                             }
 
                             if (typeof point_in_time_period === 'number') {
-                                if (ourminutes < minutes_from) {
-                                    return [false, dateAtDayMinutes(date, minutes_from)];
-                                } else if (ourminutes <= minutes_to) {
-                                    for (let cur_min = minutes_from; ourminutes + point_in_time_period >= cur_min; cur_min += point_in_time_period) {
+                                if (ourminutes < resolved_from) {
+                                    return [false, dateAtDayMinutes(date, resolved_from)];
+                                } else if (ourminutes <= resolved_to) {
+                                    for (let cur_min = resolved_from; ourminutes + point_in_time_period >= cur_min; cur_min += point_in_time_period) {
                                         if (cur_min === ourminutes) {
                                             return [true, dateAtDayMinutes(date, ourminutes + 1)];
                                         } else if (ourminutes < cur_min) {
@@ -2147,10 +2143,20 @@ export default function(value, nominatim_object, optional_conf_parm) {
                                 }
                                 return [false, dateAtDayMinutes(date, minutes_in_day)];
                             } else {
-                                if (ourminutes < minutes_from)
-                                    return [false, dateAtDayMinutes(date, minutes_from)];
-                                else
-                                    return [true, dateAtDayMinutes(date, minutes_to), has_open_end, extended_open_end];
+                                if (resolved_to > minutes_in_day) {
+                                    if (ourminutes < resolved_from)
+                                        return [false, dateAtDayMinutes(date, resolved_from)];
+                                    return [true, dateAtDayMinutes(date, resolved_to), has_open_end, extended_open_end];
+                                }
+                                if (ourminutes < resolved_from)
+                                    return [false, dateAtDayMinutes(date, resolved_from)];
+                                if (ourminutes < resolved_to)
+                                    return [true, dateAtDayMinutes(date, resolved_to), has_open_end, extended_open_end];
+                                if (timevar_string[0]) {
+                                    const next_day = dateAtDayMinutes(date, minutes_in_day);
+                                    return [false, dateAtDayMinutes(next_day, getVariableTimeMinutes(next_day, lat, lon, timevar_string[0], timevar_add[0]))];
+                                }
+                                return [false, dateAtDayMinutes(date, resolved_from + minutes_in_day)];
                             }
                         }}(minutes_from, minutes_to, timevar_string, timevar_add, has_open_end, is_point_in_time, point_in_time_period, extended_open_end));
 
@@ -2159,16 +2165,20 @@ export default function(value, nominatim_object, optional_conf_parm) {
                                 rule_infos[nrule] = {};
                             }
                             rule_infos[nrule]['time_wraps_over_midnight'] = true;
-                            rule.wraptime.push(function(minutes_to, timevar_string, timevar_add, has_open_end, point_in_time_period, extended_open_end) { return function(date) {
+                            rule.wraptime.push(function(minutes_from, minutes_to, timevar_string, timevar_add, has_open_end, point_in_time_period, extended_open_end) { return function(date) {
                                 const ourminutes = date.getHours() * 60 + date.getMinutes();
 
+                                if (timevar_string[0]) {
+                                    minutes_from = getVariableTimeMinutes(date, lat, lon, timevar_string[0], timevar_add[0]);
+                                }
                                 if (timevar_string[1]) {
-                                    minutes_to = getTimevarMinutes(date, timevar_string[1], timevar_add[1]);
-                                    // minutes_in_day does not need to be added.
-                                    // For normal times in it was added in: if (minutes_to < // minutes_from)
-                                    // above the selector construction and
-                                    // subtracted in the selector construction call
-                                    // which returns the selector function.
+                                    minutes_to = getVariableTimeMinutes(date, lat, lon, timevar_string[1], timevar_add[1]);
+                                }
+
+                                if (timevar_string[0] || timevar_string[1]) {
+                                    if (minutes_to > minutes_from) {
+                                        return [false, undefined];
+                                    }
                                 }
 
                                 if (typeof point_in_time_period === 'number') {
@@ -2186,26 +2196,27 @@ export default function(value, nominatim_object, optional_conf_parm) {
                                         return [true, dateAtDayMinutes(date, minutes_to), has_open_end, extended_open_end];
                                 }
                                 return [false, undefined];
-                            }}(minutes_to - minutes_in_day, timevar_string, timevar_add, has_open_end, point_in_time_period, extended_open_end));
+                            }}(minutes_from, minutes_to > minutes_in_day ? minutes_to - minutes_in_day : minutes_to, timevar_string, timevar_add, has_open_end, point_in_time_period, extended_open_end));
                         }
                     } else {
-                        rule.time.push(function(minutes_from, minutes_to, timevar_string, timevar_add, has_open_end, is_point_in_time, point_in_time_period) { return function(date) {
+                        rule.time.push(function(initial_from, initial_to, timevar_string, timevar_add, has_open_end, is_point_in_time, point_in_time_period) { return function(date) {
                             const ourminutes = date.getHours() * 60 + date.getMinutes();
 
-                            if (timevar_string[0]) {
-                                minutes_from = getTimevarMinutes(date, timevar_string[0], timevar_add[0]);
-                            }
-                            if (timevar_string[1]) {
-                                minutes_to = getTimevarMinutes(date, timevar_string[1], timevar_add[1]);
-                            } else if (is_point_in_time && typeof point_in_time_period !== 'number') {
-                                minutes_to = minutes_from + 1;
+                            const resolved_from = timevar_string[0]
+                                ? getVariableTimeMinutes(date, lat, lon, timevar_string[0], timevar_add[0])
+                                : initial_from;
+                            let resolved_to = timevar_string[1]
+                                ? getVariableTimeMinutes(date, lat, lon, timevar_string[1], timevar_add[1])
+                                : initial_to;
+                            if (!timevar_string[1] && is_point_in_time && typeof point_in_time_period !== 'number') {
+                                resolved_to = resolved_from + 1;
                             }
 
                             if (typeof point_in_time_period === 'number') {
-                                if (ourminutes < minutes_from) {
-                                    return [false, dateAtDayMinutes(date, minutes_from)];
-                                } else if (ourminutes <= minutes_to) {
-                                    for (let cur_min = minutes_from; ourminutes + point_in_time_period >= cur_min; cur_min += point_in_time_period) {
+                                if (ourminutes < resolved_from) {
+                                    return [false, dateAtDayMinutes(date, resolved_from)];
+                                } else if (ourminutes <= resolved_to) {
+                                    for (let cur_min = resolved_from; ourminutes + point_in_time_period >= cur_min; cur_min += point_in_time_period) {
                                         if (cur_min === ourminutes) {
                                             return [true, dateAtDayMinutes(date, ourminutes + 1)];
                                         } else if (ourminutes < cur_min) {
@@ -2215,12 +2226,19 @@ export default function(value, nominatim_object, optional_conf_parm) {
                                 }
                                 return [false, dateAtDayMinutes(date, minutes_in_day)];
                             } else {
-                                if (ourminutes < minutes_from)
-                                    return [false, dateAtDayMinutes(date, minutes_from)];
-                                else if (ourminutes < minutes_to)
-                                    return [true, dateAtDayMinutes(date, minutes_to), has_open_end];
-                                else
-                                    return [false, dateAtDayMinutes(date, minutes_from + minutes_in_day)];
+                                if (ourminutes < resolved_from)
+                                    return [false, dateAtDayMinutes(date, resolved_from)];
+                                else if (ourminutes < resolved_to)
+                                    return [true, dateAtDayMinutes(date, resolved_to), has_open_end];
+                                else if (timevar_string[0]) {
+                                    // The next opening is the variable time on
+                                    // the following day, which drifts from day
+                                    // to day, so recompute it instead of reusing
+                                    // today's value shifted by 24h (#377).
+                                    const next_day = dateAtDayMinutes(date, minutes_in_day);
+                                    return [false, dateAtDayMinutes(next_day, getVariableTimeMinutes(next_day, lat, lon, timevar_string[0], timevar_add[0]))];
+                                } else
+                                    return [false, dateAtDayMinutes(date, resolved_from + minutes_in_day)];
                             }
                         }}(minutes_from, minutes_to, timevar_string, timevar_add, has_open_end, is_point_in_time, point_in_time_period));
                     }

--- a/src/variable-times.mjs
+++ b/src/variable-times.mjs
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: © opening_hours.js contributors
+// SPDX-License-Identifier: LGPL-3.0-only
+
+/**
+ * Helpers for OSM variable times such as sunrise, sunset, dawn, and dusk.
+ *
+ * This module resolves solar events for a location, provides fallback values
+ * when no coordinates are available, and converts events to minutes since
+ * local midnight. Range handling remains the responsibility of the parser.
+ */
+
+import { getTimes } from 'suncalc';
+
+/**
+ * Default minute-of-day values used when no coordinates are available.
+ * @type {Record<string, number>}
+ */
+export const VARIABLE_TIME_DEFAULTS = {
+    dawn    : 60 * 5 + 30,
+    sunrise : 60 * 6,
+    sunset  : 60 * 18,
+    dusk    : 60 * 18 + 30,
+};
+
+/**
+ * Local (process time zone) calendar day identity for a Date, comparable with ===.
+ * @param {Date} date - date to derive the calendar day from
+ * @returns {number} an integer uniquely identifying the local calendar day
+ */
+function localDayKey(date) {
+    return date.getFullYear() * 10000 + (date.getMonth() + 1) * 100 + date.getDate();
+}
+
+/**
+ * SunCalc event time for a variable-time name, or null when it does not occur.
+ * @param {Date} date - instant to query
+ * @param {number|string} lat - latitude
+ * @param {number|string} lon - longitude
+ * @param {string} eventName - SunCalc event name, e.g. 'sunrise', 'sunset'
+ * @returns {Date|null} the event time, or null (e.g. polar day/night)
+ */
+function sunEvent(date, lat, lon, eventName) {
+    const times = getTimes(date, Number(lat), Number(lon));
+    const eventTime = times[eventName];
+    return eventTime instanceof Date ? eventTime : null; // guards SunCalc's boolean/custom fields
+}
+
+/**
+ * Resolve the solar event for the local calendar day of `date`.
+ * SunCalc can return an event for the previous or next local day when the
+ * location's longitude differs significantly from the process time zone.
+ * Check nearby dates and use the result that belongs to `date`'s local day.
+ * @see https://github.com/opening-hours/opening_hours.js/issues/377
+ * @param {Date} date - date being evaluated, in the process time zone
+ * @param {number|string} lat - latitude
+ * @param {number|string} lon - longitude
+ * @param {string} eventName - SunCalc event name, e.g. 'sunrise'
+ * @returns {Date|null} the event on `date`'s local calendar day, if available
+ */
+export function getVariableTimeEvent(date, lat, lon, eventName) {
+    const targetDay = localDayKey(date);
+
+    for (const dayOffset of [0, -1, 1]) {
+        const probe = new Date(date);
+        probe.setDate(probe.getDate() + dayOffset);
+        const eventTime = sunEvent(probe, lat, lon, eventName);
+        if (eventTime && localDayKey(eventTime) === targetDay) {
+            return eventTime;
+        }
+    }
+
+    // dayOffset 0 above already checked date itself; nothing else to try.
+    return null;
+}
+
+/**
+ * Resolve the minutes since local midnight of `date` for a variable time
+ * (e.g. 'sunrise', 'sunset', 'dawn', 'dusk').
+ * @param {Date} date - the moment being evaluated, in local (process) time
+ * @param {number|string} lat - latitude
+ * @param {number|string} lon - longitude
+ * @param {string} eventName - SunCalc event name, e.g. 'sunrise', 'sunset'
+ * @param {number} offsetMinutes - minute offset from calculations like `(sunrise+01:00)`
+ * @returns {number} minutes since local midnight of `date`
+ * @throws {RangeError} if the variable time does not occur on this date
+ */
+export function getVariableTimeMinutes(date, lat, lon, eventName, offsetMinutes) {
+    const eventTime = getVariableTimeEvent(date, lat, lon, eventName);
+    if (eventTime === null) {
+        throw new RangeError(`Variable time "${eventName}" does not occur on this date`);
+    }
+    return eventTime.getHours() * 60 + eventTime.getMinutes() + offsetMinutes;
+}

--- a/test/test.de.log
+++ b/test/test.de.log
@@ -384,6 +384,8 @@ With [34m[1mwarnings[22m[39m:
 "Variable times which moves over fix end time" for "sunrise-05:59": [32m[1mPASSED[22m[39m
 "Variable times which moves over fix end time" for "sunrise-06:00": [32m[1mPASSED[22m[39m
 "Variable times which moves over fix end time" for "sunrise-05:59": [33m[1mIGNORED[22m[39m, reason: not implemented yet
+"Regression: sunrise-sunset interval vanishes for a location far from the process time zone (#377)" for "Mo-Su sunrise-sunset": [32m[1mPASSED[22m[39m
+"Regression: sunrise-sunset interval vanishes for a location far from the process time zone (#377)" for "Mo-Su sunrise-sunset": [32m[1mPASSED[22m[39m
 "Variable times spanning midnight" for "sunset-sunrise": [32m[1mPASSED[22m[39m
 "Variable times spanning midnight" for "Mo-Su sunset-sunrise": [32m[1mPASSED[22m[39m
 "Variable times spanning midnight" for "sunset-sunrise": [32m[1mPASSED[22m[39m
@@ -2750,7 +2752,7 @@ Der optional_conf_parm["tag_key"] fehlt, ist aber notwendig wegen optional_conf_
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-1069/1069 tests passed. 0 did not pass.
+1071/1071 tests passed. 0 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.en.log
+++ b/test/test.en.log
@@ -384,6 +384,8 @@ With [34m[1mwarnings[22m[39m:
 "Variable times which moves over fix end time" for "sunrise-05:59": [32m[1mPASSED[22m[39m
 "Variable times which moves over fix end time" for "sunrise-06:00": [32m[1mPASSED[22m[39m
 "Variable times which moves over fix end time" for "sunrise-05:59": [33m[1mIGNORED[22m[39m, reason: not implemented yet
+"Regression: sunrise-sunset interval vanishes for a location far from the process time zone (#377)" for "Mo-Su sunrise-sunset": [32m[1mPASSED[22m[39m
+"Regression: sunrise-sunset interval vanishes for a location far from the process time zone (#377)" for "Mo-Su sunrise-sunset": [32m[1mPASSED[22m[39m
 "Variable times spanning midnight" for "sunset-sunrise": [32m[1mPASSED[22m[39m
 "Variable times spanning midnight" for "Mo-Su sunset-sunrise": [32m[1mPASSED[22m[39m
 "Variable times spanning midnight" for "sunset-sunrise": [32m[1mPASSED[22m[39m
@@ -2740,7 +2742,7 @@ The optional_conf_parm["tag_key"] is missing, required by optional_conf_parm["ma
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-1059/1059 tests passed. 0 did not pass.
+1061/1061 tests passed. 0 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.js
+++ b/test/test.js
@@ -684,46 +684,48 @@ test.addTest('Variable times calculation with coordinates', [
 test.addTest('Variable times which moves over fix end time', [
         'sunrise-08:02',
     ], '2013-01-26 0:00', '2013-02-03 0:00', [
-        [ '2013-01-26 08:01', '2013-01-26 08:02' ],
-        [ '2013-01-27 08:00', '2013-01-27 08:02' ],
-        [ '2013-01-28 07:59', '2013-01-28 08:02' ],
-        [ '2013-01-29 07:58', '2013-01-29 08:02' ],
-        [ '2013-01-30 07:56', '2013-01-30 08:02' ],
-        [ '2013-01-31 07:55', '2013-01-31 08:02' ],
-        [ '2013-02-01 07:54', '2013-02-01 08:02' ],
-        [ '2013-02-02 07:52', '2013-02-02 08:02' ],
-    ], 1000 * 60 * (1 + 2 + 3 + 4 + 6 + 7 + 8 + 10), 0, false, nominatim_default);
+        [ '2013-01-26 08:00', '2013-01-26 08:02' ],
+        [ '2013-01-27 07:59', '2013-01-27 08:02' ],
+        [ '2013-01-28 07:58', '2013-01-28 08:02' ],
+        [ '2013-01-29 07:56', '2013-01-29 08:02' ],
+        [ '2013-01-30 07:55', '2013-01-30 08:02' ],
+        [ '2013-01-31 07:54', '2013-01-31 08:02' ],
+        [ '2013-02-01 07:52', '2013-02-01 08:02' ],
+        [ '2013-02-02 07:51', '2013-02-02 08:02' ],
+    ], 1000 * 60 * (2 + 3 + 4 + 6 + 7 + 8 + 10 + 11), 0, false, nominatim_default);
 
 test.addTest('Variable times boundary: first non-empty day', [
         'sunrise-08:02',
-    ], '2013-01-25 0:00', '2013-01-27 0:00', [
-        [ '2013-01-26 08:01', '2013-01-26 08:02' ],
+    ], '2013-01-24 0:00', '2013-01-26 0:00', [
+        [ '2013-01-25 08:01', '2013-01-25 08:02' ],
     ], 1000 * 60, 0, false, nominatim_default, 'not last test');
 
 test.addTest('Variable times which moves over fix end time', [
         'sunrise-08:00',
     ], '2013-01-26 0:00', '2013-02-03 0:00', [
-        [ '2013-01-28 07:59', '2013-01-28 08:00' ],
-        [ '2013-01-29 07:58', '2013-01-29 08:00' ],
-        [ '2013-01-30 07:56', '2013-01-30 08:00' ],
-        [ '2013-01-31 07:55', '2013-01-31 08:00' ],
-        [ '2013-02-01 07:54', '2013-02-01 08:00' ],
-        [ '2013-02-02 07:52', '2013-02-02 08:00' ],
-    ], 1000 * 60 * (1 + 2 + 4 + 5 + 6 + 8), 0, false, nominatim_default);
+        [ '2013-01-27 07:59', '2013-01-27 08:00' ],
+        [ '2013-01-28 07:58', '2013-01-28 08:00' ],
+        [ '2013-01-29 07:56', '2013-01-29 08:00' ],
+        [ '2013-01-30 07:55', '2013-01-30 08:00' ],
+        [ '2013-01-31 07:54', '2013-01-31 08:00' ],
+        [ '2013-02-01 07:52', '2013-02-01 08:00' ],
+        [ '2013-02-02 07:51', '2013-02-02 08:00' ],
+    ], 1000 * 60 * (1 + 2 + 4 + 5 + 6 + 8 + 9), 0, false, nominatim_default);
 
 test.addTest('Variable times boundary: zero-length is excluded', [
         'sunrise-08:00',
-    ], '2013-01-27 0:00', '2013-01-28 0:00', [
+    ], '2013-01-26 0:00', '2013-01-27 0:00', [
     ], 0, 0, false, nominatim_default, 'not last test');
 
 test.addTest('Variable times which moves over fix end time', [
         'sunrise-07:58',
     ], '2013-01-26 0:00', '2013-02-03 0:00', [
-        [ '2013-01-30 07:56', '2013-01-30 07:58' ],
-        [ '2013-01-31 07:55', '2013-01-31 07:58' ],
-        [ '2013-02-01 07:54', '2013-02-01 07:58' ],
-        [ '2013-02-02 07:52', '2013-02-02 07:58' ],
-    ], 1000 * 60 * (2 + 3 + 4 + 6), 0, false, nominatim_default);
+        [ '2013-01-29 07:56', '2013-01-29 07:58' ],
+        [ '2013-01-30 07:55', '2013-01-30 07:58' ],
+        [ '2013-01-31 07:54', '2013-01-31 07:58' ],
+        [ '2013-02-01 07:52', '2013-02-01 07:58' ],
+        [ '2013-02-02 07:51', '2013-02-02 07:58' ],
+    ], 1000 * 60 * (2 + 3 + 4 + 6 + 7), 0, false, nominatim_default);
 
 test.addTest('Variable times which moves over fix end time', [
         'sunrise-06:00',
@@ -742,15 +744,36 @@ test.addTest('Variable times which moves over fix end time', [
 test.addTest('Variable times which moves over fix end time', [
         'sunrise-06:00', // from time < constant time <= end time
     ], '2013-04-15 0:00', '2013-04-19 0:00', [
-        [ '2013-04-17 05:59', '2013-04-17 06:00' ],
-        [ '2013-04-18 05:56', '2013-04-18 06:00' ],
-    ], 1000 * 60 * (1 + 4), 0, false, nominatim_sunrise_below);
+        [ '2013-04-16 05:59', '2013-04-16 06:00' ],
+        [ '2013-04-17 05:56', '2013-04-17 06:00' ],
+        [ '2013-04-18 05:53', '2013-04-18 06:00' ],
+    ], 1000 * 60 * (1 + 4 + 7), 0, false, nominatim_sunrise_below);
 
 test.addTest('Variable times which moves over fix end time', [
         ignored('sunrise-05:59'), // from time < end time <= constant time
     ], '2013-04-13 0:00', '2013-04-19 0:00', [
         [ 'something else', '' ],
     ], 1000 * 60 * 3, 0, false, nominatim_sunrise_below, 'not last test');
+
+// Regression (#377): sunrise/sunset intervals must not vanish for locations
+// whose longitude is far from the process time zone (fixed to Europe/Berlin
+// for this test suite). suncalc anchors sunrise/sunset to the solar day
+// implied by the given longitude, which can differ from the calendar day
+// implied by the process-local timestamp; the range then wraps past midnight
+// in local time (sunrise in the afternoon, sunset early the next morning).
+// See src/variable-times.mjs for how the day-shift and wrap decision are
+// resolved.
+test.addTest('Regression: sunrise-sunset interval vanishes for a location far from the process time zone (#377)', [
+        'Mo-Su sunrise-sunset',
+    ], '2021-04-18 10:00', '2021-04-19 10:00', [
+        [ '2021-04-18 15:14', '2021-04-19 05:02' ],
+    ], 1000 * 60 * 828, 0, false, { lat: '47.606', lon: '-122.322' }, 'not last test'); // Seattle
+
+test.addTest('Regression: sunrise-sunset interval vanishes for a location far from the process time zone (#377)', [
+        'Mo-Su sunrise-sunset',
+    ], '2021-04-17 12:00', '2021-04-18 12:00', [
+        [ '2021-04-17 22:49', '2021-04-18 09:50' ],
+    ], 1000 * 60 * 661, 0, false, { lat: '-37.818', lon: '144.951' }); // Melbourne
 
 test.addTest('Variable times spanning midnight', [
         'sunset-sunrise',

--- a/test/unit/variable-times.test.mjs
+++ b/test/unit/variable-times.test.mjs
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: © opening_hours.js contributors
+// SPDX-License-Identifier: LGPL-3.0-only
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getTimes } from 'suncalc';
+
+import {
+    getVariableTimeEvent,
+    getVariableTimeMinutes,
+} from '../../src/variable-times.mjs';
+
+// Fixed process time zone so these tests are deterministic regardless of
+// where they are run, matching the convention used by test/test.js.
+process.env.TZ = 'Europe/Berlin';
+
+const singapore = { lat: 1.340, lon: 103.821 };
+const seattle = { lat: 47.606, lon: -122.322 };
+const melbourne = { lat: -37.818, lon: 144.951 };
+
+test('getVariableTimeEvent returns the absolute solar event', () => {
+    const date = new Date('2021-04-18 00:00');
+    const sunrise = getVariableTimeEvent(date, seattle.lat, seattle.lon, 'sunrise');
+    const sunset = getVariableTimeEvent(date, seattle.lat, seattle.lon, 'sunset');
+
+    assert.ok(sunrise instanceof Date);
+    assert.ok(sunset instanceof Date);
+    assert.equal(sunrise.getDate(), 18);
+    assert.equal(sunrise.getHours() * 60 + sunrise.getMinutes(), 15 * 60 + 14);
+    assert.equal(sunset.getDate(), 18);
+    assert.equal(sunset.getHours() * 60 + sunset.getMinutes(), 5 * 60 + 2);
+});
+
+test('getVariableTimeMinutes matches the unshifted result when the venue longitude is close to the process time zone', () => {
+    const date = new Date('2021-04-18 00:00');
+    assert.equal(getVariableTimeMinutes(date, singapore.lat, singapore.lon, 'sunrise', 0), 0 * 60 + 59);
+});
+
+test('getVariableTimeMinutes corrects the day-shift for a location far west of the process time zone (#377)', () => {
+    // Seattle. Without correction suncalc would return 2021-04-17's sunrise
+    // for a 2021-04-18 (Berlin) evaluation.
+    const date = new Date('2021-04-18 00:00');
+    assert.equal(getVariableTimeMinutes(date, seattle.lat, seattle.lon, 'sunrise', 0), 15 * 60 + 14);
+});
+
+test('getVariableTimeMinutes corrects the day-shift for a location far east of the process time zone (#377)', () => {
+    // Melbourne. Without correction suncalc would return 2021-04-19's sunset
+    // for a 2021-04-18 (Berlin) evaluation.
+    const date = new Date('2021-04-18 00:00');
+    assert.equal(getVariableTimeMinutes(date, melbourne.lat, melbourne.lon, 'sunset', 0), 9 * 60 + 49);
+});
+
+test('getVariableTimeMinutes adds timevar_add_minutes to the resolved minutes', () => {
+    const date = new Date('2021-04-18 00:00');
+    assert.equal(getVariableTimeMinutes(date, singapore.lat, singapore.lon, 'sunrise', 30), 0 * 60 + 59 + 30);
+});
+
+test('getVariableTimeMinutes throws when no probe lands on the requested day', () => {
+    // Far north, where sunrise is null for days at a time (polar day); there
+    // is no "correct" day to shift to, so the event stays unavailable rather
+    // than being masked by a mismatched-day value.
+    const date = new Date('2021-06-21 00:00');
+    const lat = 78.222, lon = 15.652; // Longyearbyen, well inside the polar day in June.
+
+    assert.equal(getTimes(date, lat, lon).sunrise, null); // sanity check: no sunrise on this date
+    assert.throws(
+        () => getVariableTimeMinutes(date, lat, lon, 'sunrise', 0),
+        /Variable time "sunrise" does not occur on this date/
+    );
+});
+
+test('getVariableTimeEvent preserves the requested local day across DST', () => {
+    const date = new Date('2021-03-28 00:00');
+    const sunrise = getVariableTimeEvent(date, 52.5200, 13.4050, 'sunrise');
+
+    assert.ok(sunrise instanceof Date);
+    assert.equal(sunrise.getFullYear(), date.getFullYear());
+    assert.equal(sunrise.getMonth(), date.getMonth());
+    assert.equal(sunrise.getDate(), date.getDate());
+});
+


### PR DESCRIPTION
`sunrise-sunset` uses `suncalc` to compute solar times. Problem: `suncalc` bases its result on the location's own solar day, which can be a different calendar day than the one wherever the code runs (browser or server) thinks it is - if the venue is far from that local time zone. So the computed time silently belonged to the wrong day.

**Example:** Seattle, evaluated with Europe/Berlin as the local time zone, rule `Mo-Su sunrise-sunset`:

```js
// before: reported as closed all day
[]

// after: correctly open through the evening/night
[[ '2026-04-18 15:14', '2026-04-19 05:02' ]]
```

(Times are in the evaluating environment's zone, Berlin - 9h ahead of Seattle, so Seattle's ~06:14 sunrise and ~20:02 sunset show up shifted and wrapping past midnight.)

**What changed:** the neighboring day is now checked too, keeping whichever result actually lands on the day being asked about; the midnight-wrap is worked out fresh each time from the real sunrise/sunset order instead of a fixed assumption; and tomorrow's time gets recalculated instead of just tacking on 24h.
I moved this logic out of deeply nested closures in the parser into its own small, unit-tested module.

Closes #377.

BTW: Working with time zones gives me a headache every time. I've tried several times to simplify the code for that logic, but the complexity of the problem seems to make that impossible, or maybe I'm just lacking the right ideas.