### PR TITLE
refactor(iterator): simplify implementation and add tests

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4824,131 +4824,124 @@ export default function(value, nominatim_object, optional_conf_parm) {
      * @returns {OpeningHoursIterator} Iterator over state changes.
      */
     this.getIterator = function(date = new Date()) {
-        return new function(
-            /** @type {{getStatePair: (date: Date) => OpeningHoursStatePair}} */
-            oh
-        ) {
-            let state = oh.getStatePair(date);
-            let prevstate = state;
+        const iterator = {};
+        /** @type {{getStatePair: (date: Date) => OpeningHoursStatePair}} */
+        const oh = this;
+        let state = oh.getStatePair(date);
+        let prevstate = state;
 
-            /**
-             * getDate {{{
-             * @returns {Date} Current iterator date.
-             */
-            this.getDate = function() {
-                return date;
-            };
-            /* }}} */
+        /**
+         * getDate {{{
+         * @returns {Date} Current iterator date.
+         */
+        iterator.getDate = function() {
+            return date;
+        };
+        /* }}} */
 
-            /**
-             * setDate {{{
-             * @param {Date} new_date - Date to set.
-             */
-            this.setDate = function(new_date) {
-                if (typeof new_date !== 'object')
-                    throw t('date parameter needed');
+        /**
+         * setDate {{{
+         * @param {Date} new_date - Date to set.
+         */
+        iterator.setDate = function(new_date) {
+            if (typeof new_date !== 'object')
+                throw t('date parameter needed');
 
-                date = new_date;
-                state = oh.getStatePair(date);
-                prevstate = state;
-            };
-            /* }}} */
+            date = new_date;
+            state = oh.getStatePair(date);
+            prevstate = state;
+        };
+        /* }}} */
 
-            /**
-             * Check whether facility is `open' {{{
-             * @returns {boolean} Whether the facility is open.
-             */
-            this.getState = function() {
-                return state[0];
-            };
-            /* }}} */
+        /**
+         * Check whether facility is `open' {{{
+         * @returns {boolean} Whether the facility is open.
+         */
+        iterator.getState = function() {
+            return state[0];
+        };
+        /* }}} */
 
-            /**
-             * Checks whether the opening state is conditional or unknown {{{
-             * @returns {boolean} Whether the state is unknown.
-             */
-            this.getUnknown = function() {
-                return state[2];
-            };
-            /* }}} */
+        /**
+         * Checks whether the opening state is conditional or unknown {{{
+         * @returns {boolean} Whether the state is unknown.
+         */
+        iterator.getUnknown = function() {
+            return state[2];
+        };
+        /* }}} */
 
-            /**
-             * Get state string. Either 'open', 'unknown' or 'closed' {{{
-             * @param {boolean} past - Whether to report a past closed state.
-             * @returns {string} State string.
-             */
-            this.getStateString = function(past) {
-                return (state[0] ? 'open' : (state[2] ? 'unknown' : (past ? 'closed' : 'close')));
-            };
-            /* }}} */
+        /**
+         * Get state string. Either 'open', 'unknown' or 'closed' {{{
+         * @param {boolean} past - Whether to report a past closed state.
+         * @returns {string} State string.
+         */
+        iterator.getStateString = function(past) {
+            return (state[0] ? 'open' : (state[2] ? 'unknown' : (past ? 'closed' : 'close')));
+        };
+        /* }}} */
 
-            /**
-             * Get the comment, undefined in none {{{
-             * @returns {string|undefined} Current comment.
-             */
-            this.getComment = function() {
-                return state[3];
-            };
-            /* }}} */
+        /**
+         * Get the comment, undefined in none {{{
+         * @returns {string|undefined} Current comment.
+         */
+        iterator.getComment = function() {
+            return state[3];
+        };
+        /* }}} */
 
-            /**
-             * Get the rule which matched thus deterrents the current state {{{
-             * @returns {object|undefined} Matching rule.
-             */
-            this.getMatchingRule = function() {
-                if (typeof state[4] === 'undefined')
-                    return undefined;
+        /**
+         * Get the rule which matched thus deterrents the current state {{{
+         * @returns {object|undefined} Matching rule.
+         */
+        iterator.getMatchingRule = function() {
+            if (typeof state[4] === 'undefined')
+                return undefined;
 
-                return rules[state[4]].build_from_token_rule[2];
-            };
-            /* }}} */
+            return rules[state[4]].build_from_token_rule[2];
+        };
+        /* }}} */
 
-            /**
-             * Advances to the next position {{{
-             * @param {Date} datelimit - Date limit.
-             * @returns {boolean} Whether the iterator advanced.
-             */
-            this.advance = function(datelimit) {
-                if (typeof datelimit === 'undefined') {
-                    datelimit = new Date(date.getTime() + msec_in_day * 366 * 5);
-                } else if (datelimit.getTime() <= date.getTime()) {
-                    return false; /* The limit for advance needs to be after the current time. */
+        /**
+         * Advances to the next position {{{
+         * @param {Date} datelimit - Date limit.
+         * @returns {boolean} Whether the iterator advanced.
+         */
+        iterator.advance = function(datelimit) {
+            if (typeof datelimit === 'undefined') {
+                datelimit = new Date(date.getTime() + msec_in_day * 366 * 5);
+            } else if (datelimit.getTime() <= date.getTime()) {
+                return false; /* The limit for advance needs to be after the current time. */
+            }
+
+            do {
+                if (typeof state[1] === 'undefined') {
+                    return false; /* open range, we won't be able to advance */
                 }
 
-                do {
-                    if (typeof state[1] === 'undefined') {
-                        return false; /* open range, we won't be able to advance */
-                    }
+                if (state[1].getTime() <= date.getTime()) {
+                    /* We're going backwards or staying at the same time.
+                     * This most likely indicates an error in a selector code.
+                     */
+                    throw 'Fatal: infinite loop in nextChange';
+                }
 
-                    // console.log('\n' + 'previous check time:', date
-                    //     + ', current check time:',
-                    //     state[1],
-                    //     (state[0] ? 'open' : (state[2] ? 'unknown' : 'closed'))
-                    //     + ', comment:', state[3]
-                    //     + ', match_rule:', state[4]);
+                if (state[1].getTime() >= datelimit.getTime()) {
+                    /* Don't advance beyond limits. */
+                    return false;
+                }
 
-                    if (state[1].getTime() <= date.getTime()) {
-                        /* We're going backwards or staying at the same time.
-                         * This most likely indicates an error in a selector code.
-                         */
-                        throw 'Fatal: infinite loop in nextChange';
-                    }
+                // do advance
+                date = state[1];
+                prevstate = state;
+                state = oh.getStatePair(date);
+                // console.log(state);
+            } while (state[0] === prevstate[0] && state[2] === prevstate[2] && state[3] === prevstate[3]);
+            return true;
+        };
+        /* }}} */
 
-                    if (state[1].getTime() >= datelimit.getTime()) {
-                        /* Don't advance beyond limits. */
-                        return false;
-                    }
-
-                    // do advance
-                    date = state[1];
-                    prevstate = state;
-                    state = oh.getStatePair(date);
-                    // console.log(state);
-                } while (state[0] === prevstate[0] && state[2] === prevstate[2] && state[3] === prevstate[3]);
-                return true;
-            };
-            /* }}} */
-        }(this);
+        return iterator;
     };
     /* }}} */
 

--- a/src/index.js
+++ b/src/index.js
@@ -310,6 +310,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
     let week_stable = true;
 
     let rule, nrule;
+    /** @type {Array<{[key: string]: object}>} */
     const rules = [];
     const rule_infos = {};
     /* Not reliable because tokens !== new_tokens */
@@ -4287,6 +4288,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
      * Main selector traversal function (return state array for date). {{{
      * Checks which rule applies for the given date, including its state and
      * comment.
+     * @param {object[]} rules Parsed rules to inspect.
      * @param {Date} date Date to inspect.
      * @returns {OpeningHoursStatePair}
      *     Array:
@@ -4296,7 +4298,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
      *     3. comment: Comment which applies for this time range (from date to changedate).
      *     4. match_rule: Rule number starting with 0 (nrule).
      */
-    this.getStatePair = function(date) {
+    function getStatePair(rules, date) {
         let resultstate = false;
         let changedate;
         let unknown = false;
@@ -4499,6 +4501,15 @@ export default function(value, nominatim_object, optional_conf_parm) {
 
         // console.log('changedate', changedate, resultstate, comment, match_rule);
         return [ resultstate, changedate, unknown, comment, match_rule ];
+    }
+
+    /**
+     * Get the state pair for a date.
+     * @param {Date} date Date to inspect.
+     * @returns {OpeningHoursStatePair} State and next-change information.
+     */
+    this.getStatePair = function(date) {
+        return getStatePair(rules, date);
     };
     /* }}} */
 
@@ -4825,9 +4836,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
      */
     this.getIterator = function(date = new Date()) {
         const iterator = {};
-        /** @type {{getStatePair: (date: Date) => OpeningHoursStatePair}} */
-        const oh = this;
-        let state = oh.getStatePair(date);
+        let state = getStatePair(rules, date);
         let prevstate = state;
 
         /**
@@ -4848,7 +4857,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
                 throw t('date parameter needed');
 
             date = new_date;
-            state = oh.getStatePair(date);
+            state = getStatePair(rules, date);
             prevstate = state;
         };
         /* }}} */
@@ -4934,7 +4943,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
                 // do advance
                 date = state[1];
                 prevstate = state;
-                state = oh.getStatePair(date);
+                state = getStatePair(rules, date);
                 // console.log(state);
             } while (state[0] === prevstate[0] && state[2] === prevstate[2] && state[3] === prevstate[3]);
             return true;

--- a/src/index.js
+++ b/src/index.js
@@ -4828,30 +4828,29 @@ export default function(value, nominatim_object, optional_conf_parm) {
             /** @type {{getStatePair: (date: Date) => OpeningHoursStatePair}} */
             oh
         ) {
-            // TODO: only prevstate[1] (date) is ever read; indices 0/2/3/4 are dead sentinel values. Could simplify to a plain Date.
-            /** @type {[boolean|undefined, Date|undefined, boolean|undefined, string|undefined, number|undefined]} */
-            let prevstate = [ undefined, date, undefined, undefined, undefined ];
             let state = oh.getStatePair(date);
+            let prevstate = state;
 
             /**
              * getDate {{{
              * @returns {Date} Current iterator date.
              */
             this.getDate = function() {
-                return prevstate[1];
+                return date;
             };
             /* }}} */
 
             /**
              * setDate {{{
-             * @param {Date} date - Date to set.
+             * @param {Date} new_date - Date to set.
              */
-            this.setDate = function(date) {
-                if (typeof date !== 'object')
+            this.setDate = function(new_date) {
+                if (typeof new_date !== 'object')
                     throw t('date parameter needed');
 
-                prevstate = [ undefined, date, undefined, undefined, undefined ];
-                state     = oh.getStatePair(date);
+                date = new_date;
+                state = oh.getStatePair(date);
+                prevstate = state;
             };
             /* }}} */
 
@@ -4911,8 +4910,8 @@ export default function(value, nominatim_object, optional_conf_parm) {
              */
             this.advance = function(datelimit) {
                 if (typeof datelimit === 'undefined') {
-                    datelimit = new Date(prevstate[1].getTime() + msec_in_day * 366 * 5);
-                } else if (datelimit.getTime() <= prevstate[1].getTime()) {
+                    datelimit = new Date(date.getTime() + msec_in_day * 366 * 5);
+                } else if (datelimit.getTime() <= date.getTime()) {
                     return false; /* The limit for advance needs to be after the current time. */
                 }
 
@@ -4921,14 +4920,14 @@ export default function(value, nominatim_object, optional_conf_parm) {
                         return false; /* open range, we won't be able to advance */
                     }
 
-                    // console.log('\n' + 'previous check time:', prevstate[1]
+                    // console.log('\n' + 'previous check time:', date
                     //     + ', current check time:',
                     //     state[1],
                     //     (state[0] ? 'open' : (state[2] ? 'unknown' : 'closed'))
                     //     + ', comment:', state[3]
                     //     + ', match_rule:', state[4]);
 
-                    if (state[1].getTime() <= prevstate[1].getTime()) {
+                    if (state[1].getTime() <= date.getTime()) {
                         /* We're going backwards or staying at the same time.
                          * This most likely indicates an error in a selector code.
                          */
@@ -4941,8 +4940,9 @@ export default function(value, nominatim_object, optional_conf_parm) {
                     }
 
                     // do advance
+                    date = state[1];
                     prevstate = state;
-                    state = oh.getStatePair(prevstate[1]);
+                    state = oh.getStatePair(date);
                     // console.log(state);
                 } while (state[0] === prevstate[0] && state[2] === prevstate[2] && state[3] === prevstate[3]);
                 return true;

--- a/test/unit/iterator.test.mjs
+++ b/test/unit/iterator.test.mjs
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: © opening_hours.js contributors
+// SPDX-License-Identifier: LGPL-3.0-only
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+process.env.TZ = 'Europe/Berlin';
+const { default: opening_hours } = await import('../../build/opening_hours.esm.mjs');
+
+const localDate = (hour, minute = 0) => new Date(2026, 0, 5, hour, minute);
+
+test('getIterator exposes the initial state and advances to state changes', () => {
+    const start = localDate(8);
+    const iterator = new opening_hours('Mo 09:00-17:00').getIterator(start);
+
+    assert.equal(iterator.getDate().getTime(), start.getTime());
+    assert.equal(iterator.getState(), false);
+    assert.equal(iterator.getUnknown(), false);
+    assert.equal(iterator.getStateString(false), 'close');
+
+    assert.equal(iterator.advance(localDate(18)), true);
+    assert.equal(iterator.getDate().getTime(), localDate(9).getTime());
+    assert.equal(iterator.getState(), true);
+
+    assert.equal(iterator.advance(localDate(18)), true);
+    assert.equal(iterator.getDate().getTime(), localDate(17).getTime());
+    assert.equal(iterator.getStateString(true), 'closed');
+});
+
+test('getIterator exposes comments and matching rules for the current state', () => {
+    const iterator = new opening_hours('Mo 09:00-17:00 "foo"').getIterator(localDate(8));
+
+    assert.equal(iterator.getComment(), undefined);
+    assert.equal(iterator.getMatchingRule(), undefined);
+
+    assert.equal(iterator.advance(localDate(18)), true);
+    assert.equal(iterator.getComment(), 'foo');
+    assert.equal(iterator.getMatchingRule(), 0);
+
+    assert.equal(iterator.advance(localDate(18)), true);
+    assert.equal(iterator.getComment(), undefined);
+    assert.equal(iterator.getMatchingRule(), undefined);
+});
+
+test('getIterator does not advance at or beyond the date limit', () => {
+    const iterator = new opening_hours('Mo 09:00-17:00').getIterator(localDate(8));
+
+    assert.equal(iterator.advance(localDate(9)), false);
+    assert.equal(iterator.getDate().getHours(), 8);
+
+    assert.equal(iterator.advance(localDate(10)), true);
+    assert.equal(iterator.getDate().getTime(), localDate(9).getTime());
+});
+
+test('getIterator setDate resets the current state and next change', () => {
+    const iterator = new opening_hours('Mo-Fr 09:00-17:00').getIterator(localDate(8));
+
+    iterator.setDate(localDate(10));
+
+    assert.equal(iterator.getDate().getTime(), localDate(10).getTime());
+    assert.equal(iterator.getState(), true);
+    assert.equal(iterator.getUnknown(), false);
+
+    assert.equal(iterator.advance(localDate(18)), true);
+    assert.equal(iterator.getDate().getTime(), localDate(17).getTime());
+    assert.equal(iterator.getState(), false);
+});
+
+test('getIterator stops when the current state has no next boundary', () => {
+    const iterator = new opening_hours('24/7').getIterator(localDate(8));
+
+    assert.equal(iterator.getState(), true);
+    assert.equal(iterator.advance(), false);
+});


### PR DESCRIPTION
This PR follows up on the discussion in #662. The iterator originally stored its previous state in a sentinel tuple, even though only the date was needed for that purpose. The implementation now keeps track of the current date directly and avoids maintaining unnecessary placeholder fields.

While revisiting the code, I decided to add dedicated unit tests for `getIterator`, covering the initial state, state transitions, date limits, `setDate()`, comments, matching rules, and schedules that have no next boundary.

As a final cleanup, I replaced the anonymous iterator constructor with a clearer object-based implementation, making the control flow and the iterator API easier to understand.