### PR TITLE
Resolve the var-vs-const tokens TODO

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -294,7 +294,8 @@ export default function(value, nominatim_object, optional_conf_parm) {
         throw t('nothing');
     }
 
-    /** @typedef {[number, string, number] & { single_digit_lexeme?: boolean, meridian?: string }} ParserToken */
+    /** @typedef {[number|string, string, number] & { single_digit_lexeme?: boolean, meridian?: string }} ParserToken */
+    /** @typedef {[Array<ParserToken>, boolean, number?]} ParserTokenRule */
     const parsing_warnings = []; // Elements are arrays [nrule, at, type, message, tokens_to_use?] fed into formatWarnErrorMessage().
     let done_with_warnings = false; // The functions which returns warnings can be called multiple times.
     let done_with_selector_reordering = false;
@@ -302,7 +303,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
     // Rule indices for which prettify must keep the original selector order,
     // because reordering time/state would change the meaning (#596).
     const rules_without_selector_reordering = new Set();
-    /** @type {Array<unknown>} */
+    /** @type {Array<ParserTokenRule>} */
     const tokens = tokenize(value);
     // console.log(JSON.stringify(tokens, null, '    '));
     let prettified_value = '';
@@ -493,7 +494,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
      * @param {number|string} nrule Rule number starting with 0. `-1` means an
      *     error during tokenization; a string means the prettified value.
      * @param {number} at Token position. `-1` means the end of a rule.
-     * @param {Array<unknown>} [tokens_to_use] Token array, defaulting to `tokens`. Pass
+     * @param {Array<ParserTokenRule>} [tokens_to_use] Token array, defaulting to `tokens`. Pass
      *     `new_tokens` from `getWarnings()` because additional rules can make
      *     it longer than `tokens`.
      * @returns {{value: string, position: number|null}} The value the position
@@ -516,37 +517,39 @@ export default function(value, nominatim_object, optional_conf_parm) {
         }
 
         let pos;
