### PR TITLE
fix(holidays): resolve regions from Nominatim ISO codes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,6 +43,53 @@ import { normalizeToken } from './locale-resolver/normalize.mjs';
 import resolver_layers from './locale-resolver/layers.json';
 
 /**
+ * Resolve a state name from a Nominatim address.
+ * Prefer matching ISO3166-2 fields (e.g. "DE-BE" -> "Berlin"), then fall back
+ * to the address.state and address.county fields.
+ * @param {Record<string, unknown>} address Nominatim address object.
+ * @param {string|undefined} countryCode Lowercase country code.
+ * @returns {string|undefined} Resolved state name, if any.
+ */
+function getStateFromAddress(address, countryCode) {
+    if (typeof address !== 'object' || address === null) {
+        return undefined;
+    }
+
+    if (typeof countryCode === 'string') {
+        const countryDefinitions = /** @type {Record<string, Record<string, { _state_code?: unknown }>>} */ (holiday_definitions)[countryCode];
+        if (countryDefinitions) {
+            /** @type {Record<string, string>} */
+            const stateByCode = {};
+            for (const name of Object.keys(countryDefinitions)) {
+                const definition = countryDefinitions[name];
+                if (definition && typeof definition._state_code === 'string') {
+                    stateByCode[definition._state_code.toLowerCase()] = name;
+                }
+            }
+
+            for (const [key, value] of Object.entries(address)) {
+                if (key.startsWith('ISO3166-2') && typeof value === 'string') {
+                    const lower = value.toLowerCase();
+                    const localCode = lower.slice(lower.indexOf('-') + 1);
+                    if (stateByCode[localCode]) {
+                        return stateByCode[localCode];
+                    }
+                }
+            }
+        }
+    }
+
+    if (typeof address.state === 'string') {
+        return address.state;
+    }
+    if (typeof address.county === 'string') {
+        return address.county;
+    }
+
+    return undefined;
+}
+
+/**
  * Creates an opening hours parser for an OSM opening-hours value.
  * @param {string} value The opening-hours value to parse.
  * @param {object|null} [nominatim_object] Location and address data used for holidays and solar times.
@@ -188,11 +235,7 @@ export default function(value, nominatim_object, optional_conf_parm) {
             if (typeof nominatim_object.address.country_code === 'string') {
                 location_cc = nominatim_object.address.country_code;
             }
-            if (typeof nominatim_object.address.state === 'string') {
-                location_state = nominatim_object.address.state;
-            } else if (typeof nominatim_object.address.county === 'string') {
-                location_state = nominatim_object.address.county;
-            }
+            location_state = getStateFromAddress(nominatim_object.address, location_cc);
         }
 
         if (typeof nominatim_object.lon === 'string' && typeof nominatim_object.lat === 'string') {

--- a/test/test.de.log
+++ b/test/test.de.log
@@ -427,6 +427,9 @@ With [34m[1mwarnings[22m[39m:
 "Variable days: Germany school holidays. Rheinland-Pfalz" for "SH": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
 	*SH <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
+"Variable days: public holidays. Berlin Frauentag resolved via ISO3166-2-lvl4" for "PH": [32m[1mPASSED[22m[39m
+With [34m[1mwarnings[22m[39m:
+	*PH <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
 "Variable days: public holidays" for "open; PH off": [32m[1mPASSED[22m[39m
 "Variable days: public holidays (with time range)" for "PH 12:00-13:00": [32m[1mPASSED[22m[39m
 "Variable days: public holidays (with time range)" for "PH 12:00-13:00 open "this comment should override the holiday name which is returned as comment if PH matches."": [32m[1mPASSED[22m[39m
@@ -2760,7 +2763,7 @@ Der optional_conf_parm["tag_key"] fehlt, ist aber notwendig wegen optional_conf_
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-1075/1075 tests passed. 0 did not pass.
+1076/1076 tests passed. 0 did not pass.
 40 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.en.log
+++ b/test/test.en.log
@@ -427,6 +427,9 @@ With [34m[1mwarnings[22m[39m:
 "Variable days: Germany school holidays. Rheinland-Pfalz" for "SH": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
 	*SH <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
+"Variable days: public holidays. Berlin Frauentag resolved via ISO3166-2-lvl4" for "PH": [32m[1mPASSED[22m[39m
+With [34m[1mwarnings[22m[39m:
+	*PH <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
 "Variable days: public holidays" for "open; PH off": [32m[1mPASSED[22m[39m
 "Variable days: public holidays (with time range)" for "PH 12:00-13:00": [32m[1mPASSED[22m[39m
 "Variable days: public holidays (with time range)" for "PH 12:00-13:00 open "this comment should override the holiday name which is returned as comment if PH matches."": [32m[1mPASSED[22m[39m
@@ -2750,7 +2753,7 @@ The optional_conf_parm["tag_key"] is missing, required by optional_conf_parm["ma
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-1065/1065 tests passed. 0 did not pass.
+1066/1066 tests passed. 0 did not pass.
 40 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.js
+++ b/test/test.js
@@ -145,6 +145,33 @@ const nominatim_no_valid_address = {
     }
 };
 
+// https://github.com/opening-hours/opening_hours.js/issues/458
+// https://nominatim.openstreetmap.org/reverse?format=json&lat=52.55048&lon=13.409781&zoom=18&addressdetails=1
+// Nominatim does not always return address.state or address.county. Here only
+// ISO3166-2-lvl4 identifies the region (Berlin), which needs to be resolved
+// against the _state_code values in src/holidays/de.yaml.
+const nominatim_berlin_iso_only = {
+    'place_id': '144081916',
+    'licence': 'Data © OpenStreetMap contributors, ODbL 1.0. https://www.openstreetmap.org/copyright',
+    'osm_type': 'way',
+    'osm_id': '1049888449',
+    'lat': '52.5504796',
+    'lon': '13.4096999',
+    'display_name': '38, Schivelbeiner Straße, Nordisches Viertel, Prenzlauer Berg, Pankow, Berlin, 10439, Deutschland',
+    'address': {
+        'house_number': '38',
+        'road': 'Schivelbeiner Straße',
+        'quarter': 'Nordisches Viertel',
+        'suburb': 'Prenzlauer Berg',
+        'borough': 'Pankow',
+        'city': 'Berlin',
+        'ISO3166-2-lvl4': 'DE-BE',
+        'postcode': '10439',
+        'country': 'Deutschland',
+        'country_code': 'de'
+    }
+};
+
 /* }}} */
 
 const sane_value_suffix = '; 00:01-00:02 closed "warning at correct position?"';
