### PR TITLE
chore(lint): migrate HTML validation to ESLint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,10 +231,6 @@ check-holidays: scripts/PH_SH_exporter.js
 check-holiday-state-codes: scripts/check_holiday_state_codes.mjs
 	$(NODEJS) scripts/check_holiday_state_codes.mjs
 
-.PHONY: check-html
-check-html:
-	html5validator --show-warnings --root . --blacklist node_modules submodules
-
 ## }}}
 
 ## release {{{

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,6 +4,7 @@ import { defineConfig, globalIgnores } from 'eslint/config'
 import globals from 'globals'
 import js from '@eslint/js'
 import jsdoc from 'eslint-plugin-jsdoc';
+import html from '@html-eslint/eslint-plugin'
 import markdown from '@eslint/markdown'
 import stylistic from '@stylistic/eslint-plugin'
 import tseslint from 'typescript-eslint'
@@ -14,6 +15,15 @@ export default defineConfig([
   {
     files: ['**/*.yaml', '**/*.yml'],
     extends: [yml.configs.standard],
+  },
+  {
+      files: ['**/*.html'],
+      plugins: { html },
+      extends: ['html/recommended'],
+      language: 'html/html',
+      rules: {
+        'html/attrs-newline': 'off'
+      },
   },
   {
     files: ['**/*.js', '**/*.mjs'],

--- a/examples/simple_index.html
+++ b/examples/simple_index.html
@@ -2,39 +2,39 @@
 <!-- SPDX-License-Identifier: LGPL-3.0-only -->
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <title>Simple page using opening_hours.js</title>
-    <meta charset="utf-8">
-    <link rel="shortcut icon" type="image/svg+xml" href="https://openingh.openstreetmap.de/evaluation_tool/img/favicon.svg">
-    <script src="https://openingh.openstreetmap.de/build/opening_hours+deps.min.js"></script>
-  </head>
+    <head>
+        <title>Simple page using opening_hours.js</title>
+        <meta charset="utf-8">
+        <link rel="shortcut icon" type="image/svg+xml" href="https://openingh.openstreetmap.de/evaluation_tool/img/favicon.svg">
+        <script src="https://openingh.openstreetmap.de/build/opening_hours+deps.min.js"></script>
+    </head>
 
-  <body>
+    <body>
 
-    <h1>Nothing to see here, open a debug console in your browser to see the interesting stuff.</h1>
+        <h1>Nothing to see here, open a debug console in your browser to see the interesting stuff.</h1>
 
-    <script>
-      // Input string (English and German mixed) - intentionally using mixed languages to demonstrate prettification.
-      let input_value = "Mo-Tu,Do-Fr 10:00-20:00; Samstag und Sonntag geschlossen";
+        <script>
+            // Input string (English and German mixed) - intentionally using mixed languages to demonstrate prettification.
+            let input_value = "Mo-Tu,Do-Fr 10:00-20:00; Samstag und Sonntag geschlossen";
 
-      // Language for the warnings (get it from the browser settings).
-      let locale = navigator.language;
+            // Language for the warnings (get it from the browser settings).
+            let locale = navigator.language;
 
-      // Create opening_hours object.
-      let oh = new opening_hours(input_value, {}, { locale: locale });
+            // Create opening_hours object.
+            let oh = new opening_hours(input_value, {}, { locale: locale });
 
-      // Prettify the value in different languages.
-      let prettified_value_de = oh.prettifyValue({ conf: { locale: "de" } });
-      let prettified_value_en = oh.prettifyValue({ conf: { locale: "en" } });
-      let prettified_value_ru = oh.prettifyValue({ conf: { locale: "ru" } });
+            // Prettify the value in different languages.
+            let prettified_value_de = oh.prettifyValue({ conf: { locale: "de" } });
+            let prettified_value_en = oh.prettifyValue({ conf: { locale: "en" } });
+            let prettified_value_ru = oh.prettifyValue({ conf: { locale: "ru" } });
 
-      // Console outputs.
-      console.log(`Input value (German and English mixed): ${input_value}`);
-      console.log(`Prettified value (de):                  ${prettified_value_de}`);
-      console.log(`Prettified value (en):                  ${prettified_value_en}`);
-      console.log(`Prettified value (ru):                  ${prettified_value_ru}`);
-      console.log(`Warnings:\n  ${oh.getWarnings().join("\n  ")}`);
-    </script>
+            // Console outputs.
+            console.log(`Input value (German and English mixed): ${input_value}`);
+            console.log(`Prettified value (de):                  ${prettified_value_de}`);
+            console.log(`Prettified value (en):                  ${prettified_value_en}`);
+            console.log(`Prettified value (ru):                  ${prettified_value_ru}`);
+            console.log(`Warnings:\n  ${oh.getWarnings().join("\n  ")}`);
+        </script>
 
-  </body>
+    </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@commitlint/config-conventional": "^21.2.0",
         "@eslint/js": "^10.0.1",
         "@eslint/markdown": "^8.0.3",
+        "@html-eslint/eslint-plugin": "^0.65.0",
         "@rollup/plugin-commonjs": "^29.0.3",
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^16.0.3",
@@ -582,6 +583,116 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@html-eslint/core": {
+      "version": "0.65.0",
+      "resolved": "https://registry.npmjs.org/@html-eslint/core/-/core-0.65.0.tgz",
+      "integrity": "sha512-UJUf0dDI6xq6iitksPXrfLwu2Gc143LGFHMlVnRPZxkoLz1xIzKbkQVxrqxqNmandsSmhWfkGw//U2BsBH/QRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@html-eslint/types": "^0.65.0",
+        "html-standard": "^0.0.13"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@html-eslint/eslint-plugin": {
+      "version": "0.65.0",
+      "resolved": "https://registry.npmjs.org/@html-eslint/eslint-plugin/-/eslint-plugin-0.65.0.tgz",
+      "integrity": "sha512-zYa4ARNbkp/GPlIY+1NFV5v6H3EDs+jby4/rFnZDaS/S3mFEvBail4+dPqugHljrBmAZ0UkxMATR696ypRvPCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint/plugin-kit": "^0.4.1",
+        "@html-eslint/core": "^0.65.0",
+        "@html-eslint/parser": "^0.65.0",
+        "@html-eslint/template-parser": "^0.65.0",
+        "@html-eslint/template-syntax-parser": "^0.65.0",
+        "@html-eslint/types": "^0.65.0",
+        "@rviscomi/capo.js": "^2.1.0",
+        "html-standard": "^0.0.13"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.0.0 || ^10.0.0-0"
+      }
+    },
+    "node_modules/@html-eslint/eslint-plugin/node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@html-eslint/eslint-plugin/node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@html-eslint/parser": {
+      "version": "0.65.0",
+      "resolved": "https://registry.npmjs.org/@html-eslint/parser/-/parser-0.65.0.tgz",
+      "integrity": "sha512-sMZ8D60uQ/yLKViiqkzX3vnpBwcBNE8x/Ax8roAdrLiErkJ4wLMdXq+kmRm0rqfTuC0mqPJ+7uRTAgUB6wXg2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@html-eslint/template-syntax-parser": "^0.65.0",
+        "@html-eslint/types": "^0.65.0",
+        "css-tree": "^3.1.0",
+        "es-html-parser": "0.3.1"
+      }
+    },
+    "node_modules/@html-eslint/template-parser": {
+      "version": "0.65.0",
+      "resolved": "https://registry.npmjs.org/@html-eslint/template-parser/-/template-parser-0.65.0.tgz",
+      "integrity": "sha512-gUc9D4PaV5uvQjR21Q1wumbe2Qyf6decJjCZCpM77kZ7mMprIDvnF4LgCJBkTldidc4j1GzJvqkJ5e+r+skFyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@html-eslint/types": "^0.65.0",
+        "es-html-parser": "0.3.1"
+      }
+    },
+    "node_modules/@html-eslint/template-syntax-parser": {
+      "version": "0.65.0",
+      "resolved": "https://registry.npmjs.org/@html-eslint/template-syntax-parser/-/template-syntax-parser-0.65.0.tgz",
+      "integrity": "sha512-Kh7TFOM4cYcutzGZdWKxnZJpWpuZwu4hcSxbn/PHVBgDOytKOwpuPvCKn1+B11fSFxLhrrR3RHvsBVknntpcbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@html-eslint/types": "^0.65.0"
+      }
+    },
+    "node_modules/@html-eslint/types": {
+      "version": "0.65.0",
+      "resolved": "https://registry.npmjs.org/@html-eslint/types/-/types-0.65.0.tgz",
+      "integrity": "sha512-bWMTSRwFXwvturEYvA5ng43+jpFh9FTpAgC2HE3O0ijsde40VcoO6DtcjFl7QY8AW5O/PeisDDl1Hbe5q89wsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/css-tree": "^2.3.11",
+        "@types/estree": "^1.0.6",
+        "es-html-parser": "0.3.1"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1299,6 +1410,13 @@
         "win32"
       ]
     },
