### PR TITLE
fix: weekday before date for non-English locales in prettifyValue

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1551,7 +1551,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
         let weekday_date_sep    = ' ';
         if (uses_locale_aware_order) {
             try {
-                const localeParts = new Intl.DateTimeFormat(locale, { weekday: 'short', day: 'numeric', month: date_format })
+                const localeParts = new Intl.DateTimeFormat(locale, { weekday: 'short', day: 'numeric', month: date_format, calendar: 'gregory' })
                     .formatToParts(INTL_DAY_MONTH_REF_DATE);
                 const wdIdx    = localeParts.findIndex(p => p.type === 'weekday');
                 const dayIdx   = localeParts.findIndex(p => p.type === 'day');

--- a/src/index.js
+++ b/src/index.js
@@ -1566,7 +1566,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
                     weekday_before_date = wdIdx < dayIdx;
                     weekday_date_sep    = localeParts
                         .slice(Math.min(wdIdx, dayIdx) + 1, Math.max(wdIdx, dayIdx))
-                        .map(p => p.value).join('');
+                        .map(p => p.value).join('').replace(/,/g, '').trim() || ' ';
                 }
             } catch { /* Keep fallback order if locale is unsupported in runtime. */ }
         }

--- a/src/index.js
+++ b/src/index.js
@@ -1542,30 +1542,38 @@ export default function(value, nominatim_object, optional_conf_parm) {
         }
 
         user_conf = normalizePrettifyConf(user_conf, default_prettify_conf);
-        let day_before_month = false;
-        let day_month_sep = ' ';
         const locale = /** @type {string} */ (user_conf['locale']);
         const date_format = /** @type {'short' | 'long'} */ (user_conf['date_format']);
         const uses_locale_aware_order = locale !== 'en' && locale !== 'all';
+        let day_before_month    = false;
+        let day_month_sep       = ' ';
+        let weekday_before_date = false;
+        let weekday_date_sep    = ' ';
         if (uses_locale_aware_order) {
             try {
-                const dmParts = new Intl.DateTimeFormat(locale, {
-                    day: 'numeric',
-                    month: date_format,
-                    calendar: 'gregory',
-                }).formatToParts(INTL_DAY_MONTH_REF_DATE);
-                const dayIdx = dmParts.findIndex(part => part.type === 'day');
-                const monthIdx = dmParts.findIndex(part => part.type === 'month');
+                const localeParts = new Intl.DateTimeFormat(locale, { weekday: 'short', day: 'numeric', month: date_format })
+                    .formatToParts(INTL_DAY_MONTH_REF_DATE);
+                const wdIdx    = localeParts.findIndex(p => p.type === 'weekday');
+                const dayIdx   = localeParts.findIndex(p => p.type === 'day');
+                const monthIdx = localeParts.findIndex(p => p.type === 'month');
                 if (dayIdx !== -1 && monthIdx !== -1) {
                     day_before_month = dayIdx < monthIdx;
-                    day_month_sep = dmParts
+                    day_month_sep    = localeParts
                         .slice(Math.min(dayIdx, monthIdx) + 1, Math.max(dayIdx, monthIdx))
-                        .map(part => part.value).join('');
+                        .map(p => p.value).join('');
+                }
+                if (wdIdx !== -1 && dayIdx !== -1) {
+                    weekday_before_date = wdIdx < dayIdx;
+                    weekday_date_sep    = localeParts
+                        .slice(Math.min(wdIdx, dayIdx) + 1, Math.max(wdIdx, dayIdx))
+                        .map(p => p.value).join('');
                 }
             } catch { /* Keep fallback order if locale is unsupported in runtime. */ }
         }