@@ -903,6 +930,16 @@ test.addTest('Variable days: Germany school holidays. Rheinland-Pfalz', [
         [ '2024-10-14 00:00', '2024-10-26 00:00', false, 'Herbstferien' ],
         [ '2024-12-23 00:00', '2025-01-01 00:00', false, 'Weihnachtsferien' ],
     ], 1000 * 60 * 60 * 24 * 84 - 1000 * 60 * 60, 0, false, nominatim_by_loc.de_rp, 'not only test');
+
+// https://github.com/opening-hours/opening_hours.js/issues/458
+// Nominatim only returns ISO3166-2-lvl4 (DE-BE) for this address, no address.state
+// or address.county. Internationaler Frauentag is only a public holiday in Berlin
+// and Mecklenburg-Vorpommern, so this only passes if the ISO code is resolved.
+test.addTest('Variable days: public holidays. Berlin Frauentag resolved via ISO3166-2-lvl4', [
+        'PH',
+    ], '2025-03-07 0:00', '2025-03-09 0:00', [
+        [ '2025-03-08 00:00', '2025-03-09 00:00', false, 'Internationaler Frauentag' ],
+    ], 1000 * 60 * 60 * 24, 0, false, nominatim_berlin_iso_only, 'not only test');
 
 /* }}} */
 


### PR DESCRIPTION
This fixes #458.

Nominatim does not always return regional information in `address.state`. In some responses, such as Berlin, the region is only available through an `ISO3166-2` field.

This change resolves those ISO codes against the holiday definitions for the detected country. Regional holidays such as Berlin’s International Women’s Day are then recognized correctly, while the existing `state` and `county` fallbacks remain unchanged.