-        if (typeof tokens_to_use[nrule] === 'undefined') {
+        const current_rule = tokens_to_use[nrule];
+        if (typeof current_rule === 'undefined') {
             // Caller passed the wrong token array (tokens instead of new_tokens?).
             formatLibraryBugMessage('Bug in warning generation code: tokens_to_use[nrule] is undefined for nrule=' + nrule + '.');
             pos = value.length;
-        } else if (typeof tokens_to_use[nrule][0][at] === 'undefined') {
-            if (typeof tokens_to_use[nrule][0] !== 'undefined' && at === -1) {
+        } else if (typeof current_rule[0][at] === 'undefined') {
+            if (at === -1) {
                 // at === -1: point to end of rule, use offset of next rule entry if available.
                 pos = value.length;
-                if (typeof tokens_to_use[nrule+1] === 'object' && typeof tokens_to_use[nrule+1][2] === 'number') {
-                    pos -= tokens_to_use[nrule+1][2];
-                } else if (typeof tokens_to_use[nrule][2] === 'number') {
-                    pos -= tokens_to_use[nrule][2];
+                const next_rule = tokens_to_use[nrule + 1];
+                if (typeof next_rule !== 'undefined' && typeof next_rule[2] === 'number') {
+                    pos -= next_rule[2];
+                } else if (typeof current_rule[2] === 'number') {
+                    pos -= current_rule[2];
                 }
             } else {
                 // Token position is out of range. Run real_test regularly to catch this.
                 formatLibraryBugMessage('Bug in warning generation code which could not determine the exact position of the warning or error in value.');
                 pos = value.length;
-                if (typeof tokens_to_use[nrule][2] === 'number') {
+                if (typeof current_rule[2] === 'number') {
                     // Fallback: point to last token in the rule which caused the problem.
-                    pos -= tokens_to_use[nrule][2];
-                    console.warn('Last token for rule: ' + JSON.stringify(tokens_to_use[nrule]));
+                    pos -= current_rule[2];
+                    console.warn('Last token for rule: ' + JSON.stringify(current_rule));
                 } else {
                     console.warn('tokens_to_use[nrule][2] is undefined. This is ok if nrule is the last rule.');
                 }
             }
         } else {
             pos = value.length;
-            if (typeof tokens_to_use[nrule][0][at+1] === 'object') {
-                pos -= tokens_to_use[nrule][0][at+1][2];
-            } else if (typeof tokens_to_use[nrule][2] === 'number') {
-                pos -= tokens_to_use[nrule][2];
+            if (typeof current_rule[0][at + 1] === 'object') {
+                pos -= current_rule[0][at + 1][2];
+            } else if (typeof current_rule[2] === 'number') {
+                pos -= current_rule[2];
             }
         }
         return { value: value, position: pos };
@@ -559,7 +562,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
      *     position refers to that value.
      * @param {number} at Token or character position to mark.
      * @param {string} message Human-readable warning or error message.
-     * @param {Array<unknown>} [tokens_to_use] Token array used to resolve the position.
+     * @param {Array<ParserTokenRule>} [tokens_to_use] Token array used to resolve the position.
      * @returns {string} Message with the position marker, or the original message
      *     when no position can be determined.
      */
@@ -597,7 +600,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
     /**
      * Tokenize an opening-hours input stream. {{{
      * @param {string} value Raw opening-hours value.
-     * @returns {Array<unknown>} Tokenized list. See the internal documentation in `docs/`.
+     * @returns {Array<ParserTokenRule>} Tokenized list. See the internal documentation in `docs/`.
      */
     function tokenize(value) {
         // Negative list approach: Match anything that's NOT punctuation, digits, or special chars

--- a/src/index.js
+++ b/src/index.js
@@ -302,8 +302,8 @@ export default function(value, nominatim_object, optional_conf_parm) {
     // Rule indices for which prettify must keep the original selector order,
     // because reordering time/state would change the meaning (#596).
     const rules_without_selector_reordering = new Set();
-    // eslint-disable-next-line no-var
-    var tokens = tokenize(value); // TODO: Figure out why tests fail if this is const or let.
+    /** @type {Array<unknown>} */
+    const tokens = tokenize(value);
     // console.log(JSON.stringify(tokens, null, '    '));
     let prettified_value = '';
     let week_stable = true;
@@ -493,59 +493,63 @@ export default function(value, nominatim_object, optional_conf_parm) {
      * @param {number|string} nrule Rule number starting with 0. `-1` means an
      *     error during tokenization; a string means the prettified value.
      * @param {number} at Token position. `-1` means the end of a rule.
-     * @param {Array} [tokens_to_use] Token array, defaulting to `tokens`. Pass
+     * @param {Array<unknown>} [tokens_to_use] Token array, defaulting to `tokens`. Pass
      *     `new_tokens` from `getWarnings()` because additional rules can make
      *     it longer than `tokens`.
      * @returns {{value: string, position: number|null}} The value the position
      *     refers to and its character offset, or `null` if it is unknown.
      */
     function resolveWarnErrorPosition(nrule, at, tokens_to_use) {
+        if (typeof nrule === 'string') {
+            return { value: nrule, position: at };
+        }
+        if (typeof nrule !== 'number') {
+            return { value: value, position: null };
+        }
+        if (nrule === -1) {
+            // at is remaining value.length at the point of the error.
+            return { value: value, position: value.length - at };
+        }
+
         if (typeof tokens_to_use === 'undefined') {
             tokens_to_use = tokens;
         }
-        if (typeof nrule === 'number') {
-            let pos;
-            if (nrule === -1) {
-                // at is remaining value.length at the point of the error.
-                pos = value.length - at;
-            } else if (typeof tokens_to_use[nrule] === 'undefined') {
-                // Caller passed the wrong token array (tokens instead of new_tokens?).
-                formatLibraryBugMessage('Bug in warning generation code: tokens_to_use[nrule] is undefined for nrule=' + nrule + '.');
+
+        let pos;
+        if (typeof tokens_to_use[nrule] === 'undefined') {
+            // Caller passed the wrong token array (tokens instead of new_tokens?).
+            formatLibraryBugMessage('Bug in warning generation code: tokens_to_use[nrule] is undefined for nrule=' + nrule + '.');
+            pos = value.length;
+        } else if (typeof tokens_to_use[nrule][0][at] === 'undefined') {
+            if (typeof tokens_to_use[nrule][0] !== 'undefined' && at === -1) {
+                // at === -1: point to end of rule, use offset of next rule entry if available.
                 pos = value.length;
-            } else if (typeof tokens_to_use[nrule][0][at] === 'undefined') {
-                if (typeof tokens_to_use[nrule][0] !== 'undefined' && at === -1) {
-                    // at === -1: point to end of rule, use offset of next rule entry if available.
-                    pos = value.length;
-                    if (typeof tokens_to_use[nrule+1] === 'object' && typeof tokens_to_use[nrule+1][2] === 'number') {
-                        pos -= tokens_to_use[nrule+1][2];
-                    } else if (typeof tokens_to_use[nrule][2] === 'number') {
-                        pos -= tokens_to_use[nrule][2];
-                    }
-                } else {
-                    // Token position is out of range. Run real_test regularly to catch this.
-                    formatLibraryBugMessage('Bug in warning generation code which could not determine the exact position of the warning or error in value.');
-                    pos = value.length;
-                    if (typeof tokens_to_use[nrule][2] === 'number') {
-                        // Fallback: point to last token in the rule which caused the problem.
-                        pos -= tokens_to_use[nrule][2];
-                        console.warn('Last token for rule: ' + JSON.stringify(tokens_to_use[nrule]));
-                    } else {
-                        console.warn('tokens_to_use[nrule][2] is undefined. This is ok if nrule is the last rule.');
-                    }
-                }
-            } else {
-                pos = value.length;
-                if (typeof tokens_to_use[nrule][0][at+1] === 'object') {
-                    pos -= tokens_to_use[nrule][0][at+1][2];
+                if (typeof tokens_to_use[nrule+1] === 'object' && typeof tokens_to_use[nrule+1][2] === 'number') {
+                    pos -= tokens_to_use[nrule+1][2];
                 } else if (typeof tokens_to_use[nrule][2] === 'number') {
                     pos -= tokens_to_use[nrule][2];
                 }
+            } else {
+                // Token position is out of range. Run real_test regularly to catch this.
+                formatLibraryBugMessage('Bug in warning generation code which could not determine the exact position of the warning or error in value.');
+                pos = value.length;
+                if (typeof tokens_to_use[nrule][2] === 'number') {
+                    // Fallback: point to last token in the rule which caused the problem.
+                    pos -= tokens_to_use[nrule][2];
+                    console.warn('Last token for rule: ' + JSON.stringify(tokens_to_use[nrule]));
+                } else {
+                    console.warn('tokens_to_use[nrule][2] is undefined. This is ok if nrule is the last rule.');
+                }
             }
-            return { value: value, position: pos };
-        } else if (typeof nrule === 'string') {
-            return { value: nrule, position: at };
+        } else {
+            pos = value.length;
+            if (typeof tokens_to_use[nrule][0][at+1] === 'object') {
+                pos -= tokens_to_use[nrule][0][at+1][2];
+            } else if (typeof tokens_to_use[nrule][2] === 'number') {
+                pos -= tokens_to_use[nrule][2];
+            }
         }
-        return { value: value, position: null };
+        return { value: value, position: pos };
     }
     /* }}} */
 
@@ -555,7 +559,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
      *     position refers to that value.
      * @param {number} at Token or character position to mark.
      * @param {string} message Human-readable warning or error message.
-     * @param {Array} [tokens_to_use] Token array used to resolve the position.
+     * @param {Array<unknown>} [tokens_to_use] Token array used to resolve the position.
      * @returns {string} Message with the position marker, or the original message
      *     when no position can be determined.
      */
@@ -593,7 +597,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
     /**
      * Tokenize an opening-hours input stream. {{{
      * @param {string} value Raw opening-hours value.
-     * @returns {Array} Tokenized list. See the internal documentation in `docs/`.
+     * @returns {Array<unknown>} Tokenized list. See the internal documentation in `docs/`.
      */
     function tokenize(value) {
         // Negative list approach: Match anything that's NOT punctuation, digits, or special chars

--- a/test/test.de.log
+++ b/test/test.de.log
@@ -2136,6 +2136,8 @@ With [34m[1mwarnings[22m[39m:
 "Structured warning: single date of today is not past yet" for "2025 May 23 00:00-24:00": [32m[1mPASSED[22m[39m
 "Structured warning: single date of yesterday is past" for "2025 May 22 00:00-24:00": [32m[1mPASSED[22m[39m
 "Structured warning: time range without minutes" for "Mo 10-12": [32m[1mPASSED[22m[39m
+"Structured warning: additional rule positions" for "Mo 10-12, Tu 14-16": [32m[1mPASSED[22m[39m
+"Structured warning: empty rule position" for "10:00-12:00;": [32m[1mPASSED[22m[39m
 "Structured warning: word error correction has stable type" for "Mon": [32m[1mPASSED[22m[39m
 "Structured warning: no warnings yields empty list" for "Mo 10:00-12:00": [32m[1mPASSED[22m[39m
 "Structured warning: multiple warnings keep distinct positions" for "Mo 10-12; Tu 14-16": [32m[1mPASSED[22m[39m
@@ -2752,7 +2754,7 @@ Der optional_conf_parm["tag_key"] fehlt, ist aber notwendig wegen optional_conf_
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-1071/1071 tests passed. 0 did not pass.
+1073/1073 tests passed. 0 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.de.log
+++ b/test/test.de.log
@@ -2163,6 +2163,12 @@ We off; Mo,Tu,Th-Su,PH; FRÜHLING <--- (Saisonwörter sind mehrdeutig. Bitte ver
 "Season words should fail with explicit date-range guidance" for "We off; Mo,Tu,Th-Su,PH; primavera We 11:00-14:00,17:00+": [32m[1mPASSED[22m[39m
 We off; Mo,Tu,Th-Su,PH; primavera <--- (Saisonwörter sind mehrdeutig. Bitte verwende stattdessen explizite Datumsbereiche, z. B. Jun-Aug, Dec-Feb oder Jun 21-Sep 22.)
 
+"Errors during tokenization must not crash internally" for "|| Mo": [32m[1mPASSED[22m[39m
+|| <--- (Die Regel vor der Fallback-Regel enthält nichts nützliches)
+
+"Errors during tokenization must not crash internally" for "summer": [32m[1mPASSED[22m[39m
+summer <--- (Saisonwörter sind mehrdeutig. Bitte verwende stattdessen explizite Datumsbereiche, z. B. Jun-Aug, Dec-Feb oder Jun 21-Sep 22.)
+
 "Incorrect syntax which should throw an error" for "Mo-Fr 17:00-12:00; Sa-Su 24:00-12:00": [32m[1mPASSED[22m[39m
 Mo-Fr 17:00-12:00; Sa-Su 24:00 <--- (Zeitspanne beginnt außerhalb des aktuellen Tages)
 
@@ -2754,7 +2760,7 @@ Der optional_conf_parm["tag_key"] fehlt, ist aber notwendig wegen optional_conf_
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-1073/1073 tests passed. 0 did not pass.
+1075/1075 tests passed. 0 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.en.log
+++ b/test/test.en.log
@@ -2136,6 +2136,8 @@ With [34m[1mwarnings[22m[39m:
 "Structured warning: single date of today is not past yet" for "2025 May 23 00:00-24:00": [32m[1mPASSED[22m[39m
 "Structured warning: single date of yesterday is past" for "2025 May 22 00:00-24:00": [32m[1mPASSED[22m[39m
 "Structured warning: time range without minutes" for "Mo 10-12": [32m[1mPASSED[22m[39m
+"Structured warning: additional rule positions" for "Mo 10-12, Tu 14-16": [32m[1mPASSED[22m[39m
+"Structured warning: empty rule position" for "10:00-12:00;": [32m[1mPASSED[22m[39m
 "Structured warning: word error correction has stable type" for "Mon": [32m[1mPASSED[22m[39m
 "Structured warning: no warnings yields empty list" for "Mo 10:00-12:00": [32m[1mPASSED[22m[39m
 "Structured warning: multiple warnings keep distinct positions" for "Mo 10-12; Tu 14-16": [32m[1mPASSED[22m[39m
@@ -2742,7 +2744,7 @@ The optional_conf_parm["tag_key"] is missing, required by optional_conf_parm["ma
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-1061/1061 tests passed. 0 did not pass.
+1063/1063 tests passed. 0 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.en.log
+++ b/test/test.en.log
@@ -2163,6 +2163,12 @@ We off; Mo,Tu,Th-Su,PH; FRÜHLING <--- (Season words are ambiguous. Please use e
 "Season words should fail with explicit date-range guidance" for "We off; Mo,Tu,Th-Su,PH; primavera We 11:00-14:00,17:00+": [32m[1mPASSED[22m[39m
 We off; Mo,Tu,Th-Su,PH; primavera <--- (Season words are ambiguous. Please use explicit date ranges instead, e.g. Jun-Aug, Dec-Feb, or Jun 21-Sep 22.)
 
+"Errors during tokenization must not crash internally" for "|| Mo": [32m[1mPASSED[22m[39m
+|| <--- (Rule before fallback rule does not contain anything useful)
+
+"Errors during tokenization must not crash internally" for "summer": [32m[1mPASSED[22m[39m
+summer <--- (Season words are ambiguous. Please use explicit date ranges instead, e.g. Jun-Aug, Dec-Feb, or Jun 21-Sep 22.)
+
 "Incorrect syntax which should throw an error" for "Mo-Fr 17:00-12:00; Sa-Su 24:00-12:00": [32m[1mPASSED[22m[39m
 Mo-Fr 17:00-12:00; Sa-Su 24:00 <--- (Time range starts outside of the current day)
 
@@ -2744,7 +2750,7 @@ The optional_conf_parm["tag_key"] is missing, required by optional_conf_parm["ma
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-1063/1063 tests passed. 0 did not pass.
+1065/1065 tests passed. 0 did not pass.
 41 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.js
+++ b/test/test.js
@@ -5566,6 +5566,18 @@ test.addStructuredWarnings('Structured warning: time range without minutes',
         [ 'without_minutes' ],
         nominatim_default, 'not only test', { 'tag_key': 'opening_hours' });
 
+test.addStructuredWarnings('Structured warning: additional rule positions',
+    'Mo 10-12, Tu 14-16',
+    [ 'without_minutes', 'without_minutes' ],
+    nominatim_default, 'not only test', { 'tag_key': 'opening_hours' }, undefined, undefined,
+    [ 8, 18 ]);
+
+test.addStructuredWarnings('Structured warning: empty rule position',
+    '10:00-12:00;',
+    [ 'nothing_useful' ],
+    nominatim_default, 'not only test', { 'tag_key': 'opening_hours' }, undefined, undefined,
+    [ 12 ]);
+
 test.addStructuredWarnings('Structured warning: word error correction has stable type',
         'Mon',
         [ 'word_error_correction', 'vague' ],
@@ -6232,6 +6244,7 @@ function opening_hours_test() {
         const oh_mode        = test_data_object[4];
         const date           = test_data_object[5];
         const expected_is_holiday = test_data_object[6];
+        const expected_positions = test_data_object[7];
 
         let warnings, formatted, oh, public_holiday_context;
         let crashed = false;
@@ -6249,6 +6262,7 @@ function opening_hours_test() {
 
         let shape_ok = false;
         let types_ok = false;
+        let positions_ok = true;
         let derives_ok = false;
         let public_holiday_context_ok = true;
         if (!crashed && Array.isArray(warnings)) {
@@ -6265,6 +6279,12 @@ function opening_hours_test() {
             const got_types = warnings.map(function(w) { return w.type; });
             types_ok = expected_types.length === got_types.length
                 && expected_types.every(function(t, i) { return t === got_types[i]; });
+            if (typeof expected_positions !== 'undefined') {
+                positions_ok = expected_positions.length === warnings.length
+                    && expected_positions.every(function(position, i) {
+                        return warnings[i].position === position;
+                    });
+            }
             // The formatted string from getWarnings() must be derivable from the
             // structured object, proving value/position are correct.
             derives_ok = Array.isArray(formatted)
@@ -6280,7 +6300,7 @@ function opening_hours_test() {
             }
         }
 
-        if (shape_ok && types_ok && derives_ok && public_holiday_context_ok) {
+        if (shape_ok && types_ok && positions_ok && derives_ok && public_holiday_context_ok) {
             str += c.passed('PASSED');
             passed = true;
             if (this.show_passing_tests) {
@@ -6294,6 +6314,9 @@ function opening_hours_test() {
             } else {
                 console.warn('  expected types: ' + JSON.stringify(expected_types));
                 console.warn('  got warnings:   ' + JSON.stringify(warnings));
+                if (!positions_ok) {
+                    console.warn('  expected positions: ' + JSON.stringify(expected_positions));
+                }
                 if (!derives_ok) {
                     console.warn('  formatted:      ' + JSON.stringify(formatted));
                 }
@@ -6757,7 +6780,7 @@ function opening_hours_test() {
     // }}}
 
     // add test to check getStructuredWarnings returns the expected warning types {{{
-    this.addStructuredWarnings = function(name, value, expected_types, nominatim_data, last, oh_mode, date, date_relevant) {
+    this.addStructuredWarnings = function(name, value, expected_types, nominatim_data, last, oh_mode, date, date_relevant, expected_positions) {
         if (this.last === true)  {
             return;
         }
@@ -6765,7 +6788,7 @@ function opening_hours_test() {
 
         oh_mode = get_oh_mode_parameter(oh_mode);
 
-        this.tests_structured_warnings.push([name, value, expected_types, nominatim_data, oh_mode, date, date_relevant]);
+        this.tests_structured_warnings.push([name, value, expected_types, nominatim_data, oh_mode, date, date_relevant, expected_positions]);
     };
     // }}}
 

--- a/test/test.js
+++ b/test/test.js
@@ -4651,6 +4651,17 @@ test.addShouldFail('Season words should fail with explicit date-range guidance',
     ], nominatim_default, 'not only test');
 /* }}} */
 
+// Regression test for a bug where errors thrown *during* tokenize() (nrule
+// === -1) could crash with a raw ReferenceError/TypeError instead of the
+// library's own string error, if resolveWarnErrorPosition() read `tokens`
+// before its own initializing assignment had completed. runSingleTestShouldFail
+// fails these if the caught value is an Error instance instead of a string.
+test.addShouldFail('Errors during tokenization must not crash internally', [
+    '|| Mo', // empty rule before fallback rule separator
+    'summer', // ambiguous season word
+    ], nominatim_default, 'not only test');
+/* }}} */
+
 /* https://github.com/opening-hours/opening_hours.js/issues/87 {{{ */
 test.addTest('Real world example: Problem with daylight saving?', [
         'Mo-Su,PH 15:00-03:00; easter -2 days 15:00-24:00',
@@ -6169,7 +6180,11 @@ function opening_hours_test() {
                 : value
             )
             + '": ';
-        if (crashed) {
+        // Intentional parser errors are always thrown as strings (formatWarnErrorMessage()).
+        // A thrown Error instance (e.g. ReferenceError, TypeError) means an internal bug
+        // rather than the expected parser error, so it must not count as a pass.
+        const crashed_with_internal_error = crashed instanceof Error;
+        if (crashed && !crashed_with_internal_error) {
             str += c.passed('PASSED');
 
             if (this.show_passing_tests) {
@@ -6177,12 +6192,15 @@ function opening_hours_test() {
                 if (this.show_error_warnings)
                     console.info(crashed + '\n');
             }
+        } else if (crashed_with_internal_error) {
+            str += c.crashed('CRASHED') + ', reason: ' + crashed;
+            console.error(str);
         } else {
             str += c.failed('FAILED');
             console.warn(str);
         }
 
-        return crashed;
+        return crashed && !crashed_with_internal_error;
     }; /* }}} */
 
     this.runSingleTestShouldThrowWarning = function(test_data_object) { /* {{{ */


### PR DESCRIPTION
I picked up this old TODO comment and finally dug into it:

```js
var tokens = tokenize(value); // TODO: Figure out why tests fail if this is const or let.
```

The tests failed because `tokenize()` can call `resolveWarnErrorPosition()` while `tokens` is still being initialized. With `var`, that access returned `undefined`; with `const`, it triggered the temporal dead zone.

I refactored the control flow so these cases return before accessing `tokens`. This allows us to use `const` and removes the old workaround. I also tightened the related types and tests.

No change to normal parser behavior :)