### PR TITLE
fix(parser): detect full-year range as week-stable

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1606,6 +1606,36 @@ export default function(value, nominatim_object, optional_conf_parm) {
     }
     /* }}} */
 
+    /**
+     * Check whether the tokens describe the plain full-year month/day range
+     * `Jan 01-Dec 31`, without a period or following selector.
+     * @param {Array<ParserToken>} tokens Parser tokens.
+     * @param {number} at Position of the possible range.
+     * @returns {boolean} Whether the range is week-stable.
+     */
+    function isPlainFullYearMonthdayRange(tokens, at) {
+        if (matchTokens(tokens, at, 'year'))
+            return false;
+        if (!matchTokens(tokens, at, 'month', 'number', '-', 'month', 'number'))
+            return false;
+
+        const from_month = tokens[at][0];
+        const from_day = tokens[at + 1][0];
+        const to_month = tokens[at + 3][0];
+        const to_day = tokens[at + 4][0];
+
+        if (!(from_month === 0 && from_day === 1 && to_month === 11 && to_day === 31))
+            return false;
+
+        // A period or another selector means this is not the plain full-year range.
+        if (matchTokens(tokens, at + 5, '/', 'number'))
+            return false;
+        if (matchTokens(tokens, at + 5, ','))
+            return false;
+
+        return true;
+    }
+
     /* Top-level parser {{{
      *
      * :param tokens: List of tokens.
@@ -1640,9 +1670,11 @@ export default function(value, nominatim_object, optional_conf_parm) {
                     || matchTokens(tokens, at, 'year', 'month', 'number')
                     || matchTokens(tokens, at, 'year', 'event')
                     || matchTokens(tokens, at, 'event')) {
+                const is_full_year_monthday_range = isPlainFullYearMonthdayRange(tokens, at);
 
                 at = parseMonthdayRange(tokens, at, nrule);
-                week_stable = false;
+                if (!is_full_year_monthday_range)
+                    week_stable = false;
             } else if (matchTokens(tokens, at, 'year')) {
                 at = parseYearRange(tokens, at);
                 week_stable = false;

--- a/test/test.de.log
+++ b/test/test.de.log
@@ -957,7 +957,7 @@ With [34m[1mwarnings[22m[39m:
 "Full range" for "Dec-Nov": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
 	*Dec-Nov <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
-"Full range" for "Jan 01-Dec 31": [32m[1mPASSED[22m[39m, [33m[1mexcept[22m[39m weekstable which is ignored for now
+"Full range" for "Jan 01-Dec 31": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
 	*Jan 01-Dec 31 <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
 "Full range" for "week 01-53": [32m[1mPASSED[22m[39m
@@ -2761,7 +2761,7 @@ Der optional_conf_parm["tag_key"] fehlt, ist aber notwendig wegen optional_conf_
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
 1075/1075 tests passed. 0 did not pass.
-41 tests where (partly) ignored, sorted by commonness:
+40 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet
-*  4: check for week stable not implemented
+*  3: check for week stable not implemented

--- a/test/test.en.log
+++ b/test/test.en.log
@@ -957,7 +957,7 @@ With [34m[1mwarnings[22m[39m:
 "Full range" for "Dec-Nov": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
 	*Dec-Nov <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
-"Full range" for "Jan 01-Dec 31": [32m[1mPASSED[22m[39m, [33m[1mexcept[22m[39m weekstable which is ignored for now
+"Full range" for "Jan 01-Dec 31": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
 	*Jan 01-Dec 31 <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
 "Full range" for "week 01-53": [32m[1mPASSED[22m[39m
@@ -2751,7 +2751,7 @@ The optional_conf_parm["tag_key"] is missing, required by optional_conf_parm["ma
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
 1065/1065 tests passed. 0 did not pass.
-41 tests where (partly) ignored, sorted by commonness:
+40 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet
-*  4: check for week stable not implemented
+*  3: check for week stable not implemented

--- a/test/test.js
+++ b/test/test.js
@@ -2881,7 +2881,7 @@ test.addTest('Full range', [
         'Jan-Dec',
         'Feb-Jan',
         'Dec-Nov',
-        ignored('Jan 01-Dec 31', 'check for week stable not implemented'),
+        'Jan 01-Dec 31',
         'week 01-53',
         'Mo 00:00-24:00; Tu 00:00-24:00; We 00:00-24:00; Th 00:00-24:00; Fr 00:00-24:00; Sa 00:00-24:00; Su 00:00-24:00',
     ], '2025-10-01 0:00', '2025-10-08 0:00', [


### PR DESCRIPTION
`Jan 01-Dec 31` is now recognized as week-stable. This does not change opening intervals, but avoids unnecessary longer comparisons.