### PR TITLE
feat(holidays): resolve regions from ISO3166-2 codes

### DIFF
--- a/src/holidays/fr.yaml
+++ b/src/holidays/fr.yaml
@@ -3,38 +3,41 @@
 ---
 
 # @attrib https://fr.wikipedia.org/wiki/F%C3%AAtes_et_jours_f%C3%A9ri%C3%A9s_en_France
+# @attrib https://github.com/commenthol/date-holidays/blob/master/data/countries/FR.yaml
 
 _nominatim_url: "https://nominatim.openstreetmap.org/reverse?format=json&lat=46.60333&lon=1.88920&zoom=18&addressdetails=1&accept-language=fr,en"
 
 PH:
-  - {name: "Jour de l'an", fixed_date: [1, 1]}
-  - {name: Vendredi saint, variable_date: easter, offset: -2, only_states: [Moselle, Bas-Rhin, Haut-Rhin, Guadeloupe, Martinique, Polynésie française]}
+  - {name: Nouvel An, fixed_date: [1, 1]}
   - {name: Lundi de Pâques, variable_date: easter, offset: 1}
-  - {name: "Abolition de l'esclavage (Mayotte)", fixed_date: [4, 27], only_states: [Mayotte]}
-  - {name: Saint-Pierre-Chanel, fixed_date: [4, 28], only_states: [Wallis-et-Futuna]}
-  - {name: Fête du Travail, fixed_date: [5, 1]}
-  - {name: Fête de la Victoire, fixed_date: [5, 8]}
-  - {name: "Abolition de l'esclavage (Martinique)", fixed_date: [5, 22], only_states: [Martinique]}
-  - {name: "Abolition de l'esclavage (Guadeloupe)", fixed_date: [5, 27], only_states: [Guadeloupe]}
-  - {name: "Abolition de l'esclavage (Saint-Martin)", fixed_date: [5, 28], only_states: [Saint-Martin (France)]}
-  - {name: "Jeudi de l'Ascension", variable_date: easter, offset: 39}
+  - {name: Fête du travail, fixed_date: [5, 1]}
+  - {name: Fête de la Victoire 1945, fixed_date: [5, 8]}
+  - {name: Ascension, variable_date: easter, offset: 39}
   - {name: Lundi de Pentecôte, variable_date: easter, offset: 50}
-  - {name: "Abolition de l'esclavage (Guyane)", fixed_date: [6, 10], only_states: [Guyane]}
-  - {name: "Fête de l'autonomie", fixed_date: [6, 29], only_states: [Polynésie française]}
-  - {name: Fête nationale, fixed_date: [7, 14]}
-  - {name: Fête Victor Schoelcher, fixed_date: [7, 21], only_states: [Guadeloupe, Martinique]}
-  - {name: Fête du Territoire, fixed_date: [7, 29], only_states: [Wallis-et-Futuna]}
+  - {name: Fête Nationale de la France, fixed_date: [7, 14]}
   - {name: Assomption, fixed_date: [8, 15]}
-  - {name: Fête de la citoyenneté, fixed_date: [9, 24], only_states: [Nouvelle-Calédonie]}
-  - {name: "Abolition de l'esclavage (Saint-Barthélemy)", fixed_date: [10, 9], only_states: [Saint-Barthélemy]}
   - {name: Toussaint, fixed_date: [11, 1]}
-  - {name: Armistice, fixed_date: [11, 11]}
-  - {name: "Abolition de l'esclavage (Réunion)", fixed_date: [12, 20], only_states: [Réunion]}
+  - {name: Armistice 1918, fixed_date: [11, 11]}
   - {name: Noël, fixed_date: [12, 25]}
-  - {name: "Saint-Étienne ", fixed_date: [12, 26], only_states: [Moselle, Bas-Rhin, Haut-Rhin]}
-Grand Est:
-  _state_code: ge
-  _nominatim_url: "https://nominatim.openstreetmap.org/search?format=json&country=France&state=Grand+Est&zoom=18&addressdetails=1&limit=1&accept-language=fr,en"
+  - {name: Arrivée de l’Évangile, fixed_date: [3, 5], only_states: [Polynésie française]}
+  - {name: Vendredi saint, variable_date: easter, offset: -2, only_states: [Bas-Rhin, Guadeloupe, Haut-Rhin, Martinique, Moselle, Polynésie française, Saint-Barthélemy]}
+  - {name: Abolition de l’esclavage, fixed_date: [4, 27], only_states: [Mayotte]}
+  - {name: Fête de Saint Pierre-Chanel, fixed_date: [4, 28], only_states: [Wallis-et-Futuna]}
+  - {name: Abolition de l’esclavage, fixed_date: [5, 22], only_states: [Martinique]}
+  - {name: Abolition de l’esclavage, fixed_date: [5, 27], only_states: [Guadeloupe, Saint-Martin]}
+  - {name: Abolition de l’esclavage, fixed_date: [6, 10], only_states: [Guyane]}
+  - {name: Saint Pierre et Paul, fixed_date: [6, 29], only_states: [Wallis-et-Futuna]}
+  - {name: Jour de Victor Schoelcher, fixed_date: [7, 21], only_states: [Guadeloupe, Martinique]}
+  - {name: Fête du Territoire, fixed_date: [7, 29], only_states: [Wallis-et-Futuna]}
+  - {name: Fête de la Citoyenneté, fixed_date: [9, 24], only_states: [Nouvelle-Calédonie]}
+  - {name: Abolition de l’esclavage, fixed_date: [10, 9], only_states: [Saint-Barthélemy]}
+  - {name: Matari’i, fixed_date: [11, 20], only_states: [Polynésie française]}
+  - {name: Abolition de l’esclavage, fixed_date: [12, 20], only_states: [La Réunion]}
+  - {name: Lendemain de Noël, fixed_date: [12, 26], only_states: [Bas-Rhin, Haut-Rhin, Moselle]}
+
+Bas-Rhin:
+  _state_code: "67"
+  _nominatim_url: "https://nominatim.openstreetmap.org/search?format=json&country=France&state=Bas-Rhin&zoom=18&addressdetails=1&limit=1&accept-language=fr,en"
 
 Guadeloupe:
   _state_code: gp