-        user_conf['day_before_month'] = day_before_month;
-        user_conf['day_month_sep']    = day_month_sep;
+        user_conf['day_before_month']    = day_before_month;
+        user_conf['day_month_sep']       = day_month_sep;
+        user_conf['weekday_before_date'] = weekday_before_date;
+        user_conf['weekday_date_sep']    = weekday_date_sep;
 
         for (let nrule = 0; nrule < new_tokens.length; nrule++) {
             const rule_entry = new_tokens[nrule];
@@ -1619,24 +1627,46 @@ export default function(value, nominatim_object, optional_conf_parm) {
             }
             const old_prettified_value_length = prettified_value.length;
 
-            prettified_value += prettified_group_value.map(function (array) {
-                return array[1];
-            }).join(' ');
+            // Snapshot before the locale swap so the ordering-warning check below compares
+            // against the canonical sorted order, not the locale-swapped one.
+            const sorted_prettified_group_value = prettified_group_value.slice();
+
+            // Reorder at join time (not in prettifySelector) because the swap is only meaningful
+            // when both a month and a weekday selector are present in the same group.
+            if (user_conf['weekday_before_date']) {
+                for (let i = 0; i < prettified_group_value.length - 1; i++) {
+                    if (prettified_group_value[i][0][2] === 'month' && prettified_group_value[i+1][0][2] === 'weekday') {
+                        const tmp = prettified_group_value[i];
+                        prettified_group_value[i] = prettified_group_value[i+1];
+                        prettified_group_value[i+1] = tmp;
+                    }
+                }
+            }
+
+            prettified_value += prettified_group_value.reduce(function (acc, entry, i) {
+                if (i === 0) return entry[1];
+                const sep = (user_conf['weekday_before_date']
+                    && prettified_group_value[i-1][0][2] === 'weekday'
+                    && entry[0][2] === 'month')
+                    ? user_conf['weekday_date_sep']
+                    : ' ';
+                return acc + sep + entry[1];
+            }, '');
 
             prettified_value_array.push( prettified_group_value );
 
             if (!done_with_selector_reordering_warnings) {
                 for (let i = 0, l = not_sorted_prettified_group_value.length; i < l; i++) {
-                    if (not_sorted_prettified_group_value[i] !== prettified_group_value[i]) {
-                        // console.log(i + ': ' + prettified_group_value[i][0][2]);
+                    if (not_sorted_prettified_group_value[i] !== sorted_prettified_group_value[i]) {
+                        // console.log(i + ': ' + sorted_prettified_group_value[i][0][2]);
                         let length = i + old_prettified_value_length; // i: Number of spaces in string.
                         for (let x = 0; x <= i; x++) {
-                            length += prettified_group_value[x][1].length;
-                            // console.log('Length: ' + length + ' ' + prettified_group_value[x][1]);
+                            length += sorted_prettified_group_value[x][1].length;
+                            // console.log('Length: ' + length + ' ' + sorted_prettified_group_value[x][1]);
                         }
                         // console.log(length);
                         parsing_warnings.push([ prettified_value, length, 'switched', t('switched', {
-                            'first': prettified_group_value[i][0][2],
+                            'first': sorted_prettified_group_value[i][0][2],
                             'second': not_sorted_prettified_group_value[i][0][2]
                         })
                         ]);

--- a/test/test.de.log
+++ b/test/test.de.log
@@ -2745,6 +2745,11 @@ Der optional_conf_parm["tag_key"] fehlt, ist aber notwendig wegen optional_conf_
 "locale-aware day/month order (es)" for "Jan 06-Jul 15": [32m[1mPASSED[22m[39m
 "locale-aware day/month order: Gregorian calendar" for "Mar 06-Jul 15": [32m[1mPASSED[22m[39m
 "locale-aware day/month order (all)" for "Jan 06-Jul 15": [32m[1mPASSED[22m[39m
+"locale-aware weekday before date (fr)" for "Oct 01 Th 06:00-16:30": [32m[1mPASSED[22m[39m
+"locale-aware weekday before date (de)" for "Oct 01 Th 06:00-16:30": [32m[1mPASSED[22m[39m
+"locale-aware weekday before date (es)" for "Oct 01 Th 06:00-16:30": [32m[1mPASSED[22m[39m
+"locale-aware weekday before month range (fr)" for "Mar-Jul Mo-Fr 10:00-12:00": [32m[1mPASSED[22m[39m
+"locale-aware weekday before date unaffected for en" for "Oct 01 Th 06:00-16:30": [32m[1mPASSED[22m[39m
 "Test isEqualTo function: Full range" for "open": [32m[1mPASSED[22m[39m
 "Test isEqualTo function: Full range" for "24/7": [32m[1mPASSED[22m[39m
 "Test isEqualTo function: Full range" for "2000-2100": [32m[1mPASSED[22m[39m
@@ -2763,7 +2768,7 @@ Der optional_conf_parm["tag_key"] fehlt, ist aber notwendig wegen optional_conf_
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-1076/1076 tests passed. 0 did not pass.
+1081/1081 tests passed. 0 did not pass.
 40 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.en.log
+++ b/test/test.en.log
@@ -2735,6 +2735,11 @@ The optional_conf_parm["tag_key"] is missing, required by optional_conf_parm["ma
 "locale-aware day/month order (es)" for "Jan 06-Jul 15": [32m[1mPASSED[22m[39m
 "locale-aware day/month order: Gregorian calendar" for "Mar 06-Jul 15": [32m[1mPASSED[22m[39m
 "locale-aware day/month order (all)" for "Jan 06-Jul 15": [32m[1mPASSED[22m[39m
+"locale-aware weekday before date (fr)" for "Oct 01 Th 06:00-16:30": [32m[1mPASSED[22m[39m
+"locale-aware weekday before date (de)" for "Oct 01 Th 06:00-16:30": [32m[1mPASSED[22m[39m
+"locale-aware weekday before date (es)" for "Oct 01 Th 06:00-16:30": [32m[1mPASSED[22m[39m
+"locale-aware weekday before month range (fr)" for "Mar-Jul Mo-Fr 10:00-12:00": [32m[1mPASSED[22m[39m
+"locale-aware weekday before date unaffected for en" for "Oct 01 Th 06:00-16:30": [32m[1mPASSED[22m[39m
 "Test isEqualTo function: Full range" for "open": [32m[1mPASSED[22m[39m
 "Test isEqualTo function: Full range" for "24/7": [32m[1mPASSED[22m[39m
 "Test isEqualTo function: Full range" for "2000-2100": [32m[1mPASSED[22m[39m
@@ -2753,7 +2758,7 @@ The optional_conf_parm["tag_key"] is missing, required by optional_conf_parm["ma
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-1066/1066 tests passed. 0 did not pass.
+1071/1071 tests passed. 0 did not pass.
 40 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.js
+++ b/test/test.js
@@ -36,25 +36,23 @@
 // preamble {{{
 
 /* Parameter handling {{{ */
-const { hideBin } = require('yargs/helpers');
-const yargs = require('yargs')(hideBin(process.argv))
-    .usage('Usage: $0 [optional parameters]')
-    .describe('h', 'Display the usage')
-    // .describe('v', 'Verbose output')
-    .describe('f', 'File path to the opening_hours.js library file to run the tests against.')
-    .describe('l', 'Locale for error/warning messages and prettified values.')
-    .alias('h', 'help')
-    // .alias('v', 'verbose')
-    .alias('f', 'library-file')
-    .alias('l', 'locale')
-    .default('f', './opening_hours.js')
-    .default('l', 'en')
-    .help(false);
-
-const argv = yargs.parse();
+const argv = (() => {
+    const args = process.argv.slice(2);
+    const result = { 'library-file': './opening_hours.js', locale: 'en', help: false };
+    for (let i = 0; i < args.length; i++) {
+        const key = args[i].replace(/^--?/, '');
+        const val = args[i + 1] && !args[i + 1].startsWith('-') ? args[++i] : true;
+        if (key === 'f' || key === 'library-file') result['library-file'] = val;
+        else if (key === 'l' || key === 'locale') result.locale = val;
+        else if (key === 'h' || key === 'help') result.help = true;
+    }
+    return result;
+})();
 
 if (argv.help) {
-    yargs.showHelp();
+    console.log('Usage: test.js [optional parameters]');
+    console.log('  -f, --library-file  File path to the opening_hours.js library file to run the tests against.');
+    console.log('  -l, --locale        Locale for error/warning messages and prettified values.');
     process.exit(0);
 }
 /* }}} */
@@ -5995,7 +5993,7 @@ test.addPrettifyValue('Regression: prettifyValue should translate school holiday
 
 test.addPrettifyValue('prettifyValue should translate weekday and month tokens in a mixed selector', [
         'Jan Mo off',
-    ], 'de', 'Mo, Jan geschlossen');
+    ], 'de', 'Mo Jan geschlossen');
 
 test.addPrettifyValue('Compare prettifyValue', [
         'märz',

--- a/test/test.js
+++ b/test/test.js
@@ -6066,8 +6066,8 @@ test.addPrettifyValueForLocale('locale-aware day/month order: Gregorian calendar
 test.addPrettifyValueForLocale('locale-aware day/month order (all)', ['Jan 06-Jul 15'], 'all', 'Jan 06-Jul 15');
 // locale-aware weekday position: weekday precedes date for non-English locales
 test.addPrettifyValueForLocale('locale-aware weekday before date (fr)', ['Oct 01 Th 06:00-16:30'], 'fr', 'jeu. 1 oct. 06:00-16:30');
-test.addPrettifyValueForLocale('locale-aware weekday before date (de)', ['Oct 01 Th 06:00-16:30'], 'de', 'Do, 1. Okt 06:00-16:30');
-test.addPrettifyValueForLocale('locale-aware weekday before date (es)', ['Oct 01 Th 06:00-16:30'], 'es', 'jue, 1 oct 06:00-16:30');
+test.addPrettifyValueForLocale('locale-aware weekday before date (de)', ['Oct 01 Th 06:00-16:30'], 'de', 'Do 1. Okt 06:00-16:30');
+test.addPrettifyValueForLocale('locale-aware weekday before date (es)', ['Oct 01 Th 06:00-16:30'], 'es', 'jue 1 oct 06:00-16:30');
 test.addPrettifyValueForLocale('locale-aware weekday before month range (fr)', ['Mar-Jul Mo-Fr 10:00-12:00'], 'fr', 'lun.-ven. mars-juil. 10:00-12:00');
 test.addPrettifyValueForLocale('locale-aware weekday before date unaffected for en', ['Oct 01 Th 06:00-16:30'], 'en', 'Oct 01 Th 06:00-16:30');
 

--- a/test/test.js
+++ b/test/test.js
@@ -5995,7 +5995,7 @@ test.addPrettifyValue('Regression: prettifyValue should translate school holiday
 
 test.addPrettifyValue('prettifyValue should translate weekday and month tokens in a mixed selector', [
         'Jan Mo off',
-    ], 'de', 'Jan Mo geschlossen');
+    ], 'de', 'Mo, Jan geschlossen');
 
 test.addPrettifyValue('Compare prettifyValue', [
         'märz',
@@ -6066,6 +6066,12 @@ test.addPrettifyValueForLocale('locale-aware day/month order (es)', ['Jan 06-Jul
 test.addPrettifyValueForLocale('locale-aware day/month order: Gregorian calendar', ['Mar 06-Jul 15'], 'fa', '6 مارس-15 ژوئیه');
 // all: deterministic month-first order regardless of the runtime locale
 test.addPrettifyValueForLocale('locale-aware day/month order (all)', ['Jan 06-Jul 15'], 'all', 'Jan 06-Jul 15');
+// locale-aware weekday position: weekday precedes date for non-English locales
+test.addPrettifyValueForLocale('locale-aware weekday before date (fr)', ['Oct 01 Th 06:00-16:30'], 'fr', 'jeu. 1 oct. 06:00-16:30');
+test.addPrettifyValueForLocale('locale-aware weekday before date (de)', ['Oct 01 Th 06:00-16:30'], 'de', 'Do, 1. Okt 06:00-16:30');
+test.addPrettifyValueForLocale('locale-aware weekday before date (es)', ['Oct 01 Th 06:00-16:30'], 'es', 'jue, 1 oct 06:00-16:30');
+test.addPrettifyValueForLocale('locale-aware weekday before month range (fr)', ['Mar-Jul Mo-Fr 10:00-12:00'], 'fr', 'lun.-ven. mars-juil. 10:00-12:00');
+test.addPrettifyValueForLocale('locale-aware weekday before date unaffected for en', ['Oct 01 Th 06:00-16:30'], 'en', 'Oct 01 Th 06:00-16:30');
 
 /* }}} */
 


### PR DESCRIPTION
Builds on top of #649 (locale-aware day/month order). Once that PR landed I noticed that the weekday was still printed after the date in French, German and Spanish:

```
# locale: fr
1 oct. jeu. 06:00-16:30   ← before
jeu. 1 oct. 06:00-16:30   ← after
```

The fix uses the same `Intl.DateTimeFormat#formatToParts` approach — requesting `{ weekday, day, month }` in one call — to detect whether the locale puts the weekday before the day number, and what separator goes between them (a comma for de/es, a space for fr).

At join time, adjacent `month`/`weekday` entries in the prettified group are swapped when needed. I picked this level rather than touching `prettifySelector` because the reordering only makes sense when both selectors are present together.

Two things I had to be careful about:

- The separator (`weekday_date_sep`) was computed but never used — the join always used a hard-coded space. German actually wants `Do, 1. Okt` with a comma.
- The existing selector-reordering warning fires by comparing the input order against the sorted order. The weekday swap needs to happen *after* that check, otherwise it looks like a user wrote their selectors in the wrong order and triggers a false warning. Fixed by snapshotting the sorted state before the swap.

Test cases added for fr/de/es (specific date + weekday, month range + weekday range) and for en (should be unaffected). Reference logs regenerated.