+    "node_modules/@rviscomi/capo.js": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@rviscomi/capo.js/-/capo.js-2.3.0.tgz",
+      "integrity": "sha512-qY3QRtKdq//Z8jDENSUCAaSE76sUwHgN6pzoRXj6e5cSwQqxFLjm8B+GDkbtUr/WGWJRzoAMtz0I60TM1KrOBg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@simple-libs/child-process-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@simple-libs/child-process-utils/-/child-process-utils-2.0.0.tgz",
@@ -1417,6 +1535,13 @@
         "structured-source": "^4.0.0",
         "unified": "^9.2.2"
       }
+    },
+    "node_modules/@types/css-tree": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/@types/css-tree/-/css-tree-2.3.11.tgz",
+      "integrity": "sha512-aEokibJOI77uIlqoBOkVbaQGC9zII0A+JH1kcTNKW2CwyYWD8KM6qdo+4c77wD3wZOQfJuNWAr9M4hdk+YhDIg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/debug": {
       "version": "4.1.13",
@@ -1788,6 +1913,13 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/@vscode/l10n": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.18.tgz",
+      "integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/acorn": {
       "version": "8.18.0",
@@ -2747,6 +2879,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/cz-conventional-changelog": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-3.3.0.tgz",
@@ -3174,6 +3320,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-html-parser": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/es-html-parser/-/es-html-parser-0.3.1.tgz",
+      "integrity": "sha512-YTEasG4xt7FEN4b6qJIPbFo/fzQ5kjRMEQ33QMqSXTvfXqAbC2rHxo32x2/1Rhq7Mlu6wI3MIpM5Kf2VHPXrUQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-toolkit": {
       "version": "1.50.0",
@@ -4139,6 +4292,17 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/html-standard": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/html-standard/-/html-standard-0.0.13.tgz",
+      "integrity": "sha512-6oNfW3c1t44O7jVXu0tp4E5MbHifWlXrHlZBPt6y7vFdgLOUUh8hyzoRhfUgozlBUK6oLLYhqP1uIqbZ8ggcBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-css-languageservice": "^6.3.9",
+        "vscode-languageserver-textdocument": "^1.0.12"
+      }
     },
     "node_modules/htmlparser2": {
       "version": "7.2.0",
@@ -5398,6 +5562,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge": {
       "version": "2.1.1",
@@ -7357,6 +7528,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-support": {
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
@@ -8026,6 +8207,40 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/vscode-css-languageservice": {
+      "version": "6.3.10",
+      "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.3.10.tgz",
+      "integrity": "sha512-eq5N9Er3fC4vA9zd9EFhyBG90wtCCuXgRSpAndaOgXMh1Wgep5lBgRIeDgjZBW9pa+332yC9+49cZMW8jcL3MA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vscode/l10n": "^0.0.18",
+        "vscode-languageserver-textdocument": "^1.0.12",
+        "vscode-languageserver-types": "3.17.5",
+        "vscode-uri": "^3.1.0"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.14.tgz",
+      "integrity": "sha512-EQyqJMi552E4ZTf46izQ4Fj6XquqxCySR3J5ZSD1SisMf6RfpeOWHxGBE8Gr6V0/3GHIGdAzDn8F8+1nTGCnoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.2.0.tgz",
+      "integrity": "sha512-m2gXo3bn0G1kT9InzMf07fTbqMbGtyckj3bH5ktLO+1Ssv+yiATZ4dhwaQv9UZWxJh6E9IFGnQyjgWVDWVBDrg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/walk-up-path": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@commitlint/config-conventional": "^21.2.0",
     "@eslint/js": "^10.0.1",
     "@eslint/markdown": "^8.0.3",
+    "@html-eslint/eslint-plugin": "^0.65.0",
     "@rollup/plugin-commonjs": "^29.0.3",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^16.0.3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: © opening_hours.js contributors
 # SPDX-License-Identifier: CC0-1.0
 hc
-html5validator
 ruamel.yaml>=0.16
 requests-cache>=0.6.0.dev1 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/site/index.html
+++ b/site/index.html
@@ -8,8 +8,8 @@
         <meta name="viewport" content="width=device-width">
         <title>opening_hours evaluation tool</title>
         <link rel="icon" type="image/svg+xml" href="img/favicon.svg">
-        <link rel="stylesheet" href="css/main.css"/>
-        <link rel="stylesheet" href="css/table.css"/>
+        <link rel="stylesheet" href="css/main.css">
+        <link rel="stylesheet" href="css/table.css">
         <script defer src="../build/opening_hours+deps.min.js"></script>
         <script defer src="js/theme.js"></script>
         <script type="module" src="js/main.js"></script>
@@ -45,7 +45,7 @@
                             <input id="expression"
                                 name="expression"
                                 value="Mo-Fr 10:00-20:00; PH off"
-                            />
+                            >
                             <button type="button" class="input-btn copy-input-btn" id="copy-expression-btn" data-i18n-title="copy">📋</button>
                             <button type="button" class="input-btn clear-input-btn" id="clear-expression-btn" data-i18n-title="clear">×</button>
                         </div>
@@ -61,7 +61,7 @@
                             <input
                                 id="diff_value"
                                 type="text"
-                            />
+                            >
                             <button type="button" class="input-btn clear-input-btn" id="clear-diff-btn" data-i18n-title="clear">×</button>
                         </div>
                         <div id="compare-result"></div>
@@ -114,91 +114,91 @@
                     </div>
                 </section>
 
-            <section>
-                <button type="button" id="examples-toggle" class="examples-toggle-btn">
-                    <span class="toggle-icon">▼</span>
-                    <h2 id="examples"></h2>
-                </button>
-                <div id="user_examples">
-                <ol>
-                    <li><a href="#check" class="example-link">Mo-Fr 10:00-20:00; PH off</a></li>
-                    <li><a href="#check" class="example-link">Mo,Tu,Th,Fr 12:00-18:00; Sa,PH 12:00-17:00; Th[3],Th[-1] off</a></li>
-                    <li><a href="#check" class="example-link">00:00-24:00; Tu-Su,PH 08:30-09:00 off; Tu-Su 14:00-14:30 off; Mo 08:00-13:00 off</a></li>
-                    <li><a href="#check" class="example-link">Fr-Sa 18:00-06:00; PH 18:00-06:00 off</a></li>
-                    <li><a href="#check" class="example-link">Mo 10:00-12:00,12:30-15:00</a></li>
-                    <li><a href="#check" class="example-link">Mo 10:00-12:00,12:30-15:00; Tu-Fr 08:00-12:00,12:30-15:00; Sa 08:00-12:00</a></li>
-                    <li><a href="#check" class="example-link">24/7</a></li>
-                    <li><a href="#check" class="example-link">"only after registration"; PH off</a></li>
-                    <li><a href="#check" class="example-link">22:00-23:00; PH off</a></li>
-                    <li><a href="#check" class="example-link">08:00-11:00; PH off</a></li>
-                    <li><a href="#check" class="example-link">open; Mo 15:00-16:00 off; PH off</a></li>
-                    <li><a href="#check" class="example-link">Mo-Su 22:00-23:00; We,PH off</a></li>
-                    <li><a href="#check" class="example-link">We-Fr 10:00-24:00 open "it is open" || "please call"; PH off</a></li>
-                    <li><a href="#check" class="example-link">Mo-Fr 08:00-11:00 || Tu-Th,PH open "Emergency only"</a></li>
-                    <li><a href="#check" class="example-link">Tu-Th,We 22:00-23:00 open "Hot meals"; PH off</a></li>
-                    <li><a href="#check" class="example-link">Mo 12:00-14:00 open "female only", Mo 14:00-16:00 open "male only"; PH off</a></li>
-                    <li><a href="#check" class="example-link">Apr: 22:00-23:00; PH off</a></li>
-                    <li><a href="#check" class="example-link">Jul-Jan: 22:00-23:00; PH off</a></li>
-                    <li><a href="#check" class="example-link">Jan-Jul: 22:00-23:00; PH off</a></li>
-                    <li><a href="#check" class="example-link">Jul 23-Jan 3: "needs reservation by phone"; PH off</a></li>
-                    <li><a href="#check" class="example-link">Jul 23-Jan 3: 22:00-23:00 "Please make a reservation by phone."; PH off</a></li>
-                    <li><a href="#check" class="example-link">Jul 23-Jan 3: 08:00-11:00 "Please make a reservation by phone."; PH off</a></li>
-                    <li><a href="#check" class="example-link">Jan 23-Jul 3: 22:00-23:00 "Please make a reservation by phone."; PH off</a></li>
-                    <li><a href="#check" class="example-link">Mar Su[-1]-Dec Su[1] -2 days: 22:00-23:00; PH off</a></li>
-                    <!-- <li><a href="#check" class="example-link">Mar Su[&#45;1] &#45; Dec 25&#45;Su&#45;28 days: 22:00&#45;23:00; PH off</a></li> -->
-                    <!-- <li><a href="#check" class="example-link">Dec 25&#45;Su&#45;28 days &#45; Mar Su[&#45;1]: 22:00&#45;23:00; PH off</a></li> -->
-                    <!-- Currently used around 6 times: /\d\s*&#45;\s*(mo|tu|we|th|fr|sa|su)\b/ -->
-                    <li><a href="#check" class="example-link">Sa[1],Sa[1] +1 day 10:00-12:00 open "first weekend in the month"; PH off</a></li>
-                    <li><a href="#check" class="example-link">Sa[-1],Sa[-1] +1 day 10:00-12:00 open "last weekend in the month"; PH off</a></li>
-                    <li><a href="#check" class="example-link">Sa-Su 00:00-24:00; PH off</a></li>
-                    <li><a href="#check" class="example-link">Mo-Fr 00:00-24:00; PH off</a></li>
-                    <li><a href="#check" class="example-link">sunrise-sunset open "Beware of sunburn!"; PH off</a></li>
-                    <li><a href="#check" class="example-link">sunset-sunrise open "Beware of vampires!"; PH off</a></li>
-                    <li><a href="#check" class="example-link">(sunset+01:00)-24:00 || closed "No drink before sunset!"; PH off</a></li>
-                    <li><a href="#check" class="example-link">22:00+; PH 22:00-12:00 off</a></li>
-                    <!-- <li><a href="#check" class="example-link">&#45;23:00; PH off</a></li> -->
-                    <li><a href="#check" class="example-link">Tu,PH 23:59-22:59</a></li>
-                    <li><a href="#check" class="example-link">We-Mo,PH 23:59-22:59</a></li>
-                    <li><a href="#check" class="example-link">week 2-52/2 We 00:00-24:00; week 1-53/2 Sa 00:00-24:00; PH off</a></li>
-                    <li><a href="#check" class="example-link">week 4-16 We 00:00-24:00; week 38-42 Sa 00:00-24:00; PH off</a></li>
-                    <li><a href="#check" class="example-link">2012 easter -2 days-2012 easter +2 days: open "Around easter"; PH off</a></li>
-                    <li><a href="#check" class="example-link">24/7 closed "always closed"</a></li>
-                    <li>
-                        <a href="#check" class="example-link">2013,2015,2050-2053,2055/2,2020-2029/3,2060+ Jan 1</a>,
-                        <a id="year-ranges-docu" href="" target="_blank"></a>
-                    </li>
-                    <li><a href="#check" class="example-link">Jan 23-Feb 11,Feb 12 00:00-24:00; PH off</a></li>
-                    <li><a href="#check" class="example-link">Apr-Oct Su[2] 14:00-18:00; Aug Su[-1] -1 day 10:00-18:00; Aug Su[-1] 10:00-18:00; PH off</a></li>
-                    <li><a href="#check" class="example-link">Mo-Fr 08:00-12:00, We 14:00-18:00; Su,PH off</a></li>
-                    <li><a href="#check" class="example-link">00:00-24:00 week 6 Mo-Su Feb; PH off</a>,
-                        <span id="hint-error-correction-1"></span>
-                    </li>
-                    <li><a href="#check" class="example-link">   monday,    Tu, wE,   TH    12:00 - 20:00  ; 14:00-16:00      Off  ; closed public Holiday</a>,
-                        <span id="hint-error-correction-2"></span>
-                    </li>
-                    <li><a href="#check" class="example-link">We; PH off</a></li>
-                    <li><a href="#check" class="example-link">PH</a></li>
-                    <li><a href="#check" class="example-link">PH Mo-Fr</a>
-                        <span id="hint-ph-mo-fr"></span>
-                    </li>
-                    <li><a href="#check" class="example-link">PH -1 day</a></li>
-                    <li><a href="#check" class="example-link">SH</a></li>
-                    <li><a href="#check" class="example-link">SH,PH</a></li>
-                    <li><a href="#check" class="example-link">PH,SH</a>
-                        <span id="hint-sh-ph"></span>
-                    </li>
-                    <li><a href="#check" class="example-link">We[1-3]</a></li>
-                    <li><a href="#check" class="example-link">We[3-5]</a></li>
-                    <li><a href="#check" class="example-link">Sa</a></li>
-                    <li><a href="#check" class="example-link">Sa[1]</a></li>
-                    <li><a href="#check" class="example-link">Sa[1-3]</a></li>
-                    <li><a href="#check" class="example-link">Tu-Th</a></li>
-                    <li><a href="#check" class="example-link">Fr-Mo</a></li>
-                    <li><a href="#check" class="example-link">Mo-Su; We "only after registration"</a></li>
-                    <li><a href="#check" class="example-link">Oct: We[1]</a></li>
-                </ol>
-                </div>
-            </section>
+                <section>
+                    <button type="button" id="examples-toggle" class="examples-toggle-btn">
+                        <span class="toggle-icon">▼</span>
+                        <h2 id="examples"></h2>
+                    </button>
+                    <div id="user_examples">
+                        <ol>
+                            <li><a href="#check" class="example-link">Mo-Fr 10:00-20:00; PH off</a></li>
+                            <li><a href="#check" class="example-link">Mo,Tu,Th,Fr 12:00-18:00; Sa,PH 12:00-17:00; Th[3],Th[-1] off</a></li>
+                            <li><a href="#check" class="example-link">00:00-24:00; Tu-Su,PH 08:30-09:00 off; Tu-Su 14:00-14:30 off; Mo 08:00-13:00 off</a></li>
+                            <li><a href="#check" class="example-link">Fr-Sa 18:00-06:00; PH 18:00-06:00 off</a></li>
+                            <li><a href="#check" class="example-link">Mo 10:00-12:00,12:30-15:00</a></li>
+                            <li><a href="#check" class="example-link">Mo 10:00-12:00,12:30-15:00; Tu-Fr 08:00-12:00,12:30-15:00; Sa 08:00-12:00</a></li>
+                            <li><a href="#check" class="example-link">24/7</a></li>
+                            <li><a href="#check" class="example-link">"only after registration"; PH off</a></li>
+                            <li><a href="#check" class="example-link">22:00-23:00; PH off</a></li>
+                            <li><a href="#check" class="example-link">08:00-11:00; PH off</a></li>
+                            <li><a href="#check" class="example-link">open; Mo 15:00-16:00 off; PH off</a></li>
+                            <li><a href="#check" class="example-link">Mo-Su 22:00-23:00; We,PH off</a></li>
+                            <li><a href="#check" class="example-link">We-Fr 10:00-24:00 open "it is open" || "please call"; PH off</a></li>
+                            <li><a href="#check" class="example-link">Mo-Fr 08:00-11:00 || Tu-Th,PH open "Emergency only"</a></li>
+                            <li><a href="#check" class="example-link">Tu-Th,We 22:00-23:00 open "Hot meals"; PH off</a></li>
+                            <li><a href="#check" class="example-link">Mo 12:00-14:00 open "female only", Mo 14:00-16:00 open "male only"; PH off</a></li>
+                            <li><a href="#check" class="example-link">Apr: 22:00-23:00; PH off</a></li>
+                            <li><a href="#check" class="example-link">Jul-Jan: 22:00-23:00; PH off</a></li>
+                            <li><a href="#check" class="example-link">Jan-Jul: 22:00-23:00; PH off</a></li>
+                            <li><a href="#check" class="example-link">Jul 23-Jan 3: "needs reservation by phone"; PH off</a></li>
+                            <li><a href="#check" class="example-link">Jul 23-Jan 3: 22:00-23:00 "Please make a reservation by phone."; PH off</a></li>
+                            <li><a href="#check" class="example-link">Jul 23-Jan 3: 08:00-11:00 "Please make a reservation by phone."; PH off</a></li>
+                            <li><a href="#check" class="example-link">Jan 23-Jul 3: 22:00-23:00 "Please make a reservation by phone."; PH off</a></li>
+                            <li><a href="#check" class="example-link">Mar Su[-1]-Dec Su[1] -2 days: 22:00-23:00; PH off</a></li>
+                            <!-- <li><a href="#check" class="example-link">Mar Su[&#45;1] &#45; Dec 25&#45;Su&#45;28 days: 22:00&#45;23:00; PH off</a></li> -->
+                            <!-- <li><a href="#check" class="example-link">Dec 25&#45;Su&#45;28 days &#45; Mar Su[&#45;1]: 22:00&#45;23:00; PH off</a></li> -->
+                            <!-- Currently used around 6 times: /\d\s*&#45;\s*(mo|tu|we|th|fr|sa|su)\b/ -->
+                            <li><a href="#check" class="example-link">Sa[1],Sa[1] +1 day 10:00-12:00 open "first weekend in the month"; PH off</a></li>
+                            <li><a href="#check" class="example-link">Sa[-1],Sa[-1] +1 day 10:00-12:00 open "last weekend in the month"; PH off</a></li>
+                            <li><a href="#check" class="example-link">Sa-Su 00:00-24:00; PH off</a></li>
+                            <li><a href="#check" class="example-link">Mo-Fr 00:00-24:00; PH off</a></li>
+                            <li><a href="#check" class="example-link">sunrise-sunset open "Beware of sunburn!"; PH off</a></li>
+                            <li><a href="#check" class="example-link">sunset-sunrise open "Beware of vampires!"; PH off</a></li>
+                            <li><a href="#check" class="example-link">(sunset+01:00)-24:00 || closed "No drink before sunset!"; PH off</a></li>
+                            <li><a href="#check" class="example-link">22:00+; PH 22:00-12:00 off</a></li>
+                            <!-- <li><a href="#check" class="example-link">&#45;23:00; PH off</a></li> -->
+                            <li><a href="#check" class="example-link">Tu,PH 23:59-22:59</a></li>
+                            <li><a href="#check" class="example-link">We-Mo,PH 23:59-22:59</a></li>
+                            <li><a href="#check" class="example-link">week 2-52/2 We 00:00-24:00; week 1-53/2 Sa 00:00-24:00; PH off</a></li>
+                            <li><a href="#check" class="example-link">week 4-16 We 00:00-24:00; week 38-42 Sa 00:00-24:00; PH off</a></li>
+                            <li><a href="#check" class="example-link">2012 easter -2 days-2012 easter +2 days: open "Around easter"; PH off</a></li>
+                            <li><a href="#check" class="example-link">24/7 closed "always closed"</a></li>
+                            <li>
+                                <a href="#check" class="example-link">2013,2015,2050-2053,2055/2,2020-2029/3,2060+ Jan 1</a>,
+                                <a id="year-ranges-docu" href="" target="_blank"></a>
+                            </li>
+                            <li><a href="#check" class="example-link">Jan 23-Feb 11,Feb 12 00:00-24:00; PH off</a></li>
+                            <li><a href="#check" class="example-link">Apr-Oct Su[2] 14:00-18:00; Aug Su[-1] -1 day 10:00-18:00; Aug Su[-1] 10:00-18:00; PH off</a></li>
+                            <li><a href="#check" class="example-link">Mo-Fr 08:00-12:00, We 14:00-18:00; Su,PH off</a></li>
+                            <li><a href="#check" class="example-link">00:00-24:00 week 6 Mo-Su Feb; PH off</a>,
+                                <span id="hint-error-correction-1"></span>
+                            </li>
+                            <li><a href="#check" class="example-link">   monday,    Tu, wE,   TH    12:00 - 20:00  ; 14:00-16:00      Off  ; closed public Holiday</a>,
+                                <span id="hint-error-correction-2"></span>
+                            </li>
+                            <li><a href="#check" class="example-link">We; PH off</a></li>
+                            <li><a href="#check" class="example-link">PH</a></li>
+                            <li><a href="#check" class="example-link">PH Mo-Fr</a>
+                                <span id="hint-ph-mo-fr"></span>
+                            </li>
+                            <li><a href="#check" class="example-link">PH -1 day</a></li>
+                            <li><a href="#check" class="example-link">SH</a></li>
+                            <li><a href="#check" class="example-link">SH,PH</a></li>
+                            <li><a href="#check" class="example-link">PH,SH</a>
+                                <span id="hint-sh-ph"></span>
+                            </li>
+                            <li><a href="#check" class="example-link">We[1-3]</a></li>
+                            <li><a href="#check" class="example-link">We[3-5]</a></li>
+                            <li><a href="#check" class="example-link">Sa</a></li>
+                            <li><a href="#check" class="example-link">Sa[1]</a></li>
+                            <li><a href="#check" class="example-link">Sa[1-3]</a></li>
+                            <li><a href="#check" class="example-link">Tu-Th</a></li>
+                            <li><a href="#check" class="example-link">Fr-Mo</a></li>
+                            <li><a href="#check" class="example-link">Mo-Su; We "only after registration"</a></li>
+                            <li><a href="#check" class="example-link">Oct: We[1]</a></li>
+                        </ol>
+                    </div>
+                </section>
             </form>
             <footer id="footer"></footer>
 


### PR DESCRIPTION
I replaced `html5validator` with the ESLint plugin `@html-eslint/eslint-plugin`. One fewer Python dependency :)

The changes are limited to lint configuration and formatting, with no functional changes, so I'll merge this right away.