@@ -43,6 +46,10 @@ Guadeloupe:
 Guyane:
   _state_code: gf
   _nominatim_url: "https://nominatim.openstreetmap.org/search?format=json&country=France&state=Guyane&zoom=18&addressdetails=1&limit=1&accept-language=fr,en"
+
+Haut-Rhin:
+  _state_code: "68"
+  _nominatim_url: "https://nominatim.openstreetmap.org/search?format=json&country=France&state=Haut-Rhin&zoom=18&addressdetails=1&limit=1&accept-language=fr,en"
 
 La Réunion:
   _state_code: re
@@ -55,6 +62,10 @@ Martinique:
 Mayotte:
   _state_code: yt
   _nominatim_url: "https://nominatim.openstreetmap.org/search?format=json&country=France&state=Mayotte&zoom=18&addressdetails=1&limit=1&accept-language=fr,en"
+
+Moselle:
+  _state_code: "57"
+  _nominatim_url: "https://nominatim.openstreetmap.org/search?format=json&country=France&state=Moselle&zoom=18&addressdetails=1&limit=1&accept-language=fr,en"
 
 Nouvelle-Calédonie:
   _state_code: nc

--- a/src/holidays/generated-openholidays.js
+++ b/src/holidays/generated-openholidays.js
@@ -8707,7 +8707,7 @@ export const fi = {
 
 /** @type {import('./holiday-definitions.d.ts').CountryHolidayDefinitions} */
 export const fr = {
-  PH: [{"name":"Jour de l'an","fixed_date":[1,1]},{"name":"Vendredi saint","variable_date":"easter","offset":-2,"only_states":["Moselle","Bas-Rhin","Haut-Rhin","Guadeloupe","Martinique","Polynésie française"]},{"name":"Lundi de Pâques","variable_date":"easter","offset":1},{"name":"Abolition de l'esclavage (Mayotte)","fixed_date":[4,27],"only_states":["Mayotte"]},{"name":"Saint-Pierre-Chanel","fixed_date":[4,28],"only_states":["Wallis-et-Futuna"]},{"name":"Fête du Travail","fixed_date":[5,1]},{"name":"Fête de la Victoire","fixed_date":[5,8]},{"name":"Abolition de l'esclavage (Martinique)","fixed_date":[5,22],"only_states":["Martinique"]},{"name":"Abolition de l'esclavage (Guadeloupe)","fixed_date":[5,27],"only_states":["Guadeloupe"]},{"name":"Abolition de l'esclavage (Saint-Martin)","fixed_date":[5,28],"only_states":["Saint-Martin (France)"]},{"name":"Jeudi de l'Ascension","variable_date":"easter","offset":39},{"name":"Lundi de Pentecôte","variable_date":"easter","offset":50},{"name":"Abolition de l'esclavage (Guyane)","fixed_date":[6,10],"only_states":["Guyane"]},{"name":"Fête de l'autonomie","fixed_date":[6,29],"only_states":["Polynésie française"]},{"name":"Fête nationale","fixed_date":[7,14]},{"name":"Fête Victor Schoelcher","fixed_date":[7,21],"only_states":["Guadeloupe","Martinique"]},{"name":"Fête du Territoire","fixed_date":[7,29],"only_states":["Wallis-et-Futuna"]},{"name":"Assomption","fixed_date":[8,15]},{"name":"Fête de la citoyenneté","fixed_date":[9,24],"only_states":["Nouvelle-Calédonie"]},{"name":"Abolition de l'esclavage (Saint-Barthélemy)","fixed_date":[10,9],"only_states":["Saint-Barthélemy"]},{"name":"Toussaint","fixed_date":[11,1]},{"name":"Armistice","fixed_date":[11,11]},{"name":"Abolition de l'esclavage (Réunion)","fixed_date":[12,20],"only_states":["Réunion"]},{"name":"Noël","fixed_date":[12,25]},{"name":"Saint-Étienne ","fixed_date":[12,26],"only_states":["Moselle","Bas-Rhin","Haut-Rhin"]}],
+  PH: [{"name":"Nouvel An","fixed_date":[1,1]},{"name":"Lundi de Pâques","variable_date":"easter","offset":1},{"name":"Fête du travail","fixed_date":[5,1]},{"name":"Fête de la Victoire 1945","fixed_date":[5,8]},{"name":"Ascension","variable_date":"easter","offset":39},{"name":"Lundi de Pentecôte","variable_date":"easter","offset":50},{"name":"Fête Nationale de la France","fixed_date":[7,14]},{"name":"Assomption","fixed_date":[8,15]},{"name":"Toussaint","fixed_date":[11,1]},{"name":"Armistice 1918","fixed_date":[11,11]},{"name":"Noël","fixed_date":[12,25]},{"name":"Arrivée de l’Évangile","fixed_date":[3,5],"only_states":["Polynésie française"]},{"name":"Vendredi saint","variable_date":"easter","offset":-2,"only_states":["Bas-Rhin","Guadeloupe","Haut-Rhin","Martinique","Moselle","Polynésie française","Saint-Barthélemy"]},{"name":"Abolition de l’esclavage","fixed_date":[4,27],"only_states":["Mayotte"]},{"name":"Fête de Saint Pierre-Chanel","fixed_date":[4,28],"only_states":["Wallis-et-Futuna"]},{"name":"Abolition de l’esclavage","fixed_date":[5,22],"only_states":["Martinique"]},{"name":"Abolition de l’esclavage","fixed_date":[5,27],"only_states":["Guadeloupe","Saint-Martin"]},{"name":"Abolition de l’esclavage","fixed_date":[6,10],"only_states":["Guyane"]},{"name":"Saint Pierre et Paul","fixed_date":[6,29],"only_states":["Wallis-et-Futuna"]},{"name":"Jour de Victor Schoelcher","fixed_date":[7,21],"only_states":["Guadeloupe","Martinique"]},{"name":"Fête du Territoire","fixed_date":[7,29],"only_states":["Wallis-et-Futuna"]},{"name":"Fête de la Citoyenneté","fixed_date":[9,24],"only_states":["Nouvelle-Calédonie"]},{"name":"Abolition de l’esclavage","fixed_date":[10,9],"only_states":["Saint-Barthélemy"]},{"name":"Matari’i","fixed_date":[11,20],"only_states":["Polynésie française"]},{"name":"Abolition de l’esclavage","fixed_date":[12,20],"only_states":["La Réunion"]},{"name":"Lendemain de Noël","fixed_date":[12,26],"only_states":["Bas-Rhin","Haut-Rhin","Moselle"]}],
   "_nominatim_url": "https://nominatim.openstreetmap.org/reverse?format=json&lat=46.60333&lon=1.88920&zoom=18&addressdetails=1&accept-language=fr,en",
   "Auvergne-Rhône-Alpes": {
     "_state_code": "ar",
@@ -8788,6 +8788,10 @@ export const fr = {
         2027: [7,3,7,3],
       },
     ]
+  },
+  "Bas-Rhin": {
+    "_state_code": "67",
+    "_nominatim_url": "https://nominatim.openstreetmap.org/search?format=json&country=France&state=Bas-Rhin&zoom=18&addressdetails=1&limit=1&accept-language=fr,en"
   },
   "Bourgogne-Franche-Comté": {
     "_state_code": "bf",
@@ -9097,7 +9101,6 @@ export const fr = {
   },
   "Grand Est": {
     "_state_code": "ge",
-    "_nominatim_url": "https://nominatim.openstreetmap.org/search?format=json&country=France&state=Grand+Est&zoom=18&addressdetails=1&limit=1&accept-language=fr,en",
     SH: [
       {
         name: "Vacances d'hiver",
@@ -9311,6 +9314,10 @@ export const fr = {
         2026: [7,4,7,4],
       },
     ]
+  },
+  "Haut-Rhin": {
+    "_state_code": "68",
+    "_nominatim_url": "https://nominatim.openstreetmap.org/search?format=json&country=France&state=Haut-Rhin&zoom=18&addressdetails=1&limit=1&accept-language=fr,en"
   },
   "Hauts-de-France": {
     "_state_code": "hf",
@@ -9659,6 +9666,10 @@ export const fr = {
         2026: [7,4,8,21],
       },
     ]
+  },
+  "Moselle": {
+    "_state_code": "57",
+    "_nominatim_url": "https://nominatim.openstreetmap.org/search?format=json&country=France&state=Moselle&zoom=18&addressdetails=1&limit=1&accept-language=fr,en"
   },
   "Normandie": {
     "_state_code": "no",

--- a/src/holidays/nominatim_cache/fr.yaml
+++ b/src/holidays/nominatim_cache/fr.yaml
@@ -1,22 +1,33 @@
 ---
-place_id: 147691567
-licence: Data © OpenStreetMap contributors, ODbL 1.0. https://osm.org/copyright
+place_id: 94704406
+licence: Data © OpenStreetMap contributors, ODbL 1.0. http://osm.org/copyright
 osm_type: way
 osm_id: 313991558
 lat: '46.6039313'
 lon: '1.8893065'
-display_name: D 51, Le Moulin de Baudry, Sarzay, La Châtre, Indre, Centre-Val de Loire, France métropolitaine, 36230, France
+display_name: D 51, Les Loges des Bois, Sarzay, La Châtre, Indre, Centre-Val de Loire, France métropolitaine, 36230, France
 address:
   country: France
   country_code: fr
-  # county: La Châtre
-  # postcode: 36230
+  # addresstype: road
+  # ISO3166-2-lvl4: FR-CVL
+  # ISO3166-2-lvl6: FR-36
+  # county: Indre
+  # hamlet: Les Loges des Bois
+  # municipality: La Châtre
+  # postcode: "36230"
+  # region: France métropolitaine
   # road: D 51
   # state: Centre-Val de Loire
-  # suburb: Le Moulin de Baudry
   # village: Sarzay
+
 boundingbox:
-  - '46.5944601'
+  - '46.6008694'
   - '46.6043737'
-  - '1.8465511'
-  - '1.9009457'
+  - '1.8687231'
+  - '1.8932222'
+class: highway
+importance: 0.05339254062714577
+name: D 51
+place_rank: 26
+type: tertiary

--- a/src/holidays/nominatim_cache/fr_57.yaml
+++ b/src/holidays/nominatim_cache/fr_57.yaml
@@ -1,0 +1,32 @@
+---
+place_id: 118732918
+licence: Data © OpenStreetMap contributors, ODbL 1.0. http://osm.org/copyright
+osm_type: node
+osm_id: 12443507957
+lat: '49.0209039'
+lon: '6.5401579'
+display_name: 8, Chemin du Berger, Mainvillers, Forbach-Boulay-Moselle, Moselle, Grand Est, France métropolitaine, 57380, France
+address:
+  house_number: '8'
+  road: Chemin du Berger
+  village: Mainvillers
+  municipality: Forbach-Boulay-Moselle
+  county: Moselle
+  ISO3166-2-lvl6: FR-57
+  state: Grand Est
+  ISO3166-2-lvl4: FR-GES
+  region: France métropolitaine
+  postcode: '57380'
+  country: France
+  country_code: fr
+addresstype: place
+boundingbox:
+  - '49.0208539'
+  - '49.0209539'
+  - '6.5401079'
+  - '6.5402079'
+class: place
+importance: 0.00006534752422365175
+name: ''
+place_rank: 30
+type: house

--- a/src/holidays/nominatim_cache/fr_67.yaml
+++ b/src/holidays/nominatim_cache/fr_67.yaml
@@ -1,0 +1,34 @@
+---
+place_id: 120561623
+licence: Data © OpenStreetMap contributors, ODbL 1.0. http://osm.org/copyright
+osm_type: way
+osm_id: 304707197
+lat: '48.6017686'
+lon: '7.5339156'
+display_name: D 225, Scharrachbergheim, Dahlenheim, Molsheim, Bas-Rhin, Collectivité européenne d'Alsace, Grand Est, France métropolitaine, 67520, France
+address:
+  road: D 225
+  city_district: Scharrachbergheim
+  village: Dahlenheim
+  municipality: Molsheim
+  county: Bas-Rhin
+  ISO3166-2-lvl6: FR-67
+  state_district: Collectivité européenne d'Alsace
+  ISO3166-2-lvl5: FR-6AE
+  state: Grand Est
+  ISO3166-2-lvl4: FR-GES
+  region: France métropolitaine
+  postcode: '67520'
+  country: France
+  country_code: fr
+addresstype: road
+boundingbox:
+  - '48.5935602'
+  - '48.6020946'
+  - '7.5040896'
+  - '7.5510542'
+class: highway
+importance: 0.05339784466315706
+name: D 225
+place_rank: 26
+type: tertiary

--- a/src/holidays/nominatim_cache/fr_68.yaml
+++ b/src/holidays/nominatim_cache/fr_68.yaml
@@ -1,0 +1,33 @@
+---
+place_id: 93611190
+licence: Data © OpenStreetMap contributors, ODbL 1.0. http://osm.org/copyright
+osm_type: way
+osm_id: 55260122
+lat: '47.8685021'
+lon: '7.2373074'
+display_name: Chemin Saint-Georges, Soultz-Haut-Rhin, Thann-Guebwiller, Haut-Rhin, Collectivité européenne d'Alsace, Grand Est, France métropolitaine, 68360, France
+address:
+  road: Chemin Saint-Georges
+  village: Soultz-Haut-Rhin
+  municipality: Thann-Guebwiller
+  county: Haut-Rhin
+  ISO3166-2-lvl6: FR-68
+  state_district: Collectivité européenne d'Alsace
+  ISO3166-2-lvl5: FR-6AE
+  state: Grand Est
+  ISO3166-2-lvl4: FR-GES
+  region: France métropolitaine
+  postcode: '68360'
+  country: France
+  country_code: fr
+addresstype: road
+boundingbox:
+  - '47.8621992'
+  - '47.8685021'
+  - '7.2373074'
+  - '7.2434647'
+class: highway
+importance: 0.05339507057297624
+name: Chemin Saint-Georges
+place_rank: 26
+type: track

--- a/src/holidays/nominatim_cache/fr_bl.yaml
+++ b/src/holidays/nominatim_cache/fr_bl.yaml
@@ -1,20 +1,31 @@
 ---
-place_id: 239421886
-licence: Data © OpenStreetMap contributors, ODbL 1.0. https://osm.org/copyright
-osm_type: way
-osm_id: 24552759
-lat: '17.898035119474'
-lon: '-62.830675038479'
-display_name: Morne de Dépoudré, Saint-Barthélemy, 97133, France
+place_id: 298968082
+licence: Data © OpenStreetMap contributors, ODbL 1.0. http://osm.org/copyright
+osm_type: node
+osm_id: 11928298028
+lat: '17.8961320'
+lon: '-62.8258070'
+display_name: 190, Chemin Boyé, Grande Saline, Gustavia, Saint-Barthélemy, 97133, France
 address:
+  house_number: '190'
+  road: Chemin Boyé
+  neighbourhood: Grande Saline
+  quarter: Grande Saline
+  town: Gustavia
+  city: Saint-Barthélemy
+  state: Saint-Barthélemy
+  ISO3166-2-lvl3: FR-BL
+  postcode: '97133'
   country: France
   country_code: fr
-  neighbourhood: Morne de Dépoudré
-  postcode: '97133'
-  state: Saint-Barthélemy
-  town: Saint-Barthélemy
+addresstype: place
 boundingbox:
-  - '17.8980334'
-  - '17.9012471'
-  - '-62.8337719'
-  - '-62.8292748'
+  - '17.8960820'
+  - '17.8961820'
+  - '-62.8258570'
+  - '-62.8257570'
+class: place
+importance: 0.00006704890516513341
+name: ''
+place_rank: 30
+type: house

--- a/src/holidays/nominatim_cache/fr_ges.yaml
+++ b/src/holidays/nominatim_cache/fr_ges.yaml
@@ -11,8 +11,10 @@ address:
   country: France
   country_code: fr
   county: Nancy
+  ISO3166-2-lvl6: FR-54
   postcode: '54330'
   state: Grand Est
+  ISO3166-2-lvl4: FR-GES
 boundingbox:
   - '48.4812149'
   - '48.508714'

--- a/src/holidays/nominatim_cache/fr_gf.yaml
+++ b/src/holidays/nominatim_cache/fr_gf.yaml
@@ -1,0 +1,28 @@
+---
+place_id: 300527889
+licence: Data © OpenStreetMap contributors, ODbL 1.0. http://osm.org/copyright
+osm_type: relation
+osm_id: 1663804
+lat: '4.8252673'
+lon: '-53.2888215'
+display_name: Saint-Élie, Cayenne, Guyane, 97312, France
+address:
+  hamlet: Saint-Élie
+  municipality: Cayenne
+  state: Guyane
+  ISO3166-2-lvl4: FR-GF
+  ISO3166-2-lvl3: FR-973
+  postcode: '97312'
+  country: France
+  country_code: fr
+addresstype: hamlet
+boundingbox:
+  - '3.9061149'
+  - '5.0660796'
+  - '-53.4329746'
+  - '-52.7827508'
+class: boundary
+importance: 0.3960456341796639
+name: Saint-Élie
+place_rank: 16
+type: administrative

--- a/src/holidays/nominatim_cache/fr_gp.yaml
+++ b/src/holidays/nominatim_cache/fr_gp.yaml
@@ -1,0 +1,32 @@
+---
+place_id: 300795767
+licence: Data © OpenStreetMap contributors, ODbL 1.0. http://osm.org/copyright
+osm_type: way
+osm_id: 45817598
+lat: '16.2531446'
+lon: '-61.5687123'
+display_name: Rue Thomas Edison, ZAC de la Jaille 1, La Jaille, Fond Sarrail, Baie-Mahault, Basse-Terre, Guadeloupe, 97122, France
+address:
+  road: Rue Thomas Edison
+  retail: ZAC de la Jaille 1
+  quarter: La Jaille
+  hamlet: Fond Sarrail
+  town: Baie-Mahault
+  municipality: Basse-Terre
+  state: Guadeloupe
+  ISO3166-2-lvl4: FR-971
+  ISO3166-2-lvl3: FR-971
+  postcode: '97122'
+  country: France
+  country_code: fr
+addresstype: road
+boundingbox:
+  - '16.2530250'
+  - '16.2536237'
+  - '-61.5705817'
+  - '-61.5610460'
+class: highway
+importance: 0.05338729762722206
+name: Rue Thomas Edison
+place_rank: 26
+type: unclassified

--- a/src/holidays/nominatim_cache/fr_mf.yaml
+++ b/src/holidays/nominatim_cache/fr_mf.yaml
@@ -1,21 +1,29 @@
 ---
-place_id: 184687411
-licence: Data © OpenStreetMap contributors, ODbL 1.0. https://osm.org/copyright
+place_id: 300765537
+licence: Data © OpenStreetMap contributors, ODbL 1.0. http://osm.org/copyright
 osm_type: way
 osm_id: 526745624
 lat: '18.0788384'
 lon: '-63.0485467'
-display_name: Route de Pic Paradis, Colombier, Saint-Martin (France), 97150, France
+display_name: Route de Pic Paradis, Colombier, Marigot, Saint-Martin, 97150, France
 address:
+  road: Route de Pic Paradis
+  suburb: Colombier
+  town: Marigot
+  state: Saint-Martin
+  ISO3166-2-lvl8: FR-MF
+  ISO3166-2-lvl3: FR-MF
+  postcode: '97150'
   country: France
   country_code: fr
-  postcode: '97150'
-  road: Route de Pic Paradis
-  state: Saint-Martin (France)
-  suburb: Colombier
-  town: Saint-Martin (France)
+addresstype: road
 boundingbox:
   - '18.0772921'
-  - '18.079211'
-  - '-63.0509598'
+  - '18.0788384'
+  - '-63.0501925'
   - '-63.0484875'
+class: highway
+importance: 0.053399730678263486
+name: Route de Pic Paradis
+place_rank: 26
+type: track

--- a/src/holidays/nominatim_cache/fr_mq.yaml
+++ b/src/holidays/nominatim_cache/fr_mq.yaml
@@ -1,0 +1,29 @@
+---
+place_id: 300795652
+licence: Data © OpenStreetMap contributors, ODbL 1.0. http://osm.org/copyright
+osm_type: way
+osm_id: 1418444276
+lat: '14.6118129'
+lon: '-60.9628201'
+display_name: Chemin Bellonie, Le Lamentin, Fort-de-France, Martinique, 97232, France
+address:
+  road: Chemin Bellonie
+  town: Le Lamentin
+  municipality: Fort-de-France
+  state: Martinique
+  ISO3166-2-lvl4: FR-972
+  ISO3166-2-lvl3: FR-972
+  postcode: '97232'
+  country: France
+  country_code: fr
+addresstype: road
+boundingbox:
+  - '14.6090670'
+  - '14.6136386'
+  - '-60.9647461'
+  - '-60.9627061'
+class: highway
+importance: 0.05338406118867777
+name: Chemin Bellonie
+place_rank: 26
+type: tertiary

--- a/src/holidays/nominatim_cache/fr_nc.yaml
+++ b/src/holidays/nominatim_cache/fr_nc.yaml
@@ -1,21 +1,28 @@
 ---
-place_id: 133231382
-licence: Data © OpenStreetMap contributors, ODbL 1.0. https://osm.org/copyright
+place_id: 27276795
+licence: Data © OpenStreetMap contributors, ODbL 1.0. http://osm.org/copyright
 osm_type: way
 osm_id: 240446257
 lat: '-21.3047115'
 lon: '165.4846495'
-display_name: Route du Col des Roussettes, Houaïlou, Province Nord, Nouvelle-Calédonie, 98816, France
+display_name: Route du Col des Roussettes, Karovin, Houaïlou, Province Nord, Nouvelle-Calédonie, France
 address:
+  road: Route du Col des Roussettes
+  hamlet: Karovin
+  town: Houaïlou
+  county: Province Nord
+  archipelago: Nouvelle-Calédonie
+  ISO3166-2-lvl3: FR-NC
   country: France
   country_code: fr
-  county: Province Nord
-  postcode: '98816'
-  road: Route du Col des Roussettes
-  state: Nouvelle-Calédonie
-  village: Houaïlou
+addresstype: road
 boundingbox:
   - '-21.3354081'
   - '-21.2966002'
   - '165.4440169'
   - '165.4887547'
+class: highway
+importance: 0.05338064927138167
+name: Route du Col des Roussettes
+place_rank: 26
+type: primary

--- a/src/holidays/nominatim_cache/fr_pf.yaml
+++ b/src/holidays/nominatim_cache/fr_pf.yaml
@@ -1,22 +1,28 @@
 ---
-place_id: 199108554
-licence: Data © OpenStreetMap contributors, ODbL 1.0. https://osm.org/copyright
+place_id: 132031
+licence: Data © OpenStreetMap contributors, ODbL 1.0. http://osm.org/copyright
 osm_type: relation
 osm_id: 6062932
-lat: '-16.88370465'
-lon: '-144.749871887773'
-display_name: Tahanea, Faaite, Anaa, Tuamotu-Gambier, Polynésie française, 98760, France
+lat: '-16.8837046'
+lon: '-144.7498719'
+display_name: Tahanea, Faaite, Anaa, Tuamotu-Gambier, Polynésie française, France
 address:
-  city: Anaa
+  suburb: Tahanea
   city_district: Faaite
+  city: Anaa
+  archipelago: Tuamotu-Gambier
+  state: Polynésie française
+  ISO3166-2-lvl3: FR-PF
   country: France
   country_code: fr
-  county: Tuamotu-Gambier
-  postcode: '98760'
-  state: Polynésie française
-  suburb: Tahanea
+addresstype: suburb
 boundingbox:
   - '-17.1980006'
   - '-16.5727335'
   - '-145.1156128'
   - '-144.4120271'
+class: boundary
+importance: 0.4491022588632987
+name: Tahanea
+place_rank: 20
+type: administrative

--- a/src/holidays/nominatim_cache/fr_re.yaml
+++ b/src/holidays/nominatim_cache/fr_re.yaml
@@ -1,0 +1,29 @@
+---
+place_id: 35990168
+licence: Data © OpenStreetMap contributors, ODbL 1.0. http://osm.org/copyright
+osm_type: node
+osm_id: 11475719069
+lat: '-21.1337971'
+lon: '55.5247898'
+display_name: Sentier Jacky Inard, Saint-Benoît, La Réunion, 97414, France
+address:
+  road: Sentier Jacky Inard
+  town: Saint-Benoît
+  municipality: Saint-Benoît
+  state: La Réunion
+  ISO3166-2-lvl4: FR-RE
+  ISO3166-2-lvl3: FR-974
+  postcode: '97414'
+  country: France
+  country_code: fr
+addresstype: highway
+boundingbox:
+  - '-21.1338471'
+  - '-21.1337471'
+  - '55.5247398'
+  - '55.5248398'
+class: highway
+importance: 0.000051199359121034826
+name: ''
+place_rank: 30
+type: bus_stop

--- a/src/holidays/nominatim_cache/fr_wf.yaml
+++ b/src/holidays/nominatim_cache/fr_wf.yaml
@@ -1,19 +1,29 @@
 ---
-place_id: 89800125
-licence: Data © OpenStreetMap contributors, ODbL 1.0. https://osm.org/copyright
+place_id: 113596
+licence: Data © OpenStreetMap contributors, ODbL 1.0. http://osm.org/copyright
 osm_type: way
-osm_id: 53586327
-lat: '-13.2987550896755'
-lon: '-176.199474096783'
-display_name: RT 2, Lavegahau, Wallis-et-Futuna, France, Wallis-et-Futuna (eaux territoriales)
+osm_id: 259559555
+lat: '-13.2840937'
+lon: '-176.2049626'
+display_name: RT 3, Falaleu, Uvea, Wallis-et-Futuna, 98600, France
 address:
-  country: France, Wallis-et-Futuna (eaux territoriales)
-  country_code: fr
-  road: RT 2
+  road: RT 3
+  village: Falaleu
+  city: Uvea
+  ISO3166-2-lvl8: WF-UV
   state: Wallis-et-Futuna
-  village: Lavegahau
+  ISO3166-2-lvl3: FR-WF
+  postcode: '98600'
+  country: France
+  country_code: fr
+addresstype: road
 boundingbox:
-  - '-13.3057979'
-  - '-13.2948908'
-  - '-176.1995685'
-  - '-176.1987089'
+  - '-13.2841650'
+  - '-13.2804461'
+  - '-176.2083059'
+  - '-176.1964275'
+class: highway
+importance: 0.053384035248340546
+name: RT 3
+place_rank: 26
+type: tertiary

--- a/src/holidays/nominatim_cache/fr_yt.yaml
+++ b/src/holidays/nominatim_cache/fr_yt.yaml
@@ -1,0 +1,27 @@
+---
+place_id: 37298752
+licence: Data © OpenStreetMap contributors, ODbL 1.0. http://osm.org/copyright
+osm_type: node
+osm_id: 7889486262
+lat: '-12.8369679'
+lon: '45.1586516'
+display_name: Ongojou, Dembéni, Mayotte, 97660, France
+address:
+  village: Ongojou
+  state: Mayotte
+  ISO3166-2-lvl4: FR-976
+  ISO3166-2-lvl3: FR-976
+  postcode: '97660'
+  country: France
+  country_code: fr
+addresstype: village
+boundingbox:
+  - '-12.8569679'
+  - '-12.8169679'
+  - '45.1386516'
+  - '45.1786516'
+class: place
+importance: 0.1467114831769283
+name: Ongojou
+place_rank: 19
+type: village

--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,36 @@ const holidayDefinitions = holiday_definitions;
 /** @typedef {import('./holidays/holiday-definitions.d.ts').HolidayItem} HolidayItem */
 
 /**
+ * Resolve a state name from ISO3166-2 fields in a Nominatim address.
+ * @param {Record<string, unknown>} address Nominatim address object.
+ * @param {Record<string, string>} stateByCode Lowercase state code to name map.
+ * @returns {string|undefined} Resolved state name, if any.
+ */
+function getStateFromIso3166Address(address, stateByCode) {
+    const iso3166Fields = Object.keys(address)
+        .filter((key) => /^ISO3166-2-lvl\d+$/i.test(key))
+        // Prefer the most specific subdivision (e.g. lvl6 over lvl4).
+        .sort((left, right) => {
+            const leftLevel = Number(left.slice(left.lastIndexOf('lvl') + 3));
+            const rightLevel = Number(right.slice(right.lastIndexOf('lvl') + 3));
+            return rightLevel - leftLevel;
+        });
+
+    for (const field of iso3166Fields) {
+        const value = address[field];
+        if (typeof value !== 'string') {
+            continue;
+        }
+        const localCode = value.toLowerCase().replace(/^[^-]+-/, '');
+        if (stateByCode[localCode]) {
+            return stateByCode[localCode];
+        }
+    }
+
+    return undefined;
+}
+
+/**
  * Resolve a state name from a Nominatim address.
  * Prefer matching ISO3166-2 fields (e.g. "DE-BE" -> "Berlin"), then fall back
  * to the address.state and address.county fields.
@@ -73,14 +103,9 @@ function getStateFromAddress(address, countryCode) {
                 }
             }
 
-            for (const [key, value] of Object.entries(address)) {
-                if (key.startsWith('ISO3166-2') && typeof value === 'string') {
-                    const lower = value.toLowerCase();
-                    const localCode = lower.slice(lower.indexOf('-') + 1);
-                    if (stateByCode[localCode]) {
-                        return stateByCode[localCode];
-                    }
-                }
+            const stateFromIso3166 = getStateFromIso3166Address(address, stateByCode);
+            if (stateFromIso3166) {
+                return stateFromIso3166;
             }
         }
     }

--- a/test/test.de.log
+++ b/test/test.de.log
@@ -435,6 +435,9 @@ With [34m[1mwarnings[22m[39m:
 "Variable days: public holidays. Berlin Frauentag resolved via ISO3166-2-lvl4" for "PH": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
 	*PH <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
+"Variable days: public holidays. Bas-Rhin resolved via ISO3166-2-lvl6" for "PH": [32m[1mPASSED[22m[39m
+With [34m[1mwarnings[22m[39m:
+	*PH <--- (Diese Regel ist nicht sehr aussagekräftig, da kein Zeit Selektor angegeben wurde. Ein Zeit Selektor ist die Komponente die angibt, zu welcher Tageszeit ein Objekt geöffnet hat, zum Beispiel "10:00-19:00". Bitte füge eine Zeitangabe oder einen Kommentar hinzu, um dies zu verbessern.)
 "Variable days: public holidays" for "open; PH off": [32m[1mPASSED[22m[39m
 "Variable days: public holidays (with time range)" for "PH 12:00-13:00": [32m[1mPASSED[22m[39m
 "Variable days: public holidays (with time range)" for "PH 12:00-13:00 open "this comment should override the holiday name which is returned as comment if PH matches."": [32m[1mPASSED[22m[39m
@@ -2773,7 +2776,7 @@ Der optional_conf_parm["tag_key"] fehlt, ist aber notwendig wegen optional_conf_
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-1083/1083 tests passed. 0 did not pass.
+1084/1084 tests passed. 0 did not pass.
 40 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.en.log
+++ b/test/test.en.log
@@ -435,6 +435,9 @@ With [34m[1mwarnings[22m[39m:
 "Variable days: public holidays. Berlin Frauentag resolved via ISO3166-2-lvl4" for "PH": [32m[1mPASSED[22m[39m
 With [34m[1mwarnings[22m[39m:
 	*PH <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
+"Variable days: public holidays. Bas-Rhin resolved via ISO3166-2-lvl6" for "PH": [32m[1mPASSED[22m[39m
+With [34m[1mwarnings[22m[39m:
+	*PH <--- (This rule is not very explicit because there is no time selector being used. A time selector is the part specifying hours when the object is opened, for example "10:00-19:00". Please add a time selector to this rule or use a comment to make it more explicit.)
 "Variable days: public holidays" for "open; PH off": [32m[1mPASSED[22m[39m
 "Variable days: public holidays (with time range)" for "PH 12:00-13:00": [32m[1mPASSED[22m[39m
 "Variable days: public holidays (with time range)" for "PH 12:00-13:00 open "this comment should override the holiday name which is returned as comment if PH matches."": [32m[1mPASSED[22m[39m
@@ -2763,7 +2766,7 @@ The optional_conf_parm["tag_key"] is missing, required by optional_conf_parm["ma
 "getNextChange skips comment-only boundary at end of off "renovation" overlay (#523)" for "Mo-Sa 08:00-21:00; Su "some 08:00-16:00"; PH off; 2025 Jul 27 - 2025 Sep 24 off "renovacija"": [32m[1mPASSED[22m[39m
 "getNextChange skips PH comment inside contiguous open range (#489)" for "Jul-Aug Mo-Su,PH 00:00-24:00": [32m[1mPASSED[22m[39m
 "getNextChange returns undefined when state never changes" for "24/7": [32m[1mPASSED[22m[39m
-1073/1073 tests passed. 0 did not pass.
+1074/1074 tests passed. 0 did not pass.
 40 tests where (partly) ignored, sorted by commonness:
 * 26: prettifyValue (most of the cases this is used to test if values with selectors in wrong order or wrong symbols (error tolerance) are evaluated correctly)
 * 11: not implemented yet

--- a/test/test.js
+++ b/test/test.js
@@ -170,6 +170,14 @@ const nominatim_berlin_iso_only = {
     }
 };
 
+const nominatim_bas_rhin_iso_only = {
+    'address': {
+        'ISO3166-2-lvl6': 'FR-67',
+        'ISO3166-2-lvl4': 'FR-GES',
+        'country_code': 'fr'
+    }
+};
+
 /* }}} */
 
 const sane_value_suffix = '; 00:01-00:02 closed "warning at correct position?"';
@@ -949,6 +957,12 @@ test.addTest('Variable days: public holidays. Berlin Frauentag resolved via ISO3
     ], '2025-03-07 0:00', '2025-03-09 0:00', [
         [ '2025-03-08 00:00', '2025-03-09 00:00', false, 'Internationaler Frauentag' ],
     ], 1000 * 60 * 60 * 24, 0, false, nominatim_berlin_iso_only, 'not only test');
+
+test.addTest('Variable days: public holidays. Bas-Rhin resolved via ISO3166-2-lvl6', [
+        'PH',
+    ], '2024-12-26 0:00', '2024-12-27 0:00', [
+        [ '2024-12-26 00:00', '2024-12-27 00:00', false, 'Lendemain de Noël' ],
+    ], 1000 * 60 * 60 * 24, 0, false, nominatim_bas_rhin_iso_only, 'not only test');
 
 /* }}} */
 


### PR DESCRIPTION
While comparing the French holiday definitions with `date-holidays`, I noticed that specific regional holidays were not always applied correctly. Nominatim may return only a broader region in `state` or `county`, while the more specific regional assignment is available through ISO3166-2 fields such as `FR-67`.

This PR:

- resolves regions from ISO3166-2 fields in Nominatim addresses,
- updates the French holiday definitions,
- adds and updates French Nominatim cache data,
- adds a regression test for regional holidays in Bas-Rhin.